### PR TITLE
Feature/cvsb 10172-16938 - add mode to Create/Edit for Manufacturer 

### DIFF
--- a/src/app/technical-record/manufacturer/__snapshots__/manufacturer.component.spec.ts.snap
+++ b/src/app/technical-record/manufacturer/__snapshots__/manufacturer.component.spec.ts.snap
@@ -173,3 +173,25 @@ exports[`ManufacturerComponent should create view only with populated data 1`] =
   </dl>
 </vtm-manufacturer>
 `;
+
+exports[`ManufacturerComponent should render the edit components when editState is true 1`] = `
+<vtm-manufacturer
+  address1And2={[Function String]}
+  editState={[Function Boolean]}
+  manufacturer={[Function Object]}
+>
+  <dl
+    class="govuk-summary-list"
+  >
+    <div
+      class="govuk-summary-list__row"
+    >
+      <dt
+        class="govuk-summary-list__key"
+      >
+        <vtm-manufacturer-edit />
+      </dt>
+    </div>
+  </dl>
+</vtm-manufacturer>
+`;

--- a/src/app/technical-record/manufacturer/edit/__snapshots__/manufacturer-edit.component.spec.ts.snap
+++ b/src/app/technical-record/manufacturer/edit/__snapshots__/manufacturer-edit.component.spec.ts.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ManufacturerEditComponent component should render with the given properties  1`] = `
+<vtm-manufacturer-edit
+  fb={[Function FormBuilder]}
+  manufacturerEditDetails={[Function Object]}
+  parent={[Function FormGroupDirective]}
+  techRecordFg={[Function FormGroup]}
+>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      class="govuk-grid-column-three-quarters"
+    >
+      <div
+        class="govuk-form-group"
+      >
+        <fieldset
+          class="govuk-fieldset"
+        >
+          <form
+            class="ng-untouched ng-pristine ng-valid"
+            ng-reflect-form="[object Object]"
+            novalidate=""
+          >
+            
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-name--mf"
+              >
+                 Name 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="name"
+                id="test-edit-name--mf"
+                ng-reflect-name="name"
+                type="text"
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-address1--mf"
+              >
+                 Building and street 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="address1"
+                id="test-edit-address1--mf"
+                ng-reflect-name="address1"
+                type="text"
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-address2--mf"
+              />
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="address2"
+                id="test-edit-address2--mf"
+                ng-reflect-name="address2"
+                type="text"
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-postTown--mf"
+              >
+                 Town or city 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="postTown"
+                id="test-edit-postTown--mf"
+                ng-reflect-name="postTown"
+                type="text"
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-address3--mf"
+              >
+                 County (optional) 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="address3"
+                id="test-edit-address3--mf"
+                ng-reflect-name="address3"
+                type="text"
+                vtmnullvalue=""
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-postCode--mf"
+              >
+                 Postcode (optional) 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="postCode"
+                id="test-edit-postCode--mf"
+                ng-reflect-name="postCode"
+                type="text"
+                vtmnullvalue=""
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-telephoneNumber--mf"
+              >
+                 Telephone number (optional) 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="telephoneNumber"
+                id="test-edit-telephoneNumber--mf"
+                ng-reflect-name="telephoneNumber"
+                type="number"
+                vtmnullvalue=""
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-emailAddress--mf"
+              >
+                 Email address (optional) 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="emailAddress"
+                id="test-edit-emailAddress--mf"
+                ng-reflect-name="emailAddress"
+                type="email"
+                vtmnullvalue=""
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-faxNumber--mf"
+              >
+                 Fax number (optional) 
+              </label>
+              <input
+                class="govuk-input govuk-input--width-20 ng-untouched ng-pristine ng-valid"
+                formcontrolname="faxNumber"
+                id="test-edit-faxNumber--mf"
+                ng-reflect-name="faxNumber"
+                type="number"
+                vtmnullvalue=""
+              />
+            </div>
+            <div
+              class="govuk-form-group"
+            >
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-notes--mf"
+              >
+                 Manufacturer notes (optional) 
+              </label>
+              <fieldset
+                class="govuk-fieldset"
+              >
+                <textarea
+                  class="govuk-textarea ng-untouched ng-pristine ng-valid"
+                  formcontrolname="manufacturerNotes"
+                  id="test-edit-notes--mf"
+                  ng-reflect-name="manufacturerNotes"
+                  rows="5"
+                  vtmnullvalue=""
+                />
+              </fieldset>
+            </div>
+          </form>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</vtm-manufacturer-edit>
+`;

