### PR TITLE
CVSB-16937: add mode to Create/Edit the Authorisation into Service se…

### DIFF
--- a/src/app/technical-record/authorisation-into-service/authorisation-into-service.component.html
+++ b/src/app/technical-record/authorisation-into-service/authorisation-into-service.component.html
@@ -1,53 +1,67 @@
-<dl class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">COC issue date</dt>
-    <dd id="test-cocIssueDate" class="govuk-summary-list__value">
-      <span *ngIf="authIntoService?.cocIssueDate; else hyphen">
-        {{ authIntoService?.cocIssueDate | date: 'dd/MM/yyyy' }}
-      </span>
-    </dd>
-    <dd class="govuk-summary-list__value"></dd>
-  </div>
+<ng-container *ngIf="!editState">
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">COC issue date</dt>
+      <dd id="test-cocIssueDate" class="govuk-summary-list__value">
+        <span *ngIf="authIntoService?.cocIssueDate; else hyphen">
+          {{ authIntoService?.cocIssueDate | date: 'dd/MM/yyyy' }}
+        </span>
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
+    </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Date received</dt>
-    <dd id="test-dateReceived" class="govuk-summary-list__value">
-      <span *ngIf="authIntoService?.dateReceived; else hyphen">
-        {{ authIntoService?.dateReceived | date: 'dd/MM/yyyy' }}
-      </span>
-    </dd>
-    <dd class="govuk-summary-list__value"></dd>
-  </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Date received</dt>
+      <dd id="test-dateReceived" class="govuk-summary-list__value">
+        <span *ngIf="authIntoService?.dateReceived; else hyphen">
+          {{ authIntoService?.dateReceived | date: 'dd/MM/yyyy' }}
+        </span>
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
+    </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Date pending</dt>
-    <dd id="test-datePending" class="govuk-summary-list__value">
-      <span *ngIf="authIntoService?.datePending; else hyphen">
-        {{ authIntoService?.datePending | date: 'dd/MM/yyyy' }}
-      </span>
-    </dd>
-    <dd class="govuk-summary-list__value"></dd>
-  </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Date pending</dt>
+      <dd id="test-datePending" class="govuk-summary-list__value">
+        <span *ngIf="authIntoService?.datePending; else hyphen">
+          {{ authIntoService?.datePending | date: 'dd/MM/yyyy' }}
+        </span>
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
+    </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Date authorised</dt>
-    <dd id="test-dateAuthorised" class="govuk-summary-list__value">
-      <span *ngIf="authIntoService?.datePending; else hyphen">
-        {{ authIntoService?.dateAuthorised | date: 'dd/MM/yyyy' }}
-      </span>
-    </dd>
-    <dd class="govuk-summary-list__value"></dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Date rejected</dt>
-    <dd id="test-dateRejected" class="govuk-summary-list__value">
-      <span *ngIf="authIntoService?.dateRejected; else hyphen">
-        {{ authIntoService?.dateRejected | date: 'dd/MM/yyyy' }}
-      </span>
-    </dd>
-    <dd class="govuk-summary-list__value"></dd>
-  </div>
-</dl>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Date authorised</dt>
+      <dd id="test-dateAuthorised" class="govuk-summary-list__value">
+        <span *ngIf="authIntoService?.datePending; else hyphen">
+          {{ authIntoService?.dateAuthorised | date: 'dd/MM/yyyy' }}
+        </span>
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Date rejected</dt>
+      <dd id="test-dateRejected" class="govuk-summary-list__value">
+        <span *ngIf="authIntoService?.dateRejected; else hyphen">
+          {{ authIntoService?.dateRejected | date: 'dd/MM/yyyy' }}
+        </span>
+      </dd>
+      <dd class="govuk-summary-list__value"></dd>
+    </div>
+  </dl>
+</ng-container>
 <ng-template #hyphen>
   <span>-</span>
 </ng-template>
+
+<ng-container *ngIf="editState">
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <vtm-auth-into-service-edit
+          [authIntoServiceEditDetails]="authIntoService"
+        ></vtm-auth-into-service-edit>
+      </dt>
+    </div>
+  </dl>
+</ng-container>

