### PR TITLE
fix(scanrepo): enable scanrepo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,11 @@ _One line description_
 [link to ticket number]()
 
 ## Checklist
+
+- [ ] Branch is rebased against the latest develop/common
+- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
 - [ ] Code and UI has been tested manually after the additional changes
 - [ ] PR title includes the JIRA ticket number
-- [ ] Branch is rebased against the latest develop/common
 - [ ] Squashed commits contain the JIRA ticket number
-- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
+- [ ] Link to the PR added to the repo
 - [ ] Delete branch after merge

--- a/.secignore
+++ b/.secignore
@@ -1,1 +1,8 @@
 .npmrc
+.scannerwork/sonarts-bundle/node_modules/tslint-sonarts/lib/rules/*.js.map
+.scannerwork/sonarts-bundle/node_modules/tslint-sonarts/lib/rules/*.js
+.scannerwork/sonarts-bundle/node_modules/tslint-sonarts/lib/rules/*.d.ts
+.scannerwork/sonarts-bundle/node_modules/js-yaml/lib/js-yaml/*.js
+.scannerwork/css-bundle/node_modules/caniuse-lite/data/features/*.js
+.scannerwork/css-bundle/node_modules/js-yaml/lib/js-yaml/*.js
+.scannerwork/css-bundle/node_modules/validate-npm-package-license/*.log

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "./node_modules/.bin/commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "npm run lint",
+      "pre-commit": "npm run lint && npm run security-checks",
       "pre-push": "npm run prepush"
     }
   },


### PR DESCRIPTION
scanrepo was not enabled on the repo as some errors (node_modules files of .scannerwork/) were being thrown when running it due to cached files being pushed early in the project and scannerepo being enabled later.