--- a/src/app/technical-record/manufacturer/edit/manufacturer-edit.component.html
+++ b/src/app/technical-record/manufacturer/edit/manufacturer-edit.component.html
@@ -1,0 +1,144 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <form [formGroup]="techRecordFg">
+          <ng-container class="govuk-form-group" [formGroup]="manufacturerDetails">
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-name--mf">
+                Name
+              </label>
+              <input
+                id="test-edit-name--mf"
+                formControlName="name"
+                type="text"
+                class="govuk-input govuk-input--width-20"
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-address1--mf">
+                Building and street
+              </label>
+              <input
+                id="test-edit-address1--mf"
+                type="text"
+                formControlName="address1"
+                class="govuk-input govuk-input--width-20"
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-address2--mf">
+              </label>
+              <input
+                id="test-edit-address2--mf"
+                type="text"
+                formControlName="address2"
+                class="govuk-input govuk-input--width-20"
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-postTown--mf">
+                Town or city
+              </label>
+              <input
+                id="test-edit-postTown--mf"
+                type="text"
+                formControlName="postTown"
+                class="govuk-input govuk-input--width-20"
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-address3--mf">
+                County (optional)
+              </label>
+              <input
+                id="test-edit-address3--mf"
+                type="text"
+                formControlName="address3"
+                class="govuk-input govuk-input--width-20"
+                vtmNullValue
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-postCode--mf">
+                Postcode (optional)
+              </label>
+              <input
+                id="test-edit-postCode--mf"
+                type="text"
+                formControlName="postCode"
+                class="govuk-input govuk-input--width-20"
+                vtmNullValue
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-telephoneNumber--mf"
+              >
+                Telephone number (optional)
+              </label>
+              <input
+                id="test-edit-telephoneNumber--mf"
+                type="number"
+                formControlName="telephoneNumber"
+                class="govuk-input govuk-input--width-20"
+                vtmNullValue
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label
+                class="govuk-label govuk-!-font-weight-bold"
+                for="test-edit-emailAddress--mf"
+              >
+                Email address (optional)
+              </label>
+              <input
+                id="test-edit-emailAddress--mf"
+                type="email"
+                formControlName="emailAddress"
+                class="govuk-input govuk-input--width-20"
+                vtmNullValue
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-faxNumber--mf">
+                Fax number (optional)
+              </label>
+              <input
+                id="test-edit-faxNumber--mf"
+                type="number"
+                formControlName="faxNumber"
+                class="govuk-input govuk-input--width-20"
+                vtmNullValue
+              />
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label govuk-!-font-weight-bold" for="test-edit-notes--mf">
+                Manufacturer notes (optional)
+              </label>
+              <fieldset class="govuk-fieldset">
+                <textarea
+                  class="govuk-textarea"
+                  id="test-edit-notes--mf"
+                  rows="5"
+                  formControlName="manufacturerNotes"
+                  vtmNullValue
+                ></textarea>
+              </fieldset>
+            </div>
+          </ng-container>
+        </form>
+      </fieldset>
+    </div>
+  </div>
+</div>

