### PR TITLE
bug fixing + small functionality/design fixes

### DIFF
--- a/src/app/inspection-details/inspection-details.component.scss
+++ b/src/app/inspection-details/inspection-details.component.scss
@@ -1,1 +1,9 @@
 @import "node_modules/govuk-frontend/govuk/all";
+
+
+.govuk-inset-text {
+  select {
+    width: 9rem;
+  }
+}
+

--- a/src/app/models/adrDetailsForm.model.ts
+++ b/src/app/models/adrDetailsForm.model.ts
@@ -6,11 +6,6 @@ export interface approvalDate {
     year: number;
 }
 
-export interface certificateReq {
-  yesCert: boolean;
-  noCert: boolean;
-}
-
 export interface adrDetailsFormModel {
     name: string;
     street: string;
@@ -49,20 +44,14 @@ export interface adrDetailsFormModel {
         month: number;
         year: number;
     };
-    memosApply: {
-        isMemo: boolean;
-        isNotMemo: boolean;
-    };
-    listStatementApplicable: {
-        applicable: boolean;
-        notApplicable: boolean;
-    },
+    memosApply: { [id: string]: boolean };
+    listStatementApplicable: '',
     batteryListNumber: string;
     brakeDeclarationIssuer: string;
     brakeEndurance: string;
     brakeDeclarationsSeen: string;
     declarationsSeen: string;
     weight: number;
-    certificateReq: certificateReq,
+    certificateReq: string,
     adrMoreDetail: string;
 }

--- a/src/app/pipes/FilterRecordPipe.ts
+++ b/src/app/pipes/FilterRecordPipe.ts
@@ -10,8 +10,9 @@ export class FilterRecordPipe implements PipeTransform {
       records = techRecordList.find((record: any) => record.statusCode === 'provisional');
       if (records !== undefined) return records;
 
-      records = techRecordList.find((record: any) => record.statusCode === 'archived');
-      if (records !== undefined) return records;
+      records = techRecordList.filter((record: any) => record.statusCode === 'archived');
+      records.sort((a,b)=> new Date (a.createdAt).getTime() - new Date (b.createdAt).getTime() );
+      if (records !== undefined) return records[0];
     }
   }
 }

--- a/src/app/pipes/OrderByStatusPipe.ts
+++ b/src/app/pipes/OrderByStatusPipe.ts
@@ -13,8 +13,9 @@ export class OrderByStatusPipe implements PipeTransform {
       records = techRecordList.find((record: any) => record.statusCode === 'provisional');
       if (records !== undefined) orderedTechRec.push(records);
 
-      records = techRecordList.find((record: any) => record.statusCode === 'archived');
-      if (records !== undefined) orderedTechRec.push(records);
+      records = techRecordList.filter((record: any) => record.statusCode === 'archived');
+      records.sort((a,b)=> new Date (a.createdAt).getTime() - new Date (b.createdAt).getTime() );
+      if (records !== undefined) records.forEach(element => orderedTechRec.push(element));
 
       return orderedTechRec;
 

--- a/src/app/shell/header/header.component.html
+++ b/src/app/shell/header/header.component.html
@@ -1,11 +1,11 @@
 <header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="topnav govuk-header__container govuk-width-container">
     <a href="#home" class="active govuk-!-font-weight-bold govuk-!-font-size-19 ">
-      Vehicle Testing Management
+      <span>Vehicle Testing Management</span>
     </a>
-    <div id="myLinks" [ngStyle]="{'display': menuOpen ? 'block' : 'none'}">
-      <a>{{userName}}</a>
-      <a href="#login">Sign Out</a>
+    <div id="menuLinks" [ngStyle]="{'display': menuOpen ? 'block' : 'none'}">
+      <a href="#1">{{userName}}</a>
+      <a (click)="logOut()">Sign Out</a>
     </div>
     <a class="icon" (click)="onClick($event)">
       <fa-icon [icon]="['fa', 'bars'] " size="lg"></fa-icon>
@@ -13,8 +13,8 @@
   </div>
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
-      <a href="#" id="header-nav-item" class="govuk-header__link govuk-header__link--homepage">
-        Vehicle testing management
+      <a href="#home" id="header-nav-item" class="govuk-header__link govuk-header__link--homepage">
+        <span>Vehicle testing management</span>
       </a>
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation"
               aria-label="Show or hide Top Level Navigation">Menu</button>
@@ -26,7 +26,7 @@
             </a>
           </li>
           <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="#2">
+            <a class="govuk-header__link" (click)="logOut()">
               Sign out
             </a>
           </li>

--- a/src/app/shell/header/header.component.scss
+++ b/src/app/shell/header/header.component.scss
@@ -65,14 +65,33 @@
   cursor: pointer;
 }
 
