### PR TITLE
bugfix(feature/CVSB-16611): The VRM error message also appears above the VIN field

### DIFF
--- a/src/app/technical-record-create/__snapshots__/technical-record-create.component.spec.ts.snap
+++ b/src/app/technical-record-create/__snapshots__/technical-record-create.component.spec.ts.snap
@@ -132,7 +132,7 @@ exports[`TechnicalRecordSearchComponent should create 1`] = `
                     </div>
                   </div>
                   <div
-                    class="govuk-grid-row govuk-!-margin-bottom-5 govuk-!-padding-left-0 govuk-!-margin-left-0 govuk-form-group--error"
+                    class="govuk-grid-row govuk-!-margin-bottom-5 govuk-!-padding-left-0 govuk-!-margin-left-0"
                   >
                     <div
                       class="govuk-grid-column-full"
@@ -153,13 +153,10 @@ exports[`TechnicalRecordSearchComponent should create 1`] = `
                         >
                           Error:
                         </span>
-                        <span>
-                          
-                        </span>
                         
                       </span>
                       <input
-                        class="govuk-input govuk-input--width-20 govuk-input--error ng-untouched ng-pristine ng-invalid"
+                        class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-invalid"
                         formcontrolname="vin"
                         id="test-vin"
                         maxlength="21"

--- a/src/app/technical-record-create/technical-record-create.component.html
+++ b/src/app/technical-record-create/technical-record-create.component.html
@@ -53,7 +53,9 @@
                 </div>
                 <div
                   class="govuk-grid-row govuk-!-margin-bottom-5 govuk-!-padding-left-0 govuk-!-margin-left-0"
-                  [class.govuk-form-group--error]="formErrors.vinErr || formError[0]"
+                  [class.govuk-form-group--error]="
+                    formErrors.vinErr || formError[0]?.includes('VIN')
+                  "
                 >
                   <div class="govuk-grid-column-full">
                     <label class="govuk-label govuk-!-font-weight-bold" for="test-vin">
@@ -65,12 +67,13 @@
                       class="govuk-error-message"
                     >
                       <span class="govuk-visually-hidden">Error:</span>
-                      <span>{{ formErrors.vinErr }}</span>
-                      <span *ngIf="formError[0]?.includes('exists')">{{ formError[0] }}</span>
+                      <span *ngIf="formError[0]?.includes('VIN')">{{ formError[0] }}</span>
                     </span>
                     <input
                       class="govuk-input govuk-input--width-20"
-                      [class.govuk-input--error]="formErrors.vinErr || formError[0]"
+                      [class.govuk-input--error]="
+                        formErrors.vinErr || formError[0]?.includes('VIN')
+                      "
                       id="test-vin"
                       type="text"
                       formControlName="vin"

--- a/src/app/technical-record-create/technical-record-create.component.spec.ts
+++ b/src/app/technical-record-create/technical-record-create.component.spec.ts
@@ -152,9 +152,9 @@ describe('TechnicalRecordSearchComponent', () => {
     component.createTechRecordForm.controls.vehicleType.setValue('dddd');
 
     component.onSubmit();
-    expect(component.formErrors.vinErr).toEqual('');
-    expect(component.formErrors.vrmErr).toEqual('');
-    expect(component.formErrors.vTypeErr).toEqual('');
+    expect(component.formErrors.vinErr).toEqual(null);
+    expect(component.formErrors.vrmErr).toEqual(null);
+    expect(component.formErrors.vTypeErr).toEqual(null);
   });
 
 });

--- a/src/app/technical-record-create/technical-record-create.component.ts
+++ b/src/app/technical-record-create/technical-record-create.component.ts
@@ -7,12 +7,11 @@ import { Observable } from 'rxjs';
 import { CREATE_PAGE_LABELS } from '@app/app.enums';
 import { VehicleIdentifiers } from '@app/models/vehicle-tech-record.model';
 import { getErrors } from '@app/store/selectors/error.selectors';
-import { SetErrorMessage } from '@app/store/actions/Error.actions';
+import { ClearErrorMessage, SetErrorMessage } from '@app/store/actions/Error.actions';
 
 @Component({
   selector: 'vtm-technical-record-create',
   templateUrl: './technical-record-create.component.html',
-  styleUrls: ['./technical-record-create.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TechnicalRecordCreateComponent implements OnInit {
@@ -64,11 +63,13 @@ export class TechnicalRecordCreateComponent implements OnInit {
   }
 
   onSubmit() {
-    this.formErrors.vinErr = !this.createTechRecordForm.get('vin').valid ? 'Enter a VIN' : '';
-    this.formErrors.vrmErr = !this.createTechRecordForm.get('vrm').valid ? 'Enter a VRM' : '';
+    this._store.dispatch(new ClearErrorMessage());
+
+    this.formErrors.vinErr = !this.createTechRecordForm.get('vin').valid ? 'Enter a VIN' : null;
+    this.formErrors.vrmErr = !this.createTechRecordForm.get('vrm').valid ? 'Enter a VRM' : null;
     this.formErrors.vTypeErr = !this.createTechRecordForm.get('vehicleType').valid
       ? 'Select a vehicle type'
-      : '';
+      : null;
 
     if (!this.formErrors.vinErr && !this.formErrors.vrmErr && !this.formErrors.vTypeErr) {
       const createDetails: VehicleIdentifiers = {
@@ -76,6 +77,7 @@ export class TechnicalRecordCreateComponent implements OnInit {
         vrm: this.createTechRecordForm.get('vrm').value,
         vType: this.createTechRecordForm.get('vehicleType').value
       };
+
       this.formErrors.requestErr = [];
       this._store.dispatch(new SetVehicleTechRecordModelOnCreate(createDetails));
     } else {


### PR DESCRIPTION
## Bugfix for: CVSB-10141 

Bugfix for: CVSB-10141 - As the DVSA, we want to be able to search for a vehicle before creating it to ensure that it does not already exist

The VRM error message also appears above the VIN field

https://jira.dvsacloud.uk/browse/CVSB-16611


## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