--- a/src/app/technical-record/manufacturer/edit/manufacturer-edit.component.spec.ts
+++ b/src/app/technical-record/manufacturer/edit/manufacturer-edit.component.spec.ts
@@ -1,0 +1,45 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormGroupDirective,
+  FormGroup,
+  AbstractControl
+} from '@angular/forms';
+
+import { ManufacturerEditComponent } from './manufacturer-edit.component';
+import { TESTING_UTILS } from '@app/utils';
+
+describe('ManufacturerEditComponent component', () => {
+  let component: ManufacturerEditComponent;
+  let fixture: ComponentFixture<ManufacturerEditComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, ReactiveFormsModule],
+      declarations: [ManufacturerEditComponent],
+      providers: [
+        FormGroupDirective,
+        {
+          provide: FormGroupDirective,
+          useValue: TESTING_UTILS.mockFormGroupDirective({
+            techRecord: new FormGroup({}) as AbstractControl
+          })
+        }
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ManufacturerEditComponent);
+    component = fixture.componentInstance;
+    component.manufacturerEditDetails = TESTING_UTILS.mockManufacturer();
+  });
+
+  it('should render with the given properties ', () => {
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+    expect(fixture).toMatchSnapshot();
+  });
+});

--- a/src/app/technical-record/manufacturer/edit/manufacturer-edit.component.ts
+++ b/src/app/technical-record/manufacturer/edit/manufacturer-edit.component.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
+import { FormGroup, ControlContainer, FormGroupDirective, FormBuilder } from '@angular/forms';
+
+import { ManufacturerDetails } from '@app/models/tech-record.model';
+
+@Component({
+  selector: 'vtm-manufacturer-edit',
+  templateUrl: './manufacturer-edit.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [
+    {
+      provide: ControlContainer,
+      useExisting: FormGroupDirective
+    }
+  ]
+})
+export class ManufacturerEditComponent implements OnInit {
+  @Input() manufacturerEditDetails: ManufacturerDetails;
+
+  techRecordFg: FormGroup;
+
+  constructor(private parent: FormGroupDirective, private fb: FormBuilder) {}
+
+  get manufacturerDetails() {
+    return this.techRecordFg.get('manufacturerDetails') as FormGroup;
+  }
+
+  ngOnInit() {
+    this.techRecordFg = this.parent.form.get('techRecord') as FormGroup;
+
+    const manufDetails: ManufacturerDetails = !!this.manufacturerEditDetails
+      ? this.manufacturerEditDetails
+      : ({} as ManufacturerDetails);
+
+    this.techRecordFg.addControl(
+      'manufacturerDetails',
+      this.fb.group({
+        name: this.fb.control(manufDetails.name),
+        address1: this.fb.control(manufDetails.address1),
+        address2: this.fb.control(manufDetails.address2),
+        postTown: this.fb.control(manufDetails.postTown),
+        address3: this.fb.control(manufDetails.address3),
+        postCode: this.fb.control(manufDetails.postCode),
+        telephoneNumber: this.fb.control(manufDetails.telephoneNumber),
+        emailAddress: this.fb.control(manufDetails.emailAddress),
+        faxNumber: this.fb.control(manufDetails.faxNumber),
+        manufacturerNotes: this.fb.control(manufDetails.manufacturerNotes)
+      })
+    );
+  }
+}

--- a/src/app/technical-record/manufacturer/manufacturer.component.html
+++ b/src/app/technical-record/manufacturer/manufacturer.component.html
@@ -1,9 +1,9 @@
-<ng-container>
+<ng-container *ngIf="!editState">
   <dl class="govuk-summary-list">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Name</dt>
       <dd id="test-manufacturer-name" class="govuk-summary-list__value">
-        {{  manufacturer?.name | DefaultNullOrEmpty }}
+        {{ manufacturer?.name | DefaultNullOrEmpty }}
       </dd>
       <dd class="govuk-summary-list__value"></dd>
     </div>
@@ -65,6 +65,16 @@
         {{ manufacturer?.manufacturerNotes | DefaultNullOrEmpty }}
       </dd>
       <dd class="govuk-summary-list__value"></dd>
+    </div>
+  </dl>
+</ng-container>
+
+<ng-container *ngIf="editState">
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <vtm-manufacturer-edit [manufacturerEditDetails]="manufacturer"></vtm-manufacturer-edit>
+      </dt>
     </div>
   </dl>
 </ng-container>

