### PR TITLE
fixes(feature/cvsb-12375): bugfixing & clarifications on test section from test record edit

### DIFF
--- a/src/app/shared/components/date-input/date-input.component.ts
+++ b/src/app/shared/components/date-input/date-input.component.ts
@@ -144,6 +144,7 @@ export class DateInputComponent
     let year = '';
 
     [year, month, day] = (dateString || '').split('-');
+    day = !!day ? (day.includes('T') ? day.split('T')[0] : day) : '';
 
     this.dateInputs.patchValue({ day, month, year });
   }

--- a/src/app/shared/components/time-input/__snapshots__/time-input.component.spec.ts.snap
+++ b/src/app/shared/components/time-input/__snapshots__/time-input.component.spec.ts.snap
@@ -56,6 +56,19 @@ exports[`TimeInputComponent should create 1`] = `
           >
             <label
               class="govuk-label govuk-date-input__label"
+            >
+               : 
+            </label>
+          </div>
+        </div>
+        <div
+          class="govuk-date-input__item"
+        >
+          <div
+            class="govuk-form-group"
+          >
+            <label
+              class="govuk-label govuk-date-input__label"
               for="testTime-1-minute"
             >
                Minute 

--- a/src/app/shared/components/time-input/time-input.component.html
+++ b/src/app/shared/components/time-input/time-input.component.html
@@ -19,7 +19,13 @@
         />
       </div>
     </div>
-
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label">
+          :
+        </label>
+      </div>
+    </div>
     <div class="govuk-date-input__item">
       <div class="govuk-form-group">
         <label class="govuk-label govuk-date-input__label" for="{{ id }}-minute">

--- a/src/app/shared/dialog-box/__snapshots__/dialog-box.component.spec.ts.snap
+++ b/src/app/shared/dialog-box/__snapshots__/dialog-box.component.spec.ts.snap
@@ -32,7 +32,7 @@ exports[`DialogBoxComponent should create 1`] = `
         cdkfocusinitial=""
         class="govuk-button"
         data-module="govuk-button"
-        id="test-"
+        id="test-save-action"
       >
           
       </button>
@@ -43,6 +43,7 @@ exports[`DialogBoxComponent should create 1`] = `
       <a
         class="govuk-link govuk-!-margin-left-2"
         href="javascript:void(0)"
+        id="test-cancel-action"
       >
         <span>
           Cancel

--- a/src/app/shared/dialog-box/dialog-box.component.html
+++ b/src/app/shared/dialog-box/dialog-box.component.html
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-one-quarter govuk-!-margin-right-0 govuk-!-padding-right-0">
     <button
       class="govuk-button"
-      id="test-{{ data.actionName }}"
+      id="test-save-action"
       data-module="govuk-button"
       (click)="save(data.response)"
       cdkFocusInitial
@@ -22,8 +22,15 @@
       {{ data.actionName }}
     </button>
   </div>
-  <div class="govuk-grid-column-one-quarter govuk-!-margin-right-0 govuk-!-padding-right-0 govuk-!-padding-top-2">
-    <a class="govuk-link govuk-!-margin-left-2" (click)="close()" href="javascript:void(0)">
+  <div
+    class="govuk-grid-column-one-quarter govuk-!-margin-right-0 govuk-!-padding-right-0 govuk-!-padding-top-2"
+  >
+    <a
+      class="govuk-link govuk-!-margin-left-2"
+      (click)="close()"
+      href="javascript:void(0)"
+      id="test-cancel-action"
+    >
       <span>Cancel</span>
     </a>
   </div>

--- a/src/app/store/effects/VehicleTestResultModel.effects.ts
+++ b/src/app/store/effects/VehicleTestResultModel.effects.ts
@@ -84,7 +84,7 @@ export class VehicleTestResultModelEffects {
             ];
           }),
           catchError(({ error }) => {
-            const errorMessage = !!error ? error.errors : [''];
+            const errorMessage = error.errors;
             return [new SetErrorMessage(errorMessage)];
           })
         );

--- a/src/app/test-record/emission-details/edit/__snapshots__/emission-details-edit.component.spec.ts.snap
+++ b/src/app/test-record/emission-details/edit/__snapshots__/emission-details-edit.component.spec.ts.snap
@@ -335,7 +335,7 @@ exports[`EmissionDetailsEditComponent should create 1`] = `
                       formcontrolname="modType"
                       id="test-modType-0"
                       type="radio"
-                      value="p - particulate trap"
+                      value="P - Particulate trap"
                     />
                     <label
                       class="govuk-label govuk-radios__label"
@@ -351,7 +351,7 @@ exports[`EmissionDetailsEditComponent should create 1`] = `
                       formcontrolname="modType"
                       id="test-modType-1"
                       type="radio"
-                      value="m - modification or change of engine"
+                      value="M - Modification or change of engine"
                     />
                     <label
                       class="govuk-label govuk-radios__label"
@@ -367,7 +367,7 @@ exports[`EmissionDetailsEditComponent should create 1`] = `
                       formcontrolname="modType"
                       id="test-modType-2"
                       type="radio"