--- a/src/app/technical-record/authorisation-into-service/authorisation-into-service.component.ts
+++ b/src/app/technical-record/authorisation-into-service/authorisation-into-service.component.ts
@@ -7,11 +7,9 @@ import { AuthIntoService } from '@app/models/tech-record.model';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AuthorisationIntoServiceComponent implements OnInit {
-
+  @Input() editState: boolean;
   @Input() authIntoService: AuthIntoService;
-  constructor() { }
+  constructor() {}
 
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/app/technical-record/authorisation-into-service/edit/__snapshots__/auth-into-service-edit.component.spec.ts.snap
+++ b/src/app/technical-record/authorisation-into-service/edit/__snapshots__/auth-into-service-edit.component.spec.ts.snap
@@ -1,0 +1,576 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AuthIntoServiceEditComponent: should create with empty control states 1`] = `
+<vtm-auth-into-service-edit
+  authIntoServiceEditDetails={[Function Object]}
+  fb={[Function FormBuilder]}
+  parent={[Function FormGroupDirective]}
+  techRecordFg={[Function FormGroup]}
+>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      class="govuk-grid-column-three-quarters"
+    >
+      <div
+        class="govuk-form-group"
+      >
+        <fieldset
+          class="govuk-fieldset"
+        >
+          <form
+            class="ng-untouched ng-pristine ng-valid"
+            ng-reflect-form="[object Object]"
+            novalidate=""
+          >
+            
+            <div
+              class="govuk-form-group ng-untouched ng-pristine ng-valid"
+              ng-reflect-form="[object Object]"
+            >
+              
+              
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label govuk-!-font-weight-bold"
+                  for="test-edit-cocIssueDate"
+                >
+                   COC issue date (optional) 
+                </label>
+                <vtm-date-input
+                  class="ng-untouched ng-pristine ng-valid"
+                  ng-reflect-aria-described-by="cocIssueDate"
+                  ng-reflect-id="test-edit-cocIssueDate"
+                  ng-reflect-name="cocIssueDate"
+                >
+                  
+                  <div
+                    class="govuk-date-input"
+                  >
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-cocIssueDate-5-day"
+                        >
+                           Day 
+                        </label>
+                        <input
+                          aria-describedby="cocIssueDate"
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="day"
+                          id="test-edit-cocIssueDate-5-day"
+                          maxlength="2"
+                          name="dateDay"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="day"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-cocIssueDate-5-month"
+                        >
+                           Month 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="month"
+                          id="test-edit-cocIssueDate-5-month"
+                          maxlength="2"
+                          name="dateMonth"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="month"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-cocIssueDate-5-year"
+                        >
+                           Year 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-4 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="year"
+                          id="test-edit-cocIssueDate-5-year"
+                          maxlength="4"
+                          minlength="4"
+                          name="dateYear"
+                          ng-reflect-maxlength="4"
+                          ng-reflect-minlength="4"
+                          ng-reflect-name="year"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </vtm-date-input>
+              </div>
+              
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label govuk-!-font-weight-bold"
+                  for="test-edit-dateReceived"
+                >
+                   Date received (optional) 
+                </label>
+                <vtm-date-input
+                  class="ng-untouched ng-pristine ng-valid"
+                  ng-reflect-aria-described-by="dateReceived"
+                  ng-reflect-id="test-edit-dateReceived"
+                  ng-reflect-name="dateReceived"
+                >
+                  
+                  <div
+                    class="govuk-date-input"
+                  >
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateReceived-5-day"
+                        >
+                           Day 
+                        </label>
+                        <input
+                          aria-describedby="dateReceived"
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="day"
+                          id="test-edit-dateReceived-5-day"
+                          maxlength="2"
+                          name="dateDay"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="day"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateReceived-5-month"
+                        >
+                           Month 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="month"
+                          id="test-edit-dateReceived-5-month"
+                          maxlength="2"
+                          name="dateMonth"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="month"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateReceived-5-year"
+                        >
+                           Year 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-4 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="year"
+                          id="test-edit-dateReceived-5-year"
+                          maxlength="4"
+                          minlength="4"
+                          name="dateYear"
+                          ng-reflect-maxlength="4"
+                          ng-reflect-minlength="4"
+                          ng-reflect-name="year"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </vtm-date-input>
+              </div>
+              
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label govuk-!-font-weight-bold"
+                  for="test-edit-datePending"
+                >
+                   Date pending (optional) 
+                </label>
+                <vtm-date-input
+                  class="ng-untouched ng-pristine ng-valid"
+                  ng-reflect-aria-described-by="datePending"
+                  ng-reflect-id="test-edit-datePending"
+                  ng-reflect-name="datePending"
+                >
+                  
+                  <div
+                    class="govuk-date-input"
+                  >
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-datePending-5-day"
+                        >
+                           Day 
+                        </label>
+                        <input
+                          aria-describedby="datePending"
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="day"
+                          id="test-edit-datePending-5-day"
+                          maxlength="2"
+                          name="dateDay"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="day"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-datePending-5-month"
+                        >
+                           Month 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="month"
+                          id="test-edit-datePending-5-month"
+                          maxlength="2"
+                          name="dateMonth"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="month"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-datePending-5-year"
+                        >
+                           Year 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-4 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="year"
+                          id="test-edit-datePending-5-year"
+                          maxlength="4"
+                          minlength="4"
+                          name="dateYear"
+                          ng-reflect-maxlength="4"
+                          ng-reflect-minlength="4"
+                          ng-reflect-name="year"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </vtm-date-input>
+              </div>
+              
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label govuk-!-font-weight-bold"
+                  for="test-edit-dateAuthorised"
+                >
+                   Date authorized (optional) 
+                </label>
+                <vtm-date-input
+                  class="ng-untouched ng-pristine ng-valid"
+                  ng-reflect-aria-described-by="dateAuthorised"
+                  ng-reflect-id="test-edit-dateAuthorised"
+                  ng-reflect-name="dateAuthorised"
+                >
+                  
+                  <div
+                    class="govuk-date-input"
+                  >
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateAuthorised-5-day"
+                        >
+                           Day 
+                        </label>
+                        <input
+                          aria-describedby="dateAuthorised"
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="day"
+                          id="test-edit-dateAuthorised-5-day"
+                          maxlength="2"
+                          name="dateDay"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="day"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateAuthorised-5-month"
+                        >
+                           Month 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="month"
+                          id="test-edit-dateAuthorised-5-month"
+                          maxlength="2"
+                          name="dateMonth"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="month"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateAuthorised-5-year"
+                        >
+                           Year 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-4 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="year"
+                          id="test-edit-dateAuthorised-5-year"
+                          maxlength="4"
+                          minlength="4"
+                          name="dateYear"
+                          ng-reflect-maxlength="4"
+                          ng-reflect-minlength="4"
+                          ng-reflect-name="year"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </vtm-date-input>
+              </div>
+              
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label govuk-!-font-weight-bold"
+                  for="test-edit-dateRejected"
+                >
+                   Date rejected (optional) 
+                </label>
+                <vtm-date-input
+                  class="ng-untouched ng-pristine ng-valid"
+                  ng-reflect-aria-described-by="dateRejected"
+                  ng-reflect-id="test-edit-dateRejected"
+                  ng-reflect-name="dateRejected"
+                >
+                  
+                  <div
+                    class="govuk-date-input"
+                  >
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateRejected-5-day"
+                        >
+                           Day 
+                        </label>
+                        <input
+                          aria-describedby="dateRejected"
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="day"
+                          id="test-edit-dateRejected-5-day"
+                          maxlength="2"
+                          name="dateDay"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="day"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateRejected-5-month"
+                        >
+                           Month 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-2 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="month"
+                          id="test-edit-dateRejected-5-month"
+                          maxlength="2"
+                          name="dateMonth"
+                          ng-reflect-maxlength="2"
+                          ng-reflect-name="month"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="govuk-date-input__item"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <label
+                          class="govuk-label govuk-date-input__label"
+                          for="test-edit-dateRejected-5-year"
+                        >
+                           Year 
+                        </label>
+                        <input
+                          autocomplete="off"
+                          class="govuk-input govuk-date-input__input govuk-input--width-4 ng-untouched ng-pristine ng-valid"
+                          formcontrolname="year"
+                          id="test-edit-dateRejected-5-year"
+                          maxlength="4"
+                          minlength="4"
+                          name="dateYear"
+                          ng-reflect-maxlength="4"
+                          ng-reflect-minlength="4"
+                          ng-reflect-name="year"
+                          ng-reflect-pattern="[0-9]*"
+                          pattern="[0-9]*"
+                          type="number"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </vtm-date-input>
+              </div>
+            </div>
+            
+          </form>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+</vtm-auth-into-service-edit>
+`;

--- a/src/app/technical-record/authorisation-into-service/edit/auth-into-service-edit.component.html
+++ b/src/app/technical-record/authorisation-into-service/edit/auth-into-service-edit.component.html
@@ -1,0 +1,64 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <form [formGroup]="techRecordFg">
+          <!-- Date Auth fields -->
+          <ng-container
+            *ngTemplateOutlet="
+              dateTemplate;
+              context: {
+                $implicit: {
+                  group: authIntoService,
+                  dateFields: [
+                    {
+                      label: 'COC issue date (optional)',
+                      field: 'cocIssueDate'
+                    },
+                    {
+                      label: 'Date received (optional)',
+                      field: 'dateReceived'
+                    },
+                    {
+                      label: 'Date pending (optional)',
+                      field: 'datePending'
+                    },
+                    {
+                      label: 'Date authorized (optional)',
+                      field: 'dateAuthorised'
+                    },
+                    {
+                      label: 'Date rejected (optional)',
+                      field: 'dateRejected'
+                    }
+                  ]
+                }
+              }
+            "
+          >
+          </ng-container>
+          <!-- ariaDescribedBy="item" -->
+          <ng-template let-dateTemplate #dateTemplate>
+            <div class="govuk-form-group" [formGroup]="dateTemplate.group">
+              <ng-container *ngFor="let item of dateTemplate.dateFields">
+                <div class="govuk-form-group">
+                  <label
+                    class="govuk-label govuk-!-font-weight-bold"
+                    for="test-edit-{{ item.field }}"
+                  >
+                    {{ item.label }}
+                  </label>
+                  <vtm-date-input
+                    id="test-edit-{{ item.field }}"
+                    aria-describedby="{{ item.field }}"
+                    formControlName="{{ item.field }}"
+                  ></vtm-date-input>
+                </div>
+              </ng-container>
+            </div>
+          </ng-template>
+        </form>
+      </fieldset>
+    </div>
+  </div>
+</div>

--- a/src/app/technical-record/authorisation-into-service/edit/auth-into-service-edit.component.spec.ts
+++ b/src/app/technical-record/authorisation-into-service/edit/auth-into-service-edit.component.spec.ts
@@ -1,0 +1,68 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormGroupDirective,
+  FormGroup,
+  AbstractControl
+} from '@angular/forms';
+
+import { AuthIntoServiceEditComponent } from './auth-into-service-edit.component';
+import { TechRecord, AuthIntoService } from '@app/models/tech-record.model';
+import { TESTING_UTILS } from '@app/utils';
+import { SharedModule } from '@app/shared';
+
+const mockTechRecord = {
+  authIntoService: TESTING_UTILS.mockAuthoIntoService()
+} as TechRecord;
+
+describe('AuthIntoServiceEditComponent:', () => {
+  let component: AuthIntoServiceEditComponent;
+  let fixture: ComponentFixture<AuthIntoServiceEditComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, ReactiveFormsModule, SharedModule],
+      declarations: [AuthIntoServiceEditComponent],
+      providers: [
+        FormGroupDirective,
+        {
+          provide: FormGroupDirective,
+          useValue: TESTING_UTILS.mockFormGroupDirective({
+            techRecord: new FormGroup({}) as AbstractControl
+          })
+        }
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthIntoServiceEditComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create with empty control states', () => {
+    component.authIntoServiceEditDetails = {} as AuthIntoService;
+    fixture.detectChanges();
+
+    expect(component).toBeDefined();
+    expect(component.techRecordFg.get('authIntoService').value).toEqual({
+      cocIssueDate: null,
+      dateAuthorised: null,
+      datePending: null,
+      dateReceived: null,
+      dateRejected: null
+    });
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should create with initialized form controls', () => {
+    component.authIntoServiceEditDetails = mockTechRecord.authIntoService;
+    fixture.detectChanges();
+
+    expect(component.techRecordFg.get('authIntoService').value).toEqual(
+      mockTechRecord.authIntoService
+    );
+  });
+});

--- a/src/app/technical-record/authorisation-into-service/edit/auth-into-service-edit.component.ts
+++ b/src/app/technical-record/authorisation-into-service/edit/auth-into-service-edit.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit, ChangeDetectionStrategy, Input } from '@angular/core';
+import { FormGroup, ControlContainer, FormGroupDirective, FormBuilder } from '@angular/forms';
+
+import { AuthIntoService } from '@app/models/tech-record.model';
+
+@Component({
+  selector: 'vtm-auth-into-service-edit',
+  templateUrl: './auth-into-service-edit.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [
+    {
+      provide: ControlContainer,
+      useExisting: FormGroupDirective
+    }
+  ]
+})
+export class AuthIntoServiceEditComponent implements OnInit {
+  @Input() authIntoServiceEditDetails: AuthIntoService;
+
+  techRecordFg: FormGroup;
+
+  constructor(private parent: FormGroupDirective, private fb: FormBuilder) {}
+
+  get authIntoService() {
+    return this.techRecordFg.get('authIntoService') as FormGroup;
+  }
+
+  ngOnInit() {
+    this.techRecordFg = this.parent.form.get('techRecord') as FormGroup;
+
+    const authDetails: AuthIntoService = !!this.authIntoServiceEditDetails
+      ? this.authIntoServiceEditDetails
+      : ({} as AuthIntoService);
+
+    this.techRecordFg.addControl(
+      'authIntoService',
+      this.fb.group({
+        cocIssueDate: this.fb.control(authDetails.cocIssueDate),
+        dateReceived: this.fb.control(authDetails.dateReceived),
+        datePending: this.fb.control(authDetails.datePending),
+        dateAuthorised: this.fb.control(authDetails.dateAuthorised),
+        dateRejected: this.fb.control(authDetails.dateRejected)
+      })
+    );
+  }
+}

--- a/src/app/technical-record/technical-record.component.html
+++ b/src/app/technical-record/technical-record.component.html
@@ -621,6 +621,7 @@
 
           <vtm-authorisation-into-service
             [authIntoService]="activeRecord.authIntoService"
+            [editState]="isEditable"
           ></vtm-authorisation-into-service>
         </mat-expansion-panel>
       </div>

--- a/src/app/technical-record/technical-record.module.ts
+++ b/src/app/technical-record/technical-record.module.ts
@@ -57,6 +57,7 @@ import { BrakesPsvComponent } from './brakes/brakes-psv/brakes-psv.component';
 import { PurchaserComponent } from './purchaser/purchaser.component';
 import { ManufacturerComponent } from './manufacturer/manufacturer.component';
 import { AuthorisationIntoServiceComponent } from './authorisation-into-service/authorisation-into-service.component';
+import { AuthIntoServiceEditComponent } from './authorisation-into-service/edit/auth-into-service-edit.component';
 import { LettersOfAuthorisationComponent } from './letters-of-authorisation/letters-of-authorisation.component';
 import { AxleBrakesComponent } from './brakes/axle-brakes/axle-brakes.component';
 import { DdaComponent } from './dda/dda.component';
@@ -108,6 +109,7 @@ const COMPONENTS = [
   PurchaserComponent,
   ManufacturerComponent,
   AuthorisationIntoServiceComponent,
+  AuthIntoServiceEditComponent,
   LettersOfAuthorisationComponent,
   AxleBrakesComponent,
   DdaComponent


### PR DESCRIPTION
## Subtask: Add sub component for Authorisation Into Service, create template, implementation and unit tests
_It allows to select Trailer vehicle type & create AIS record.
Also it's synced if we try to edit that data._
[https://jira.dvsacloud.uk/browse/CVSB-16937](https://jira.dvsacloud.uk/browse/CVSB-16937)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [ ] Delete branch after merge

In the screenshot we see that _techRecord_ object is populated for Authorisation Into Service section upon _onSaveChanges_:

<img width="1120" alt="Screenshot 2020-07-10 at 17 35 34" src="https://user-images.githubusercontent.com/2506018/87309886-dff41a80-c525-11ea-8e8f-9f3b480ef46b.png">