--- a/src/app/technical-record/manufacturer/manufacturer.component.spec.ts
+++ b/src/app/technical-record/manufacturer/manufacturer.component.spec.ts
@@ -2,9 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ManufacturerComponent } from './manufacturer.component';
 import { SharedModule } from '@app/shared/shared.module';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, Component, Input } from '@angular/core';
 import { TESTING_UTILS } from '@app/utils/testing.utils';
-import { ManufacturerDetails } from '@app/models/tech-record.model';
 
 describe('ManufacturerComponent', () => {
   let component: ManufacturerComponent;
@@ -38,5 +37,12 @@ describe('ManufacturerComponent', () => {
     });
     fixture.detectChanges();
     expect(component.address1And2).toEqual('someone somewhere');
+  });
+
+  it('should render the edit components when editState is true', () => {
+    component.editState = true;
+    fixture.detectChanges();
+
+    expect(fixture).toMatchSnapshot();
   });
 });

--- a/src/app/technical-record/manufacturer/manufacturer.component.ts
+++ b/src/app/technical-record/manufacturer/manufacturer.component.ts
@@ -7,15 +7,14 @@ import { ManufacturerDetails } from '@app/models/tech-record.model';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ManufacturerComponent implements OnInit {
-
+  @Input() editState: boolean;
   @Input() manufacturer: ManufacturerDetails;
   address1And2 = '';
-  constructor() { }
+  constructor() {}
 
   ngOnInit() {
     if (this.manufacturer) {
       this.address1And2 = `${this.manufacturer.address1} ${this.manufacturer.address2}`;
     }
   }
-
 }

--- a/src/app/technical-record/technical-record.component.html
+++ b/src/app/technical-record/technical-record.component.html
@@ -576,7 +576,10 @@
             </mat-panel-description>
           </mat-expansion-panel-header>
 
-          <vtm-manufacturer [manufacturer]="activeRecord.manufacturerDetails"></vtm-manufacturer>
+          <vtm-manufacturer
+            [manufacturer]="activeRecord.manufacturerDetails"
+            [editState]="isEditable"
+          ></vtm-manufacturer>
         </mat-expansion-panel>
       </div>
 

--- a/src/app/technical-record/technical-record.module.ts
+++ b/src/app/technical-record/technical-record.module.ts
@@ -56,6 +56,7 @@ import { BrakesComponent } from './brakes/brakes.component';
 import { BrakesPsvComponent } from './brakes/brakes-psv/brakes-psv.component';
 import { PurchaserComponent } from './purchaser/purchaser.component';
 import { ManufacturerComponent } from './manufacturer/manufacturer.component';
+import { ManufacturerEditComponent } from './manufacturer/edit/manufacturer-edit.component';
 import { AuthorisationIntoServiceComponent } from './authorisation-into-service/authorisation-into-service.component';
 import { LettersOfAuthorisationComponent } from './letters-of-authorisation/letters-of-authorisation.component';
 import { AxleBrakesComponent } from './brakes/axle-brakes/axle-brakes.component';
@@ -107,6 +108,7 @@ const COMPONENTS = [
   BrakesPsvComponent,
   PurchaserComponent,
   ManufacturerComponent,
+  ManufacturerEditComponent,
   AuthorisationIntoServiceComponent,
   LettersOfAuthorisationComponent,
   AxleBrakesComponent,


### PR DESCRIPTION
## Subtask: Add sub component for Manufactures, create template, implementation and unit tests
_It allows to select Trailer & create Manufacturer record._
[https://jira.dvsacloud.uk/browse/CVSB-16938](https://jira.dvsacloud.uk/browse/CVSB-16938)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [ ] Delete branch after merge


In the screenshot we see that _techRecord_ object is populated for Manufacturer section upon onSaveChanges:

<img width="1581" alt="Screenshot 2020-07-09 at 16 28 05" src="https://user-images.githubusercontent.com/2506018/87048412-592cfe00-c204-11ea-8573-639c0d3af885.png">