-                      value="g - gas engine"
+                      value="G - Gas engine"
                     />
                     <label
                       class="govuk-label govuk-radios__label"

--- a/src/app/test-record/emission-details/edit/emission-details-edit.component.html
+++ b/src/app/test-record/emission-details/edit/emission-details-edit.component.html
@@ -84,7 +84,7 @@
                     id="{{ 'test-modType-' + i }}"
                     type="radio"
                     formControlName="modType"
-                    value="{{ modOption | lowercase }}"
+                    value="{{ modOption }}"
                     [checked]="this.modTypeValue === (modOption | lowercase)"
                   />
                   <label class="govuk-label govuk-radios__label">

--- a/src/app/test-record/emission-details/emission-details.component.html
+++ b/src/app/test-record/emission-details/emission-details.component.html
@@ -36,10 +36,14 @@
     </dd>
   </div>
   <div *ngIf="editModTypeUsed" class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
+    <dt class="govuk-summary-list__key" [class.border--bottom-none]="!editParticulate">
       Modification type used
     </dt>
-    <dd class="govuk-summary-list__value" id="test-modificationTypeUsed">
+    <dd
+      class="govuk-summary-list__value"
+      id="test-modificationTypeUsed"
+      [class.border--bottom-none]="!editParticulate"
+    >
       {{ testType.modificationTypeUsed | DefaultNullOrEmpty | CapitalizeString }}
     </dd>
   </div>

--- a/src/app/test-record/test-record.component.html
+++ b/src/app/test-record/test-record.component.html
@@ -81,6 +81,7 @@
                 [testRecord]="testResultObj.testRecord"
                 [testTypesApplicable]="testTypesApplicable"
                 [editState]="editState"
+                (testResult)="testResultHandler($event)"
               ></vtm-test-section>
             </vtm-accordion-item>
             <span [hidden]="hasDefectsApplicable">
@@ -101,14 +102,16 @@
                 ></vtm-seatbelt-installation-check>
               </vtm-accordion-item>
             </span>
-            <span [hidden]="hasEmissionApplicable">
+            <span [hidden]="hasEmissionApplicable" id="test-emissions">
               <vtm-accordion-item [title]="'Emission details'">
-                <vtm-emission-details
-                  [testRecord]="testResultObj.testRecord"
-                  [testType]="testResultObj.testType"
-                  [editState]="editState"
-                  [hasEmissionApplicable]="hasEmissionApplicable"
-                ></vtm-emission-details>
+                <ng-container *ngIf="viewEmissionDetails">
+                  <vtm-emission-details
+                    [testRecord]="testResultObj.testRecord"
+                    [testType]="testResultObj.testType"
+                    [editState]="editState"
+                    [hasEmissionApplicable]="hasEmissionApplicable"
+                  ></vtm-emission-details>
+                </ng-container>
               </vtm-accordion-item>
             </span>
             <vtm-accordion-item [title]="'Visit'">

--- a/src/app/test-record/test-record.component.ts
+++ b/src/app/test-record/test-record.component.ts
@@ -4,7 +4,8 @@ import {
   ChangeDetectionStrategy,
   Input,
   EventEmitter,
-  Output
+  Output,
+  ChangeDetectorRef
 } from '@angular/core';
 import { FormBuilder, FormGroup, FormGroupDirective } from '@angular/forms';
 import { initAll } from 'govuk-frontend';
