### PR TITLE
fix(cb2-3590): Sync user state with local storage

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,25 +1,23 @@
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { MsalBroadcastService, MsalGuard, MsalGuardConfiguration, MsalInterceptor, MsalInterceptorConfiguration, MsalModule, MsalRedirectComponent, MsalService, MSAL_GUARD_CONFIG, MSAL_INSTANCE, MSAL_INTERCEPTOR_CONFIG } from '@azure/msal-angular';
 import { BrowserCacheLocation, InteractionType, IPublicClientApplication, PublicClientApplication } from '@azure/msal-browser';
-import { ActionReducer, MetaReducer } from '@ngrx/store';
-import { localStorageSync } from 'ngrx-store-localstorage';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { GlobalErrorComponent } from './features/global-error/global-error.component';
 import { HomeButtonComponent } from './features/home/components/home-button/home-button.component';
 import { HomeComponent } from './features/home/home.component';
 import { SearchComponent } from './features/search/search.component';
+import { TestRecordSummaryComponent } from './features/test-record-summary/test-record-summary.component';
+import { DynamicFormsModule } from './forms/dynamic-forms.module';
 import { FooterComponent } from './layout/footer/footer.component';
 import { HeaderComponent } from './layout/header/header.component';
 import { UserService } from './services/user-service/user-service';
 import { AppStoreModule } from './store/app-store.module';
 import { VehicleTechnicalRecordComponent } from './vehicle-technical-record/vehicle-technical-record.component';
-import { TestRecordSummaryComponent } from './features/test-record-summary/test-record-summary.component';
-import { GlobalErrorComponent } from './features/global-error/global-error.component';
-import { DynamicFormsModule } from './forms/dynamic-forms.module';
-import { ReactiveFormsModule } from '@angular/forms';
 
 export function MSALInstanceFactory(): IPublicClientApplication {
   return new PublicClientApplication({
@@ -54,12 +52,6 @@ export function MSALGuardConfigFactory(): MsalGuardConfiguration {
     loginFailedRoute: ''
   };
 }
-
-export function localStorageSyncReducer(reducer: ActionReducer<any>): ActionReducer<any> {
-  return localStorageSync({ keys: ['userservice'], rehydrate: true })(reducer);
-}
-
-const metaReducers: Array<MetaReducer<any, any>> = [localStorageSyncReducer];
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, FooterComponent, HomeComponent, HomeButtonComponent, SearchComponent, VehicleTechnicalRecordComponent, TestRecordSummaryComponent, GlobalErrorComponent],

--- a/src/app/store/app-store.module.ts
+++ b/src/app/store/app-store.module.ts
@@ -3,12 +3,12 @@ import { NgModule } from '@angular/core';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { GlobalErrorStateModule } from '@store/global-error/global-error-state.module';
 import { environment } from '../../environments/environment';
 import { RouterStateModule } from './router/router-state.module';
 import { TechnicalRecordsStateModule } from './technical-records/technical-records-state.module';
 import { TestRecordsStateModule } from './test-records/test-records.module';
 import { UserStateModule } from './user/user-state.module';
-import { GlobalErrorStateModule } from '@store/global-error/global-error-state.module';
 
 @NgModule({
   declarations: [],

--- a/src/app/store/user/user-state.module.ts
+++ b/src/app/store/user/user-state.module.ts
@@ -1,10 +1,17 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { StoreModule } from '@ngrx/store';
+import { NgModule } from '@angular/core';
+import { ActionReducer, MetaReducer, StoreModule } from '@ngrx/store';
+import { localStorageSync } from 'ngrx-store-localstorage';
 import { STORE_FEATURE_USER_KEY, userServiceReducer } from './user-service.reducer';
+
+export function localStorageSyncReducer(reducer: ActionReducer<any>): ActionReducer<any> {
+  return localStorageSync({ keys: ['username'], rehydrate: true })(reducer);
+}
+
+const metaReducers: Array<MetaReducer<any, any>> = [localStorageSyncReducer];
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, StoreModule.forFeature(STORE_FEATURE_USER_KEY, userServiceReducer)]
+  imports: [CommonModule, StoreModule.forFeature(STORE_FEATURE_USER_KEY, userServiceReducer, { metaReducers })]
 })
 export class UserStateModule {}


### PR DESCRIPTION
## [VTM] - BUG - Refreshing the VTM app losing the username in header

_Refreshing the VTM app loses the user's name in the header of the app_
[CB2-3590](https://jira.dvsacloud.uk/browse/CB2-3590)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
