### PR TITLE
fix(cb2-2877): re-instate sonarqube config

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,20 @@
+#----- Default SonarQube server
+sonar.host.url=http://volted-monkey-sonarqube.ops:9000
+# sonar.host.url=http://localhost:9000
+
+# must be unique in a given SonarQube instance
+sonar.projectKey=org.sonarqube:cvs-app-vtm
+
+# this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
+sonar.projectName=VTM App
+sonar.projectVersion=1.0
+sonar.sourceEncoding=UTF-8
+
+# Path is relative to the sonar-project.properties file. Replace “\” by “/” on Windows.
+# This property is optional if sonar.modules is set.
+sonar.sources=src/app
+sonar.exclusions=test-config/**, cypress/**, dist/**, .nyc_output/**, .scannerwork/**, coverage/**, **/*.module.ts, **/*.routes.ts, **/*.state.ts, **/utils.ts
+sonar.test.inclusions=**/*.spec.ts
+sonar.tslint.reportPaths=.reports/lint_issues.json
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.testExecutionReportPaths=.reports/test-report.xml


### PR DESCRIPTION
Re-instates the SonarQube config which fixes the sonarqube stage in the build pipeline
[cb2-2877](https://jira.dvsacloud.uk/browse/CB2-2877)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
