### PR TITLE
fix(scanrepo): reenable scan repo and add it to commit msg hook

### DIFF
--- a/.secignore
+++ b/.secignore
@@ -1,0 +1,8 @@
+.npmrc
+.scannerwork/sonarts-bundle/node_modules/tslint-sonarts/lib/rules/*.js.map
+.scannerwork/sonarts-bundle/node_modules/tslint-sonarts/lib/rules/*.js
+.scannerwork/sonarts-bundle/node_modules/tslint-sonarts/lib/rules/*.d.ts
+.scannerwork/sonarts-bundle/node_modules/js-yaml/lib/js-yaml/*.js
+.scannerwork/css-bundle/node_modules/caniuse-lite/data/features/*.js
+.scannerwork/css-bundle/node_modules/js-yaml/lib/js-yaml/*.js
+.scannerwork/css-bundle/node_modules/validate-npm-package-license/*.log

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run prepush"
+      "pre-push": "npm run prepush",
+      "pre-commit": "npm run security-checks"
     }
   },
   "description": "CVS VTM Application"


### PR DESCRIPTION
scanrepo was not enabled on the repo as some errors (node_modules files of .scannerwork/) were being thrown when running it due to cached files being pushed early in the project and scannerepo being enabled later.