+.topnav a:visited, #menuLinks:visited {
+  color: #fff;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .topnav a:hover {
-  background-color: #ddd;
-  color: black;
+
+  fa-icon:hover {
+    color: white;
+    border: solid $govuk-focus-colour;
+    padding: 5px;
+  }
+
+  span:hover {
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
+    text-decoration: underline;
+    padding: 5px;
+  }
   cursor: pointer;
 }
 
 .active {
-  color: white;
+  color: $govuk-focus-colour;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 @media (max-width: 1313px) {

--- a/src/app/shell/header/header.component.ts
+++ b/src/app/shell/header/header.component.ts
@@ -19,4 +19,8 @@ export class HeaderComponent implements OnInit {
   onClick($event) {
     this.menuOpen = !this.menuOpen;
   }
+
+  logOut(){
+   (this.adal.isAuthenticated) ? this.adal.logout(): false;
+  }
 }

--- a/src/app/store/state/adrDetailsForm.state.ts
+++ b/src/app/store/state/adrDetailsForm.state.ts
@@ -65,23 +65,14 @@ export const INITIAL_STATE = createFormGroupState<adrDetailsFormModel>(FORM_ID, 
     month: 1,
     year: 1920
   },
-  memosApply: {
-    isMemo: true,
-    isNotMemo: true,
-  },
-  listStatementApplicable: {
-    applicable: true,
-    notApplicable: false,
-  },
+  memosApply: { '07/09 3mth leak ext' : false },
+  listStatementApplicable: '',
   batteryListNumber: '',
   brakeDeclarationIssuer: '',
   brakeEndurance: '',
   brakeDeclarationsSeen: '',
   declarationsSeen: '',
   weight: 0,
-  certificateReq: {
-    yesCert: true,
-    noCert: false,
-  },
+  certificateReq: '',
   adrMoreDetail: ''
 });

--- a/src/app/technical-record-search/technical-record-search.module.ts
+++ b/src/app/technical-record-search/technical-record-search.module.ts
@@ -43,7 +43,7 @@ import {AdrReasonModalComponent} from '@app/shared/adr-reason-modal/adr-reason-m
     TechnicalRecordSearchComponent,
   ],
   exports: [
-    TechnicalRecordSearchComponent
+    TechnicalRecordSearchComponent,
   ],
   providers: [TechnicalRecordService, TestResultService],
   entryComponents: [AdrReasonModalComponent],

--- a/src/app/technical-record-search/technical-record.service.spec.ts
+++ b/src/app/technical-record-search/technical-record.service.spec.ts
@@ -18,8 +18,9 @@ import {IAppState, INITIAL_STATE} from '@app/store/state/adrDetailsForm.state';
 import {APP_BASE_HREF} from '@angular/common';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {Router} from '@angular/router';
-import { environment } from '@environments/environment';
 import {AuthenticationGuardMock} from '../../../testconfig/services-mocks/authentication-guard.mock';