@@ -37,6 +38,7 @@ export class TestRecordComponent implements OnInit {
   hasDefectsApplicable: boolean;
   hasEmissionApplicable: boolean;
   hasSeatBeltApplicable: boolean;
+  viewEmissionDetails: boolean;
 
   constructor(
     private parent: FormGroupDirective,
@@ -49,9 +51,10 @@ export class TestRecordComponent implements OnInit {
     this.hasDefectsApplicable = this.testTypesApplicable.defectsApplicable[
       this.testResultObj.testType.testTypeId
     ];
-    this.hasSeatBeltApplicable =
-      !(this.testTypesApplicable.seatBeltApplicable[this.testResultObj.testType.testTypeId] &&
-      this.testResultObj.testRecord.vehicleType === 'psv');
+    this.hasSeatBeltApplicable = !(
+      this.testTypesApplicable.seatBeltApplicable[this.testResultObj.testType.testTypeId] &&
+      this.testResultObj.testRecord.vehicleType === 'psv'
+    );
     this.hasEmissionApplicable = !(
       this.testTypesApplicable.emissionDetailsApplicable[
         this.testResultObj.testType.testTypeId
@@ -60,6 +63,7 @@ export class TestRecordComponent implements OnInit {
         this.testResultObj.testRecord.vehicleType === 'hgv') &&
       this.testResultObj.testType.testResult === 'pass'
     );
+    this.viewEmissionDetails = this.testResultObj.testType.testResult === 'pass';
 
     initAll();
     this.switchState.emit(VIEW_STATE.VIEW_ONLY);
@@ -108,5 +112,10 @@ export class TestRecordComponent implements OnInit {
   downloadCertificate() {
     const fileName = `${this.testResultObj.testType.testNumber}_${this.testResultObj.testRecord.vin}.pdf`;
     this.downloadCert.emit(fileName);
+  }
+
+  testResultHandler(tResult: string) {
+    this.viewEmissionDetails = tResult === 'pass';
+    this.hasEmissionApplicable = tResult !== 'pass';
   }
 }

--- a/src/app/test-record/test-record.constants.ts
+++ b/src/app/test-record/test-record.constants.ts
@@ -1,0 +1,1 @@
+export const PROHIBITION_RADIO_OPTIONS = { ['Yes']: true, ['No']: false };

--- a/src/app/test-record/test-record.enums.ts
+++ b/src/app/test-record/test-record.enums.ts
@@ -78,53 +78,59 @@ export enum RESULT {
   ABANDONED = 'Abandoned'
 }
 
+export enum RESULT_LEC {
+  FAIL = 'Fail',
+  PASS = 'Pass',
+  ABANDONED = 'Abandoned'
+}
+
 export enum REASON_FOR_ABANDONING_PSV {
-  R1 = 'The vehicle was not submitted for test at the appointed time',
-  R2 = 'The relevant test fee has not been paid',
-  R3 = 'There was no means of identifying the vehicle i.e. the vehicle chassis/serial number was missing or did not relate to the vehicle',
-  R4 = 'The registration document or other evidence of the date of first registration was not presented when requested',
-  R5 = 'The vehicle was emitting substantial amounts of exhaust smoke so as to make it unreasonable for the test to be carried out',
-  R6 = 'The vehicle was in such a dirty or dangerous condition as to make it unreasonable for the test to be carried out',
-  R7 = 'The vehicle did not have sufficient fuel and oil to allow the test to be carried out',
-  R8 = 'The test could not be completed due to a failure of a part of the vehicle which made movement under its own power impossible',
-  R9 = 'Current Health and Safety legislation cannot be met in testing the vehicle',
-  R10 = 'The driver and/or presenter of the vehicle declined either to remain in the vehicle or in its vicinity throughout the examination' +
-    'or to drive it or to operate controls or doors or to remove or refit panels after being requested to do so',
-  R11 = 'The vehicle exhaust outlet has been modified in such a way as to prevent a metered smoke check being conducted',
-  R12 = 'A proper examination cannot be readily carried out as any door engine cover hatch or other access device designed to be opened is locked or otherwise cannot be opened'
+  R1 = 'The vehicle was not submitted for test at the appointed time',
+  R2 = 'The relevant test fee has not been paid',
+  R3 = 'There was no means of identifying the vehicle i.e. the vehicle chassis/serial number was missing or did not relate to the vehicle',
+  R4 = 'The registration document or other evidence of the date of first registration was not presented when requested',
+  R5 = 'The vehicle was emitting substantial amounts of exhaust smoke so as to make it unreasonable for the test to be carried out',
+  R6 = 'The vehicle was in such a dirty or dangerous condition as to make it unreasonable for the test to be carried out',
+  R7 = 'The vehicle did not have sufficient fuel and oil to allow the test to be carried out',
+  R8 = 'The test could not be completed due to a failure of a part of the vehicle which made movement under its own power impossible',
+  R9 = 'Current Health and Safety legislation cannot be met in testing the vehicle',
+  R10 = 'The driver and/or presenter of the vehicle declined either to remain in the vehicle or in its vicinity throughout the examination' +
+    'or to drive it or to operate controls or doors or to remove or refit panels after being requested to do so',
+  R11 = 'The vehicle exhaust outlet has been modified in such a way as to prevent a metered smoke check being conducted',
+  R12 = 'A proper examination cannot be readily carried out as any door engine cover hatch or other access device designed to be opened is locked or otherwise cannot be opened'
 }
 
 export enum REASON_FOR_ABANDONING_HGV_TRL {
-  R1 = 'The vehicle was not submitted for test at the appointed time',
-  R2 = 'The relevant test fee has not been paid',
-  R3 = 'The trailer was not accompanied by a suitable motor vehicle',
-  R4 = 'There is not permanently fixed to the chassis serial number as shown on the registration document (motor vehicle) or the identification' +
-    'mark issued by the Secretary of State (trailer)',
-  R5 = 'A Ministry Plate has been issued and is not fitted to the vehicle or trailer',
-  R6 = 'The particulars of the motor vehicle or trailer (e.g. number of axles / axle weights) do not match the VTG6 Ministry Plate fitted to the vehicle',
-  R7 = 'The vehicle or motor vehicle by which it is accompanied emits substantial amounts of smoke so as to make it unreasonable for the test to be carried out',
-  R8 = 'The vehicle or trailer (any part) was in such a dirty or dangerous condition as to make it unreasonable for the test to be carried out',
-  R9 = 'No proof was given that the vehicle used for carrying dangerous/toxic/corrosive or inflammable goods had been cleaned or otherwise rendered safe for test',
-  R10 = 'The vehicle did not have sufficient fuel and oil to allow the test to be carried out',
-  R11 = 'The vehicle was not loaded as required',
-  R12 = 'The test could not be completed due to a failure of a part of the vehicle, or trailer and accompanying motor vehicle which made movement impossible',
-  R13 = 'The vehicle was presented for test carrying livestock or other unsuitable material',
-  R14 = 'Current Health and Safety legislation cannot be met in testing the vehicle',
-  R15 = 'The vehicle exhaust outlet has been modified preventing a metered smoke check',
-  R16 = 'The examiner could not open the tachograph',
-  R17 = 'The driver and/or presenter of the vehicle refused to or was unable to comply with the instructions of DVSA staff making it impractical or unsafe to continue the test'
+  R1 = 'The vehicle was not submitted for test at the appointed time',
+  R2 = 'The relevant test fee has not been paid',
+  R3 = 'The trailer was not accompanied by a suitable motor vehicle',
+  R4 = 'There is not permanently fixed to the chassis serial number as shown on the registration document (motor vehicle) or the' +
+    ' identification mark issued by the Secretary of State (trailer)',
+  R5 = 'A Ministry Plate has been issued and is not fitted to the vehicle or trailer',
+  R6 = 'The particulars of the motor vehicle or trailer (e.g. number of axles / axle weights) do not match the VTG6 Ministry Plate fitted to the vehicle',
+  R7 = 'The vehicle or motor vehicle by which it is accompanied emits substantial amounts of smoke so as to make it unreasonable for the test to be carried out',
+  R8 = 'The vehicle or trailer (any part) was in such a dirty or dangerous condition as to make it unreasonable for the test to be carried out',
+  R9 = 'No proof was given that the vehicle used for carrying dangerous/toxic/corrosive or inflammable goods had been cleaned or otherwise rendered safe for test',
+  R10 = 'The vehicle did not have sufficient fuel and oil to allow the test to be carried out',
+  R11 = 'The vehicle was not loaded as required',
+  R12 = 'The test could not be completed due to a failure of a part of the vehicle, or trailer and accompanying motor vehicle which made movement impossible',
+  R13 = 'The vehicle was presented for test carrying livestock or other unsuitable material',
+  R14 = 'Current Health and Safety legislation cannot be met in testing the vehicle',
+  R15 = 'The vehicle exhaust outlet has been modified preventing a metered smoke check',
+  R16 = 'The examiner could not open the tachograph',
+  R17 = 'The driver and/or presenter of the vehicle refused to or was unable to comply with the instructions of DVSA staff making it impractical or unsafe to continue the test'
 }
 
 export enum REASON_FOR_ABANDONING_TIR {
-  R1 = 'The vehicle was not submitted for test at the appointed time',
-  R2 = 'The relevant test fee has not been paid',
-  R3 = 'The trailer was not accompanied by a suitable drawing motor vehicle',
-  R4 = 'There is not permanently fixed to the chassis a serial number (motor vehicle) or the identification mark issued by the Secretary of State (trailer)',
-  R5 = 'The vehicle or motor vehicle by which it is accompanied emits substantial amounts of smoke so as to make it unreasonable for the test to be carried out',
-  R6 = 'The vehicle or trailer (any part) was in such a dirty or dangerous condition as to make it unreasonable for the test to be carried out',
-  R7 = 'The vehicle did not have sufficient fuel and oil to allow the test to be carried out',
-  R8 = 'The test could not be completed due to a failure of a part of the vehicle, or trailer and accompanying motor vehicle which made movement impossible',
-  R9 = 'The vehicle was presented for test carrying unsuitable material',
-  R10 = 'Current Health and Safety legislation cannot be met in testing the vehicle',
-  R11 = 'The driver and/or presenter of the vehicle refused to or was unable to comply with the instructions of DVSA staff making it impractical or unsafe to continue the test'
+  R1 = 'The vehicle was not submitted for test at the appointed time',
+  R2 = 'The relevant test fee has not been paid',
+  R3 = 'The trailer was not accompanied by a suitable drawing motor vehicle',
+  R4 = 'There is not permanently fixed to the chassis a serial number (motor vehicle) or the identification mark issued by the Secretary of State (trailer)',
+  R5 = 'The vehicle or motor vehicle by which it is accompanied emits substantial amounts of smoke so as to make it unreasonable for the test to be carried out',
+  R6 = 'The vehicle or trailer (any part) was in such a dirty or dangerous condition as to make it unreasonable for the test to be carried out',
+  R7 = 'The vehicle did not have sufficient fuel and oil to allow the test to be carried out',
+  R8 = 'The test could not be completed due to a failure of a part of the vehicle, or trailer and accompanying motor vehicle which made movement impossible',
+  R9 = 'The vehicle was presented for test carrying unsuitable material',
+  R10 = 'Current Health and Safety legislation cannot be met in testing the vehicle',
+  R11 = 'The driver and/or presenter of the vehicle refused to or was unable to comply with the instructions of DVSA staff making it impractical or unsafe to continue the test'
 }

--- a/src/app/test-record/test-record.mapper.spec.ts
+++ b/src/app/test-record/test-record.mapper.spec.ts
@@ -69,7 +69,7 @@ describe('TestRecordMapper', () => {
       },
       testResultObject
     );
-    expect(Object.values(testResultMapped).length).toEqual(25);
+    expect(Object.values(testResultMapped).length).toEqual(24);
   });
 
   describe('should return reasons for abandoning based on vehicle type & test type id', () => {
@@ -111,7 +111,7 @@ describe('TestRecordMapper', () => {
       Object.values(REASON_FOR_ABANDONING_PSV)
     );
     expect(reasonsSelected).toEqual(
-      'The vehicle was not submitted for test at the appointed time,The relevant test fee has not been paid'
+      'The vehicle was not submitted for test at the appointed time. The relevant test fee has not been paid'
     );
   });
 });

--- a/src/app/test-record/test-section/__snapshots__/test-section.component.spec.ts.snap
+++ b/src/app/test-record/test-section/__snapshots__/test-section.component.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`TestSectionComponent should create 1`] = `
 <vtm-test-section
   hasCertificateNumber="undefined"
   testRecord={[Function Object]}
+  testResult={[Function EventEmitter]}
   testType={[Function Object]}
   testTypesApplicable={[Function Object]}
 >
@@ -123,7 +124,7 @@ exports[`TestSectionComponent should create 1`] = `
       </dt>
       <dd
         class="govuk-summary-list__value"
