### PR TITLE
fix(cvsb-10184): handle header for low page width --- [dep fix(cvsb-17179)]

### DIFF
--- a/src/app/directives/form-connector/form-connector.directive.ts
+++ b/src/app/directives/form-connector/form-connector.directive.ts
@@ -1,11 +1,9 @@
 import { Directive, Input, OnInit, OnDestroy } from '@angular/core';
 import { FormGroupDirective, FormGroup } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { debounceTime, withLatestFrom, tap } from 'rxjs/operators';
+import { debounceTime, tap } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { IAppState } from '@app/store/state/app.state';
-import { SetAppFormDirty } from '@app/store/actions/app-form-state.actions';
-import { getAppFormState } from '../../store/selectors/app-form-state.selectors';
 
 @Directive({
   selector: '[vtmFormConnector]'
@@ -13,8 +11,6 @@ import { getAppFormState } from '../../store/selectors/app-form-state.selectors'
 export class FormConnectorDirective implements OnInit, OnDestroy {
   @Input('vtmFormConnector') path: string;
   @Input() debounce = 400;
-  // @Output() error = new EventEmitter();
-  // @Output() success = new EventEmitter();
 
   formChange: Subscription;
   formSuccess: Subscription;
@@ -26,13 +22,9 @@ export class FormConnectorDirective implements OnInit, OnDestroy {
     this.formChange = this.formGroupDirective.form.valueChanges
       .pipe(
         debounceTime(this.debounce),
-        withLatestFrom(this.store.select(getAppFormState)),
-        tap(([formValue, appForm]: [FormGroup, boolean]) => {
+        tap(([formValue]: [FormGroup]) => {
           // TODO: to be removed
           console.log('VALUE: ', formValue, 'PATH: ', this.path);
-          if (!this.formGroupDirective.form.pristine && appForm) {
-            this.store.dispatch(new SetAppFormDirty());
-          }
         })
       )
       .subscribe();

--- a/src/app/modal/components/lose-changes/__snapshots__/lose-changes.component.spec.ts.snap
+++ b/src/app/modal/components/lose-changes/__snapshots__/lose-changes.component.spec.ts.snap
@@ -19,13 +19,13 @@ exports[`LoseChangesComponent should create lose changes modal component 1`] = `
        If you leave this page, your changes will be lost. 
     </span>
   </div><button
-    cdkfocusinitial=""
     class="govuk-button"
     data-module="govuk-button"
     id="test-lose-changes"
   >
      Leave and lose changes 
   </button><a
+    cdkfocusinitial=""
     class="cancel"
     id="test-cancel"
   >

--- a/src/app/modal/components/lose-changes/lose-changes.component.html
+++ b/src/app/modal/components/lose-changes/lose-changes.component.html
@@ -5,10 +5,10 @@
     </span>
   </div>
 
-  <button id="test-lose-changes" class="govuk-button" data-module="govuk-button" (click)="onLoseChangesClick()" cdkFocusInitial>
+  <button id="test-lose-changes" class="govuk-button" data-module="govuk-button" (click)="onLoseChangesClick()">
     Leave and lose changes
   </button>
 
-  <a  id= "test-cancel" class="cancel" (click)="onCancelClick()">
+  <a  id= "test-cancel" class="cancel" (click)="onCancelClick()" cdkFocusInitial>
     <span>Continue changing record</span>
   </a>

--- a/src/app/shell/header/header.component.html
+++ b/src/app/shell/header/header.component.html
@@ -1,5 +1,12 @@
 <header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="topnav govuk-header__container govuk-width-container">
+    <a
+      [routerLink]="['/']"
+      id="test-header-nav-item"
+      class="govuk-header__link govuk-header__link--homepage"
+    >
+      <span>Vehicle testing management</span>
+    </a>
     <div id="menuLinks" [ngStyle]="{ display: menuOpen ? 'block' : 'none' }">
       <a href="javascript:void(0)">{{ userName }}</a>
       <a (click)="logOut()">Sign out</a>

--- a/src/app/store/effects/app-form.effects.spec.ts
+++ b/src/app/store/effects/app-form.effects.spec.ts
@@ -8,8 +8,9 @@ import { SetViewState } from '../actions/VehicleTechRecordModel.actions';
 import { VIEW_STATE } from '@app/app.enums';
 
 import { AppFormEffects } from './app-form.effects';
-import { SetAppFormPristine } from '../actions/app-form-state.actions';
+import { SetAppFormPristine, SetAppFormDirty } from '../actions/app-form-state.actions';
 import { ClearErrorMessage } from '../actions/Error.actions';
+import { SetTestViewState } from '../actions/VehicleTestResultModel.actions';
 
 describe('AppFormEffects', () => {
   let effects: AppFormEffects;
@@ -29,8 +30,8 @@ describe('AppFormEffects', () => {
     expect(effects).toBeTruthy();
   });
 
-  describe('setAppFormPristine$', () => {
-    it('should dispatch SetAppFormPristine action if view state is set to view only', () => {
+  describe('setTechFormPristine$', () => {
+    it('should dispatch SetAppFormPristine and ClearErrorMessage action if view state is set to view only', () => {
       action = new SetViewState(VIEW_STATE.VIEW_ONLY);
       actions$ = hot('-a--', { a: action });
 
@@ -39,7 +40,7 @@ describe('AppFormEffects', () => {
 
       const expected$ = cold('-(bc)', { b: appFormPristine, c: clearErrorMessage });
 
-      expect(effects.setAppFormPristine$).toBeObservable(expected$);
+      expect(effects.setTechFormPristine$).toBeObservable(expected$);
     });
 
     it('should return an empty stream if view state is set to edit', () => {
@@ -48,7 +49,74 @@ describe('AppFormEffects', () => {
 
       const expected$ = cold('--');
 
-      expect(effects.setAppFormPristine$).toBeObservable(expected$);
+      expect(effects.setTechFormPristine$).toBeObservable(expected$);
+    });
+  });
+
+  describe('setTechFormDirty$', () => {
+    it('should dispatch setAppFormDirty action if view state is set to edit or create', () => {
+      action = new SetViewState(VIEW_STATE.EDIT);
+      actions$ = hot('-a--', { a: action });
+
+      const appFormDirty = new SetAppFormDirty();
+
+      const expected$ = cold('-(b)', { b: appFormDirty });
+
+      expect(effects.setTechFormDirty$).toBeObservable(expected$);
+    });
+
+    it('should return an empty stream if view state is set to view only', () => {
+      action = new SetViewState(VIEW_STATE.VIEW_ONLY);
+      actions$ = hot('-a--', { a: action });
+
+      const expected$ = cold('--');
+
+      expect(effects.setTechFormDirty$).toBeObservable(expected$);
+    });
+  });
+
+  describe('setTestFormPristine$', () => {
+    it('should dispatch SetAppFormPristine and ClearErrorMessage action if test view state is set to view only', () => {
+      action = new SetTestViewState(VIEW_STATE.VIEW_ONLY);
+      actions$ = hot('-a--', { a: action });
+
+      const appFormPristine = new SetAppFormPristine();
+      const clearErrorMessage = new ClearErrorMessage();
+
+      const expected$ = cold('-(bc)', { b: appFormPristine, c: clearErrorMessage });
+
+      expect(effects.setTestFormPristine$).toBeObservable(expected$);
+    });
+
+    it('should return an empty stream if view state is set to edit', () => {
+      action = new SetTestViewState(VIEW_STATE.EDIT);
+      actions$ = hot('-a--', { a: action });
+
+      const expected$ = cold('--');
+
+      expect(effects.setTestFormPristine$).toBeObservable(expected$);
+    });
+  });
+
+  describe('setTestFormDirty$', () => {
+    it('should dispatch setAppFormDirty action if view state is set to edit or create', () => {
+      action = new SetTestViewState(VIEW_STATE.EDIT);
+      actions$ = hot('-a--', { a: action });
+
+      const appFormDirty = new SetAppFormDirty();
+
+      const expected$ = cold('-(b)', { b: appFormDirty });
+
+      expect(effects.setTestFormDirty$).toBeObservable(expected$);
+    });
+
+    it('should return an empty stream if view state is set to view only', () => {
+      action = new SetTestViewState(VIEW_STATE.VIEW_ONLY);
+      actions$ = hot('-a--', { a: action });
+
+      const expected$ = cold('--');
+
+      expect(effects.setTestFormDirty$).toBeObservable(expected$);
     });
   });
 });

--- a/src/app/store/effects/app-form.effects.ts
+++ b/src/app/store/effects/app-form.effects.ts
@@ -2,20 +2,21 @@ import { Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
 import { Effect, Actions, ofType } from '@ngrx/effects';
 import { Observable } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import { filter, switchMap, tap, map } from 'rxjs/operators';
 
 import {
   SetViewState,
   EVehicleTechRecordActions
 } from '../actions/VehicleTechRecordModel.actions';
-import { SetAppFormPristine } from '../actions/app-form-state.actions';
+import { SetAppFormPristine, SetAppFormDirty } from '../actions/app-form-state.actions';
 import { VIEW_STATE } from '@app/app.enums';
 import { ClearErrorMessage } from '../actions/Error.actions';
+import { SetTestViewState, EVehicleTestResultModelActions } from '../actions/VehicleTestResultModel.actions';
 
 @Injectable()
 export class AppFormEffects {
   @Effect()
-  setAppFormPristine$: Observable<Action> = this.actions$.pipe(
+  setTechFormPristine$: Observable<Action> = this.actions$.pipe(
     ofType<SetViewState>(EVehicleTechRecordActions.SetViewState),
     filter((action: SetViewState): boolean => action.viewState === VIEW_STATE.VIEW_ONLY),
     switchMap(() => {
@@ -24,6 +25,33 @@ export class AppFormEffects {
       actions.push(new ClearErrorMessage());
       return actions;
     })
+  );
+
+  @Effect()
+  setTechFormDirty$: Observable<Action> = this.actions$.pipe(
+    ofType<SetViewState>(EVehicleTechRecordActions.SetViewState),
+    filter((action: SetViewState): boolean => action.viewState !== VIEW_STATE.VIEW_ONLY),
+    map(() => new SetAppFormDirty())
+  );
+
+
+  @Effect()
+  setTestFormPristine$: Observable<Action> = this.actions$.pipe(
+    ofType<SetTestViewState>(EVehicleTestResultModelActions.SetTestViewState),
+    filter((action: SetTestViewState): boolean => action.editState === VIEW_STATE.VIEW_ONLY),
+    switchMap(() => {
+      const actions = [];
+      actions.push(new SetAppFormPristine());
+      actions.push(new ClearErrorMessage());
+      return actions;
+    })
+  );
+
+  @Effect()
+  setTestFormDirty$: Observable<Action> = this.actions$.pipe(
+    ofType<SetTestViewState>(EVehicleTestResultModelActions.SetTestViewState),
+    filter((action: SetTestViewState): boolean => action.editState !== VIEW_STATE.VIEW_ONLY),
+    map(() => new SetAppFormDirty())
   );
 
   constructor(private actions$: Actions) {}

--- a/src/app/technical-record/record-status/record-status.component.ts
+++ b/src/app/technical-record/record-status/record-status.component.ts
@@ -20,6 +20,7 @@ import { PANEL_TITLE } from '@app/app.enums';
 export class RecordStatusComponent implements OnChanges {
   @Input() activeRecord: TechRecord;
   @Input() editState: boolean;
+  // tslint:disable-next-line: no-output-on-prefix TODO: need to fix this
   @Output() onScrollToSection = new EventEmitter<Object>();
 
   titleOfTechHistory: string = PANEL_TITLE.TECHNICAL_RECORD_HISTORY;

--- a/src/app/technical-record/tech-rec-history/tech-rec-history.component.ts
+++ b/src/app/technical-record/tech-rec-history/tech-rec-history.component.ts
@@ -19,12 +19,14 @@ import { TechRecord } from '@app/models/tech-record.model';
 export class TechRecHistoryComponent implements OnInit {
   @Input() vehicleRecord: VehicleTechRecordModel;
   @Input() focusedRecord: TechRecord;
+  // tslint:disable-next-line: no-output-on-prefix TODO: need to fix this
   @Output() onViewRecord = new EventEmitter<TechRecord>();
 
   techRecords: TechRecord[];
 
   constructor() {}
 
+  // tslint:disable-next-line: use-life-cycle-interface TODO: Need to remove this
   ngOnChanges(changes: SimpleChanges): void {
     const { focusedRecord, vehicleRecord } = changes;
     if (focusedRecord && vehicleRecord) {

--- a/src/app/technical-record/technical-record.component.html
+++ b/src/app/technical-record/technical-record.component.html
@@ -805,8 +805,7 @@
                 </div>
               </mat-panel-description>
             </mat-expansion-panel-header>
-
-            <vtm-test-history [testResultJson]="testResultJson"></vtm-test-history>
+            <vtm-test-history [testResultJson]="testResultJson" (viewTestRecord)="viewTestRecordHandler()"></vtm-test-history>
           </mat-expansion-panel>
         </div>
       </ng-container>

--- a/src/app/technical-record/technical-record.component.ts
+++ b/src/app/technical-record/technical-record.component.ts
@@ -42,6 +42,7 @@ export class TechnicalRecordComponent implements OnChanges, OnInit {
   @Output() submitVehicleRecord = new EventEmitter<VehicleTechRecordEditState>();
   @Output() changeViewState = new EventEmitter<VIEW_STATE>();
   @Output() sendPlates = new EventEmitter<VehicleTechRecordEdit>();
+  @Output() viewTestRecord = new EventEmitter<void>();
 
   showAdrDetails: boolean;
   adrDisplayParams: { [key: string]: boolean };
@@ -225,5 +226,9 @@ export class TechnicalRecordComponent implements OnChanges, OnInit {
         this.sendPlates.emit(vehicleRecord);
       }
     });
+  }
+
+  viewTestRecordHandler(): void {
+    this.viewTestRecord.emit();
   }
 }

--- a/src/app/technical-record/technical-record.container.ts
+++ b/src/app/technical-record/technical-record.container.ts
@@ -24,6 +24,7 @@ import {
 } from '@app/models/vehicle-tech-record.model';
 import { TestResultModel } from '@app/models/test-result.model';
 import { VIEW_STATE } from '@app/app.enums';
+import { SetTestViewState } from '@app/store/actions/VehicleTestResultModel.actions';
 
 @Component({
   selector: 'vtm-technical-record-container',
@@ -42,6 +43,7 @@ import { VIEW_STATE } from '@app/app.enums';
             (submitVehicleRecord)="vehicleRecordSubmissionHandler($event)"
             (changeViewState)="viewStateHandler($event)"
             (sendPlates)="sendPlatesHandler($event)"
+            (viewTestRecord)="viewTestRecordHandler()"
           >
           </vtm-technical-record>
         </main>
@@ -83,5 +85,9 @@ export class TechnicalRecordsContainer implements OnInit {
 
   sendPlatesHandler(editedVehicleRecord: VehicleTechRecordEdit) {
     this.store.dispatch(new UpdateVehicleTechRecord(editedVehicleRecord));
+  }
+
+  viewTestRecordHandler(): void {
+    this.store.dispatch(new SetTestViewState(VIEW_STATE.VIEW_ONLY));
   }
 }

--- a/src/app/technical-record/test-history/__snapshots__/test-history.component.spec.ts.snap
+++ b/src/app/technical-record/test-history/__snapshots__/test-history.component.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`TestHistoryComponent should create view only with populated data 1`] = `
 <vtm-test-history
   testResultJson={[Function Array]}
+  viewTestRecord={[Function EventEmitter]}
 >
   <table
     class="govuk-table govuk-!-margin-bottom-0"

--- a/src/app/technical-record/test-history/test-history.component.html
+++ b/src/app/technical-record/test-history/test-history.component.html
@@ -66,7 +66,7 @@
               testResultId: testRes.testResultId,
               systemNumber: testRes.systemNumber
             }"
-            >View</a
+            (click)="viewTest()" >View</a
           >
         </td>
       </tr>

--- a/src/app/technical-record/test-history/test-history.component.ts
+++ b/src/app/technical-record/test-history/test-history.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, Input, EventEmitter, Output } from '@angular/core';
 import { TestResultModel } from '@app/models/test-result.model';
 
 @Component({
@@ -8,8 +8,12 @@ import { TestResultModel } from '@app/models/test-result.model';
 })
 export class TestHistoryComponent implements OnInit {
   @Input() testResultJson: TestResultModel[];
-
+  @Output() viewTestRecord = new EventEmitter<void>();
   constructor() {}
 
   ngOnInit() {}
+
+  viewTest() {
+    this.viewTestRecord.emit();
+  }
 }

--- a/src/app/test-record/test-record.component.ts
+++ b/src/app/test-record/test-record.component.ts
@@ -62,7 +62,7 @@ export class TestRecordComponent implements OnInit {
     );
 
     initAll();
-    this.switchState.emit(VIEW_STATE.VIEW_ONLY);
+
     this.testResultParentForm = new FormGroup({ testType: new FormGroup({}) });
   }
 


### PR DESCRIPTION
## Header bug fix and modification in AppFormDirty.
Header bug is fixed to render properly on smaller screen size. FormConnector is not used for triggering AppFormDirty. Instead ViewState is used.
Bug fix for back button behavior when test record is in edit mode.
[https://jira.dvsacloud.uk/browse/CVSB-10184]()
https://jira.dvsacloud.uk/browse/CVSB-17156

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
