### PR TITLE
feat(package): cb2-3104 Removing call to scanrepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "sonar-scanner": "npm run test && sonar-scanner",
     "test:deploy": "npm run build && npx http-server ./dist -p 4200 -c-1",
     "prepush": "npm run build && npm test",
-    "security-checks": "git secrets --scan && git log -p | scanrepo",
+    "security-checks": "git secrets --scan",
     "coverage": "jest --coverage",
     "audit-dep": "npm audit --audit-level=high --json | audit-filter --nsp-config=.nsprc --audit=-"
   },


### PR DESCRIPTION
## CB2-3104 Investigate/Resolve VTM Deploy issues
Revoming use of `scanrepo`
[CB2-3104](https://jira.dvsacloud.uk/browse/CB2-3104)

## Checklist

- [ x ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ x ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