-        id="test-testEndTimestamp"
+        id="test-testTypeEndDate"
       >
         
         <span>
@@ -141,7 +142,7 @@ exports[`TestSectionComponent should create 1`] = `
       </dt>
       <dd
         class="govuk-summary-list__value"
-        id="test-testTypeStartTimestamp"
+        id="test-testTypeStartTime"
       >
         
         <span>
@@ -159,7 +160,7 @@ exports[`TestSectionComponent should create 1`] = `
       </dt>
       <dd
         class="govuk-summary-list__value border--bottom-none"
-        id="test-testTypeEndTimestamp"
+        id="test-testTypeEndTime"
       >
         
         <span>

--- a/src/app/test-record/test-section/edit/__snapshots__/test-section-edit.component.spec.ts.snap
+++ b/src/app/test-record/test-section/edit/__snapshots__/test-section-edit.component.spec.ts.snap
@@ -4,14 +4,15 @@ exports[`TestSectionEditComponent should create 1`] = `
 <vtm-test-section-edit
   dialog={[Function MatDialog]}
   isAbandoned="false"
-  prohibitionOptionSelected={[Function String]}
-  prohibitionOptions={[Function Array]}
+  prohibitionOptions={[Function Object]}
   reasonsForAbandoning={[Function Array]}
   reasonsForAbandoningOptions={[Function Array]}
   resultOptions={[Function Array]}
   router={[Function Router]}
+  selectedOptions={[Function Array]}
   testRecord={[Function Object]}
   testRecordMapper={[Function TestRecordMapper]}
+  testResult={[Function EventEmitter]}
   testResultChildForm={[Function FormGroupDirective]}
   testResultSubscription={[Function Subscriber]}
   testType={[Function Object]}
@@ -61,24 +62,6 @@ exports[`TestSectionEditComponent should create 1`] = `
         id="test-testCode"
       >
          - 
