### PR TITLE
Feature/CVSB-13970 - back button cursor pointer on tech record view page

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -495,4 +495,5 @@ a#cancel2 {
 
 .govuk-back-link {
   text-decoration: underline;
+  cursor: pointer;
 }


### PR DESCRIPTION
Added cursor pointer for back button on tecc record view page. We should not have all this problems once we replace accordion from tech rec page and delete the css from app.css

https://jira.dvsacloud.uk/browse/CVSB-13970