+import {TechnicalRecordSearchModule} from "@app/technical-record-search/technical-record-search.module";
+import {environment} from "@environments/environment";
 
 export const adalConfig = {
   cacheLocation: 'localStorage',
@@ -53,6 +54,7 @@ describe('TechnicalRecordService', () => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot(appReducers),
+        TechnicalRecordSearchModule,
         HttpClientTestingModule,
         MatDialogModule,
         FormsModule,
@@ -106,18 +108,6 @@ describe('TechnicalRecordService', () => {
   it('should be created', inject([HttpTestingController, MsAdalAngular6Service], (serviceI: TechnicalRecordService) => {
     expect(serviceI).toBeTruthy();
   }));
-
-  it('getTechnicalRecords should return data', (done) => {
-    service.getTechnicalRecords('1234567').subscribe((res) => {
-      expect(res).toBeDefined();
-      expect(res).toEqual({mockObject: 'mock'});
-      done();
-    });
-
-    const req = httpMock.expectOne(routes.techRecords('1234567'));
-    expect(req.request.method).toBe('GET');
-    req.flush({mockObject: 'mock'});
-  });
 
   it('getTechnicalRecordsAllStatuses should return data', (done) => {
     service.getTechnicalRecordsAllStatuses('1234567').subscribe((res) => {

--- a/src/app/technical-record-search/technical-record.service.ts
+++ b/src/app/technical-record-search/technical-record.service.ts
@@ -7,11 +7,10 @@ import {AppConfig} from '@app/app.config';
   providedIn: 'root'
 })
 export class TechnicalRecordService {
-  protected apiServer ;
+  protected apiServer = AppConfig.settings.apiServer;
   private readonly routes;
 
   constructor(private httpClient: HttpClient) {
-    this.apiServer = AppConfig.settings.apiServer;
     console.log(`TechnicalRecordService ctor apiServer => ${JSON.stringify(this.apiServer)}`);
     this.routes = {
       techRecords: (searchIdentifier: string) => `${this.apiServer.APITechnicalRecordServerUri}/vehicles/${searchIdentifier}/tech-records`,

--- a/src/app/technical-record-search/test-result.service.spec.ts
+++ b/src/app/technical-record-search/test-result.service.spec.ts
@@ -1,6 +1,6 @@
-import {TestBed, inject, getTestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, inject, getTestBed} from '@angular/core/testing';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {AuthenticationGuard, MsAdalAngular6Module, MsAdalAngular6Service} from 'microsoft-adal-angular6';
+import {AuthenticationGuard} from 'microsoft-adal-angular6';
 import {TestResultService} from './test-result.service';
 import {APP_BASE_HREF} from '@angular/common';
 import {Store, StoreModule} from '@ngrx/store';
@@ -14,14 +14,13 @@ import {SharedModule} from '@app/shared/shared.module';
 import {RouterTestingModule} from '@angular/router/testing';
 import {adrDetailsReducer} from '@app/store/reducers/adrDetailsForm.reducer';
 import { environment } from '@environments/environment';
-import { TechnicalRecordService } from './technical-record.service';
-import { TechnicalRecordComponent } from '@app/technical-record/technical-record.component';
 import {NgrxFormsModule} from 'ngrx-forms';
 import {AuthenticationGuardMock} from '../../../testconfig/services-mocks/authentication-guard.mock';
 import {Router} from '@angular/router';
 import {CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
 import {FontAwesomeModule} from '@fortawesome/angular-fontawesome';
 import {hot} from 'jasmine-marbles';
+import {TechnicalRecordSearchModule} from "@app/technical-record-search/technical-record-search.module";
 
 const routes = {
   testResults: (searchIdentifier: string) => `${environment.APITestResultServerUri}/test-results/${searchIdentifier}`,
@@ -35,8 +34,6 @@ describe('TestResultService', () => {
   let httpMock: HttpTestingController;
   let injector: TestBed;
   let service: TestResultService;
-  let component: TechnicalRecordComponent;
-  let fixture: ComponentFixture<TechnicalRecordComponent>;
   const authenticationGuardMock = new AuthenticationGuardMock();
   let store: Store<IAppState>;
 
@@ -44,6 +41,7 @@ describe('TestResultService', () => {
     TestBed.configureTestingModule({
       imports: [
         StoreModule.forRoot(appReducers),
+        TechnicalRecordSearchModule,
         HttpClientTestingModule,
         MatDialogModule,
         FormsModule,
@@ -55,21 +53,11 @@ describe('TestResultService', () => {
         StoreModule.forFeature('adrDetails', adrDetailsReducer),
         FontAwesomeModule,
         ReactiveFormsModule,
-        NgrxFormsModule,
-        MsAdalAngular6Module.forRoot({
-          tenant: '1x111x11-1xx1-1xxx-xx11-1x1xx11x1111',
-          clientId: '11x111x1-1xx1-1111-1x11-x1xx111x11x1',
-          redirectUri: window.location.origin,
-          endpoints: {
-            'https://localhost/Api/': 'xxx-xxx1-1111-x111-xxx'
-          },
-          navigateToLoginRequestUrl: true,
-          cacheLocation: 'localStorage',
-        })
+        NgrxFormsModule
       ],
-      declarations: [TechnicalRecordComponent],
+      declarations: [],
       providers: [
-        TechnicalRecordService,
+        TestResultService,
         {
           provide: Store,
           useValue: {
@@ -86,19 +74,22 @@ describe('TestResultService', () => {
     }).compileComponents();
         store = TestBed.get(Store);
         spyOn(store, 'dispatch').and.callThrough();
-        fixture = TestBed.createComponent(TechnicalRecordComponent);
         injector = getTestBed();
         service  = injector.get(TestResultService);
         httpMock = injector.get(HttpTestingController);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
+  });
+
+  beforeEach( ()=> {
+    injector = getTestBed();
+    service  = injector.get(TestResultService);
+    httpMock = injector.get(HttpTestingController);
   });
 
   afterEach(() => {
     httpMock.verify();
   });
 
-  it('should be created', inject([HttpTestingController, MsAdalAngular6Service], (serviceI: TestResultService) => {
+  it('should be created', inject([HttpTestingController], (serviceI: TestResultService) => {
     expect(serviceI).toBeTruthy();
   }));
 

--- a/src/app/technical-record/technical-record.component.html
+++ b/src/app/technical-record/technical-record.component.html
@@ -1109,14 +1109,14 @@
                                 <div class="govuk-radios__item">
                                   <input class="govuk-radios__input" id="isMemo" type="radio"
                                          value="07/09 3mth leak ext"
-                                         [ngrxFormControlState]="(formState$ | async).controls.memosApply.controls.isMemo">
+                                         [ngrxFormControlState]="(formState$ | async).controls.memosApply">
                                   <label class="govuk-label govuk-radios__label" for="isMemo">
                                     Yes
                                   </label>
                                 </div>
                                 <div class="govuk-radios__item">
                                   <input class="govuk-radios__input" id="isNotMemo" type="radio" value="false"
-                                         [ngrxFormControlState]="(formState$ | async).controls.memosApply.controls.isNotMemo">
+                                         [ngrxFormControlState]="(formState$ | async).controls.memosApply">
                                   <label class="govuk-label govuk-radios__label" for="isNotMemo">
                                     No
                                   </label>
@@ -1155,7 +1155,7 @@
                                 <div class="govuk-radios__item">
                                   <input class="govuk-radios__input" id="applicable" type="radio" value="applicable"
                                          (change)="onBatteryApplicableChange($event)"
-                                         [ngrxFormControlState]="(formState$ | async).controls.listStatementApplicable.controls.applicable">
+                                         [ngrxFormControlState]="(formState$ | async).controls.listStatementApplicable">
                                   <label class="govuk-label govuk-radios__label" for="applicable">
                                     Yes
                                   </label>
@@ -1163,7 +1163,7 @@
                                 <div class="govuk-radios__item">
                                   <input class="govuk-radios__input" id="notApplicable" type="radio"
                                          value="notApplicable" (change)="onBatteryApplicableChange($event)"
-                                         [ngrxFormControlState]="(formState$ | async).controls.listStatementApplicable.controls.notApplicable">
+                                         [ngrxFormControlState]="(formState$ | async).controls.listStatementApplicable">
                                   <label class="govuk-label govuk-radios__label" for="notApplicable">
                                     No
                                   </label>
@@ -1240,15 +1240,15 @@
                             <h2 class="govuk-heading-m">Certificate required</h2>
                             <div class="govuk-radios govuk-radios--inline">
                               <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="yesCert" type="radio" value="yes"
-                                       [ngrxFormControlState]="(formState$ | async).controls.certificateReq.controls.yesCert">
+                                <input class="govuk-radios__input" id="yesCert" type="radio" value="New certificate requested"
+                                       [ngrxFormControlState]="(formState$ | async).controls.certificateReq">
                                 <label class="govuk-label govuk-radios__label" for="yesCert">
                                   Yes
                                 </label>
                               </div>
                               <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="noCert" type="radio" value="no"
-                                       [ngrxFormControlState]="(formState$ | async).controls.certificateReq.controls.yesCert">
+                                <input class="govuk-radios__input" id="noCert" type="radio" value=""
+                                       [ngrxFormControlState]="(formState$ | async).controls.certificateReq">
                                 <label class="govuk-label govuk-radios__label" for="noCert">
                                   No
                                 </label>

--- a/src/app/technical-record/technical-record.component.scss
+++ b/src/app/technical-record/technical-record.component.scss
@@ -1,4 +1,5 @@
 @import "node_modules/govuk-frontend/govuk/all";
+
 .un-number {
   display: grid;
   grid-template-columns: auto auto;


### PR DESCRIPTION
CVSB-10517 - Implement UI logic to display proper tech record in the tech record view page
CVSB-10575 - The order in which we display tech records in the tech record history section is not correct
CVSB-10615 - The list of documents is not in the adr details sections is not correct
CVSB-10636 - User can select both statement and product list
CVSB-10733 - User can select both yes and no to "Memo 07/09 (3 month extension)"
CVSB-10734 - User can select both yes and no to "Battery list applicable"
CVSB-10500 - For vehicles with no primary VRM we should display "-" and not ""