-      </dd>
-      <dd
-        class="govuk-summary-list__value"
-      />
-    </div>
-    <div
-      class="govuk-summary-list__row"
-    >
-      <dt
-        class="govuk-summary-list__key"
-      >
-         Test number 
-      </dt>
-      <dd
-        class="govuk-summary-list__value"
-        id="test-testNumber"
-      >
-         123123 
       </dd>
       <dd
         class="govuk-summary-list__value"
@@ -182,118 +165,55 @@ exports[`TestSectionEditComponent should create 1`] = `
     </div>
     
     
-    
-    
-    <div
-      class="govuk-grid-row govuk-!-margin-bottom-3"
+    <dl
+      class="govuk-summary-list"
     >
       <div
-        class="govuk-grid-column-three-quarters"
+        class="govuk-summary-list__row"
       >
-        <label
-          class="govuk-label govuk-!-font-weight-bold"
+        <dt
+          class="govuk-summary-list__key"
+        >
+           Test number 
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+          id="test-testNumber"
+        >
+           123123 
+        </dd>
+        <dd
+          class="govuk-summary-list__value"
+        />
+      </div>
+    </dl>
+    
+    
+    <dl
+      class="govuk-summary-list"
+    >
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
         >
            Test date 
-        </label>
-        <vtm-date-input
-          ariadescribedby="testTypeEndTimestampDate"
-          class="ng-untouched ng-pristine ng-valid"
-          formcontrolname="testTypeEndTimestampDate"
-          ng-reflect-id="test-testTypeEndTimestampDate"
-          ng-reflect-name="testTypeEndTimestampDate"
-          ngdefaultcontrol=""
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+          id="test-testTypeEndDate"
         >
           
-          <div
-            class="govuk-date-input"
-          >
-            <div
-              class="govuk-date-input__item"
-            >
-              <div
-                class="govuk-form-group"
-              >
-                <label
-                  class="govuk-label govuk-date-input__label"
-                  for="test-testTypeEndTimestampDate-1-day"
-                >
-                   Day 
-                </label>
-                <input
-                  autocomplete="off"
-                  class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-invalid"
-                  formcontrolname="day"
-                  id="test-testTypeEndTimestampDate-1-day"
-                  maxlength="2"
-                  name="dateDay"
-                  ng-reflect-maxlength="2"
-                  ng-reflect-name="day"
-                  ng-reflect-pattern="[0-9]*"
-                  pattern="[0-9]*"
-                  type="number"
-                />
-              </div>
-            </div>
-            <div
-              class="govuk-date-input__item"
-            >
-              <div
-                class="govuk-form-group"
-              >
-                <label
-                  class="govuk-label govuk-date-input__label"
-                  for="test-testTypeEndTimestampDate-1-month"
-                >
-                   Month 
-                </label>
-                <input
-                  autocomplete="off"
-                  class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
-                  formcontrolname="month"
-                  id="test-testTypeEndTimestampDate-1-month"
-                  maxlength="2"
-                  name="dateMonth"
-                  ng-reflect-maxlength="2"
-                  ng-reflect-name="month"
-                  ng-reflect-pattern="[0-9]*"
-                  pattern="[0-9]*"
-                  type="number"
-                />
-              </div>
-            </div>
-            <div
-              class="govuk-date-input__item"
-            >
-              <div
-                class="govuk-form-group"
-              >
-                <label
-                  class="govuk-label govuk-date-input__label"
-                  for="test-testTypeEndTimestampDate-1-year"
-                >
-                   Year 
-                </label>
-                <input
-                  autocomplete="off"
-                  class="govuk-input govuk-date-input__input govuk-input--width-4 ng-untouched ng-pristine ng-invalid"
-                  formcontrolname="year"
-                  id="test-testTypeEndTimestampDate-1-year"
-                  maxlength="4"
-                  minlength="4"
-                  name="dateYear"
-                  ng-reflect-maxlength="4"
-                  ng-reflect-minlength="4"
-                  ng-reflect-name="year"
-                  ng-reflect-pattern="[0-9]*"
-                  pattern="[0-9]*"
-                  type="number"
-                />
-              </div>
-            </div>
-          </div>
-        </vtm-date-input>
+          <span>
+             16/01/2020 
+          </span>
+        </dd>
+        <dd
+          class="govuk-summary-list__value"
+        />
       </div>
-    </div>
+    </dl>
     <div
       class="govuk-grid-row govuk-!-margin-bottom-3"
     >
@@ -309,7 +229,7 @@ exports[`TestSectionEditComponent should create 1`] = `
           ariadescribedby="testTypeStartTimestamp"
           class="ng-untouched ng-pristine ng-valid"
           formcontrolname="testTypeStartTimestamp"
