### PR TITLE
Fix hook

### DIFF
--- a/.secignore
+++ b/.secignore
@@ -6,3 +6,4 @@
 .scannerwork/css-bundle/node_modules/caniuse-lite/data/features/*.js
 .scannerwork/css-bundle/node_modules/js-yaml/lib/js-yaml/*.js
 .scannerwork/css-bundle/node_modules/validate-npm-package-license/*.log
+src/assets/config/config.dev.json~feat(cvsb-10710): download certificate logic with unit tests


### PR DESCRIPTION
remove unnecessary warning thrown by scanrepo