### PR TITLE
fix(cb2-2880): sonarqube build step

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,4 +17,3 @@ sonar.exclusions=test-config/**, cypress/**, dist/**, .nyc_output/**, .scannerwo
 sonar.test.inclusions=**/*.spec.ts
 sonar.tslint.reportPaths=.reports/lint_issues.json
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
-sonar.testExecutionReportPaths=.reports/test-report.xml


### PR DESCRIPTION
## Build Pipeline Fix (SonarQube step)
Removes the reference to an additional test report that isn't generated since the project was re-started and the test framework was changed

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