-          id="test-testTypeStartTimestamp"
+          id="test-testTypeStartTime"
           ng-reflect-name="testTypeStartTimestamp"
           ngdefaultcontrol=""
         />
@@ -330,7 +250,7 @@ exports[`TestSectionEditComponent should create 1`] = `
           ariadescribedby="testTypeEndTimestampTime"
           class="ng-untouched ng-pristine ng-valid"
           formcontrolname="testTypeEndTimestampTime"
-          id="test-testTypeEndTimestampTime"
+          id="test-testTypeEndTime"
           ng-reflect-name="testTypeEndTimestampTime"
           ngdefaultcontrol=""
         />

--- a/src/app/test-record/test-section/edit/test-section-edit.component.html
+++ b/src/app/test-record/test-section/edit/test-section-edit.component.html
@@ -25,15 +25,6 @@
     </dd>
     <dd class="govuk-summary-list__value"></dd>
   </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Test number
-    </dt>
-    <dd class="govuk-summary-list__value" id="test-testNumber">
-      {{ testType.testNumber | DefaultNullOrEmpty }}
-    </dd>
-    <dd class="govuk-summary-list__value"></dd>
-  </div>
 </dl>
 
 <form formGroupName="testType">
@@ -136,6 +127,18 @@
     </div>
   </div>
 
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Test number
+      </dt>
+      <dd class="govuk-summary-list__value" id="test-testNumber">
+        {{ testType.testNumber | DefaultNullOrEmpty }}
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
+    </div>
+  </dl>
+
   <div
     *ngIf="testTypesApplicable.expiryDateApplicable[testType.testTypeId]"
     class="govuk-grid-row govuk-!-margin-bottom-3"
@@ -172,20 +175,19 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row govuk-!-margin-bottom-3">
-    <div class="govuk-grid-column-three-quarters">
-      <label class="govuk-label govuk-!-font-weight-bold">
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
         Test date
-      </label>
-      <vtm-date-input
-        id="test-testTypeEndTimestampDate"
-        ariaDescribedBy="testTypeEndTimestampDate"
-        formControlName="testTypeEndTimestampDate"
-        ngDefaultControl
-      >
-      </vtm-date-input>
+      </dt>
+      <dd class="govuk-summary-list__value" id="test-testTypeEndDate">
+        <span *ngIf="testType.testTypeEndTimestamp; else hyphen">
+          {{ testType.testTypeEndTimestamp | date: 'dd/MM/yyyy' }}
+        </span>
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
     </div>
-  </div>
+  </dl>
 
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
     <div class="govuk-grid-column-three-quarters">
@@ -193,7 +195,7 @@
         Start time
       </label>
       <vtm-time-input
-        id="test-testTypeStartTimestamp"
+        id="test-testTypeStartTime"
         ariaDescribedBy="testTypeStartTimestamp"
         formControlName="testTypeStartTimestamp"
         ngDefaultControl
@@ -208,7 +210,7 @@
         End time
       </label>
       <vtm-time-input
-        id="test-testTypeEndTimestampTime"
+        id="test-testTypeEndTime"
         ariaDescribedBy="testTypeEndTimestampTime"
         formControlName="testTypeEndTimestampTime"
         ngDefaultControl
@@ -226,20 +228,27 @@
         Prohibition Issued
       </label>
       <div class="govuk-radios">
-        <div class="govuk-radios__item" *ngFor="let option of prohibitionOptions">
+        <div
+          class="govuk-radios__item"
+          *ngFor="let option of prohibitionOptions | keyvalue; let i = index"
+        >
           <input
             class="govuk-radios__input"
-            id="test-prohibitionIssued-{{ option.id }}"
+            id="test-prohibitionIssued-{{ i }}"
             formControlName="prohibitionIssued"
             type="radio"
-            value="{{ option.selected }}"
-            [checked]="option.selected"
+            value="{{ option.value }}"
+            [checked]="testType.prohibitionIssued === option.value"
           />
           <label class="govuk-label govuk-radios__label">
-            {{ option.name }}
+            {{ option.key }}
           </label>
         </div>
       </div>
     </div>
   </div>
 </form>
+
+<ng-template #hyphen>
+  <span>-</span>
+</ng-template>

--- a/src/app/test-record/test-section/edit/test-section-edit.component.spec.ts
+++ b/src/app/test-record/test-section/edit/test-section-edit.component.spec.ts
@@ -37,8 +37,8 @@ describe('TestSectionEditComponent', () => {
     component.testRecord = TEST_MODEL_UTILS.mockTestRecord();
     component.testType = TEST_MODEL_UTILS.mockTestType({
       testResult: 'pass',
-      testTypeStartTimestamp: '22-11-2019',
-      testTypeEndTimestamp: '22-11-2019'
+      testTypeStartTimestamp: '2020-01-16T12:24:38.027Z',
+      reasonForAbandoning: 'test'
     });
     component.testTypesApplicable = TEST_TYPE_APPLICABLE_UTILS.mockTestTypesApplicable();
   });
@@ -52,7 +52,10 @@ describe('TestSectionEditComponent', () => {
   });
 
   it('should update isAbandoned based on test result value', () => {
-    component.testType = TEST_MODEL_UTILS.mockTestType({ testResult: 'abandoned' });
+    component.testType = TEST_MODEL_UTILS.mockTestType({
+      testResult: 'abandoned',
+      reasonForAbandoning: 'test'
+    });
     fixture.detectChanges();
     expect(component.isAbandoned).toEqual(true);
   });

--- a/src/app/test-record/test-section/test-section.component.html
+++ b/src/app/test-record/test-section/test-section.component.html
@@ -12,7 +12,7 @@
       Test code
     </dt>
     <dd class="govuk-summary-list__value" id="test-testCode">
-      {{ testType.testCode | DefaultNullOrEmpty | CapitalizeString }}
+      {{ testType.testCode | DefaultNullOrEmpty }}
     </dd>
   </div>
   <div class="govuk-summary-list__row">
@@ -20,7 +20,7 @@
       Result
     </dt>
     <dd class="govuk-summary-list__value" id="test-testResult">
-      {{ testType.testResult | DefaultNullOrEmpty | CapitalizeString }}
+      {{ testResultVal | DefaultNullOrEmpty }}
     </dd>
   </div>
   <div class="govuk-summary-list__row">
@@ -28,7 +28,7 @@
       Reason for abandoning
     </dt>
     <dd class="govuk-summary-list__value" id="test-reasonForAbandoning">
-      {{ testType.reasonForAbandoning | DefaultNullOrEmpty | CapitalizeString }}
+      {{ testType.reasonForAbandoning | DefaultNullOrEmpty }}
     </dd>
   </div>
   <div class="govuk-summary-list__row">
@@ -105,7 +105,7 @@
     <dt class="govuk-summary-list__key">
       Test date
     </dt>
-    <dd class="govuk-summary-list__value" id="test-testEndTimestamp">
+    <dd class="govuk-summary-list__value" id="test-testTypeEndDate">
       <span *ngIf="testType.testTypeEndTimestamp; else hyphen">
         {{ testType.testTypeEndTimestamp | date: 'dd/MM/yyyy' }}
       </span>
@@ -115,7 +115,7 @@
     <dt class="govuk-summary-list__key">
       Start time
     </dt>
-    <dd class="govuk-summary-list__value" id="test-testTypeStartTimestamp">
+    <dd class="govuk-summary-list__value" id="test-testTypeStartTime">
       <span *ngIf="testType.testTypeStartTimestamp; else hyphen">
         {{ testType.testTypeStartTimestamp | date: 'shortTime':'UTC' }}
       </span>
@@ -137,7 +137,7 @@
         !testTypesApplicable.defectsApplicable[testType.testTypeId] &&
         !testTypesApplicable.specialistTestApplicable[testType.testTypeId]
       "
-      id="test-testTypeEndTimestamp"
+      id="test-testTypeEndTime"
     >
       <span *ngIf="testType.testTypeEndTimestamp; else hyphen">
         {{ testType.testTypeEndTimestamp | date: 'shortTime':'UTC' }}
@@ -156,7 +156,7 @@
         Prohibition issued
       </dt>
       <dd class="govuk-summary-list__value border--bottom-none" id="test-prohibitionIssued">
-        {{ testType.prohibitionIssued | DefaultNullOrEmpty }}
+        {{ prohibitionIssue | DefaultNullOrEmpty }}
       </dd>
     </div>
   </ng-container>
@@ -170,5 +170,6 @@
     [testRecord]="testRecord"
     [testType]="testType"
     [testTypesApplicable]="testTypesApplicable"
+    (testResult)="testResultHandler($event)"
   ></vtm-test-section-edit>
 </ng-container>

--- a/src/app/test-record/test-section/test-section.component.spec.ts
+++ b/src/app/test-record/test-section/test-section.component.spec.ts
@@ -1,15 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { TestSectionComponent } from './test-section.component';
 import { SharedModule } from '@app/shared/shared.module';
-import { TestType } from '@app/models/test.type';
-import { TestResultModel } from '@app/models/test-result.model';
-import { RouterTestingModule } from '@angular/router/testing';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TEST_MODEL_UTILS } from '@app/utils/test-model.utils';
 import { TEST_TYPE_APPLICABLE_UTILS } from '@app/utils/test-type-applicable-models.utils';
-
-
 
 describe('TestSectionComponent', () => {
   let component: TestSectionComponent;
@@ -26,7 +21,7 @@ describe('TestSectionComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TestSectionComponent);
     component = fixture.componentInstance;
-    component.testType = TEST_MODEL_UTILS.mockTestType();
+    component.testType = TEST_MODEL_UTILS.mockTestType({ testResult: 'prs' });
     component.testRecord = TEST_MODEL_UTILS.mockTestRecord();
     component.testTypesApplicable = TEST_TYPE_APPLICABLE_UTILS.mockTestTypesApplicable();
     fixture.detectChanges();

--- a/src/app/test-record/test-section/test-section.component.ts
+++ b/src/app/test-record/test-section/test-section.component.ts
@@ -1,20 +1,32 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges
+} from '@angular/core';
 import { TestType } from '@app/models/test.type';
 import { TestResultModel } from '@app/models/test-result.model';
 import { TestTypesApplicable } from '@app/test-record/test-record.mapper';
 import { VIEW_STATE } from '@app/app.enums';
+import { CapitalizeString } from '@app/pipes/capitalize-string';
 
 @Component({
   selector: 'vtm-test-section',
   templateUrl: './test-section.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TestSectionComponent implements OnInit {
+export class TestSectionComponent implements OnInit, OnChanges {
   @Input() testType: TestType;
   @Input() testRecord: TestResultModel;
   @Input() testTypesApplicable: TestTypesApplicable;
   @Input() editState: VIEW_STATE;
+  @Output() testResult = new EventEmitter<string>();
 
+  testResultVal: string;
+  prohibitionIssue: string;
   hasCertificateNumber: boolean;
 
   constructor() {}
@@ -24,5 +36,16 @@ export class TestSectionComponent implements OnInit {
       this.testTypesApplicable.certificateApplicable[this.testType.testTypeId] ||
       (this.testTypesApplicable.specialistCertificateApplicable[this.testType.testTypeId] &&
         this.testType.testResult === 'pass');
+  }
+  ngOnChanges() {
+    this.testResultVal =
+      this.testType.testResult === 'prs'
+        ? this.testType.testResult.toUpperCase()
+        : new CapitalizeString().transform(this.testType.testResult);
+    this.prohibitionIssue = this.testType.prohibitionIssued ? 'Yes' : 'No';
+  }
+
+  testResultHandler(tResult: string) {
+    this.testResult.emit(tResult);
   }
 }


### PR DESCRIPTION
## fixes(feature/cvsb-12375): bugfixing & clarifications on test section from test record edit
Bugs fixed in here:

- [x] https://jira.dvsacloud.uk/browse/CVSB-16724 
- [x] https://jira.dvsacloud.uk/browse/CVSB-16851
- [x] https://jira.dvsacloud.uk/browse/CVSB-16850

New clarifications from BA & PO:
- test result display (view mode) will be consistent with the radios label format (edit mode) – this was for PRS
- the order of the fields in the edit will be consistent with the order in the view (both editable & non editable fields)
- test date will not be editable & will be displayed as the other non editable fields (i.e. test code)
- each reason for abandoning will be displayed on new line in view mode (not split by comma)
- PRS option to be removed from LEC test types

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
