### PR TITLE
fix(cb2-3615): http request timeout

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { HomeComponent } from './features/home/home.component';
 import { SearchComponent } from './features/search/search.component';
 import { TestRecordSummaryComponent } from './features/test-record-summary/test-record-summary.component';
 import { DynamicFormsModule } from './forms/dynamic-forms.module';
+import { InterceptorModule } from './interceptors/interceptor.module';
 import { FooterComponent } from './layout/footer/footer.component';
 import { HeaderComponent } from './layout/header/header.component';
 import { UserService } from './services/user-service/user-service';
@@ -55,7 +56,7 @@ export function MSALGuardConfigFactory(): MsalGuardConfiguration {
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, FooterComponent, HomeComponent, HomeButtonComponent, SearchComponent, VehicleTechnicalRecordComponent, TestRecordSummaryComponent, GlobalErrorComponent],
-  imports: [BrowserModule, AppRoutingModule, MsalModule, HttpClientModule, AppStoreModule, DynamicFormsModule, ReactiveFormsModule],
+  imports: [BrowserModule, AppRoutingModule, MsalModule, HttpClientModule, AppStoreModule, DynamicFormsModule, ReactiveFormsModule, InterceptorModule],
   providers: [
     {
       provide: HTTP_INTERCEPTORS,

--- a/src/app/features/global-error/global-error.service.ts
+++ b/src/app/features/global-error/global-error.service.ts
@@ -1,33 +1,31 @@
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { State } from '@store/.';
-import { getGlobalErrorState, globalErrorState } from '@store/global-error/reducers/global-error-service.reducer';
-import { BehaviorSubject, combineLatest, map, Observable } from 'rxjs';
 import { addError, clearError } from '@store/global-error/actions/global-error.actions';
+import { globalErrorState } from '@store/global-error/reducers/global-error-service.reducer';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class GlobalErrorService {
-
   private errors: Observable<GlobalError[]>;
 
   constructor(private store: Store<State>) {
-    this.errors = this.store.pipe(select(globalErrorState))
+    this.errors = this.store.pipe(select(globalErrorState));
   }
 
   get errors$() {
     return this.errors;
   }
 
-  addError(error: GlobalError){
-    this.store.dispatch(addError(error))
+  addError(error: GlobalError) {
+    this.store.dispatch(addError(error));
   }
 
-  clearError() : void {
-    this.store.dispatch(clearError())
+  clearError(): void {
+    this.store.dispatch(clearError());
   }
-
 }
 
 export interface GlobalError {

--- a/src/app/interceptors/delayed-retry/delayed-retry.interceptor.spec.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.interceptor.spec.ts
@@ -1,0 +1,72 @@
+import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
+import { DelayedRetryInterceptor } from './delayed-retry.interceptor';
+import { HttpRetryInterceptorConfig } from './delayed-retry.module';
+
+describe('DelayedRetryInterceptor', () => {
+  let httpTestingController: HttpTestingController;
+  let client: HttpClient;
+  let interceptor: DelayedRetryInterceptor;
+
+  const DUMMY_ENDPOINT = 'https://www.someapi.com';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DelayedRetryInterceptor,
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: DelayedRetryInterceptor,
+          multi: true
+        },
+        { provide: HttpRetryInterceptorConfig, useValue: new HttpRetryInterceptorConfig({ delay: 500, count: 3, httpStatusRetry: [408] }) }
+      ]
+    });
+
+    client = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    interceptor = TestBed.inject(DelayedRetryInterceptor);
+  });
+
+  afterEach(() => {
+    // After every test, assert that there are no more pending requests.
+    httpTestingController.verify();
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+
+  it('should throw error "Reached maximum number of attemps (3). Please try again later." after final retry', fakeAsync(() => {
+    client.get(DUMMY_ENDPOINT).subscribe({
+      error: (e) => {
+        expect(e).toEqual('Reached maximum number of attemps (3). Please try again later.');
+      }
+    });
+
+    const retryCount = 3;
+    for (var i = 0, c = retryCount; i < c; i++) {
+      tick(500);
+      let req = httpTestingController.expectOne(DUMMY_ENDPOINT);
+      req.flush('Deliberate 408 error', { status: 408, statusText: 'Request Timeout' });
+    }
+    flush();
+  }));
+
+  it('should cascade errors not in the retry list', (done) => {
+    client.get(DUMMY_ENDPOINT).subscribe({
+      error: (e) => {
+        const { error, status, statusText } = e;
+        expect(error).toEqual('Deliberate 401 error');
+        expect(status).toEqual(401);
+        expect(statusText).toEqual('401 Unauthorized');
+        done();
+      }
+    });
+
+    const req = httpTestingController.expectOne(DUMMY_ENDPOINT);
+    req.flush('Deliberate 401 error', { status: 401, statusText: '401 Unauthorized' });
+  });
+});

--- a/src/app/interceptors/delayed-retry/delayed-retry.interceptor.spec.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.interceptor.spec.ts
@@ -21,52 +21,83 @@ describe('DelayedRetryInterceptor', () => {
           useClass: DelayedRetryInterceptor,
           multi: true
         },
-        { provide: HttpRetryInterceptorConfig, useValue: new HttpRetryInterceptorConfig({ delay: 500, count: 3, httpStatusRetry: [408] }) }
+        { provide: HttpRetryInterceptorConfig, useValue: new HttpRetryInterceptorConfig({ delay: 500, count: 3, httpStatusRetry: [504] }) }
       ]
     });
-
-    client = TestBed.inject(HttpClient);
-    httpTestingController = TestBed.inject(HttpTestingController);
-    interceptor = TestBed.inject(DelayedRetryInterceptor);
   });
 
-  afterEach(() => {
-    // After every test, assert that there are no more pending requests.
-    httpTestingController.verify();
-  });
-
-  it('should be created', () => {
-    expect(interceptor).toBeTruthy();
-  });
-
-  it('should throw error "Reached maximum number of attemps (3). Please try again later." after final retry', fakeAsync(() => {
-    client.get(DUMMY_ENDPOINT).subscribe({
-      error: (e) => {
-        expect(e).toEqual('Reached maximum number of attemps (3). Please try again later.');
-      }
+  describe('no backof', () => {
+    beforeEach(() => {
+      client = TestBed.inject(HttpClient);
+      httpTestingController = TestBed.inject(HttpTestingController);
+      interceptor = TestBed.inject(DelayedRetryInterceptor);
     });
 
-    const retryCount = 3;
-    for (var i = 0, c = retryCount; i < c; i++) {
-      tick(500);
-      let req = httpTestingController.expectOne(DUMMY_ENDPOINT);
-      req.flush('Deliberate 408 error', { status: 408, statusText: 'Request Timeout' });
-    }
-    flush();
-  }));
-
-  it('should cascade errors not in the retry list', (done) => {
-    client.get(DUMMY_ENDPOINT).subscribe({
-      error: (e) => {
-        const { error, status, statusText } = e;
-        expect(error).toEqual('Deliberate 401 error');
-        expect(status).toEqual(401);
-        expect(statusText).toEqual('401 Unauthorized');
-        done();
-      }
+    afterEach(() => {
+      // After every test, assert that there are no more pending requests.
+      httpTestingController.verify();
     });
 
-    const req = httpTestingController.expectOne(DUMMY_ENDPOINT);
-    req.flush('Deliberate 401 error', { status: 401, statusText: '401 Unauthorized' });
+    it('should be created', () => {
+      expect(interceptor).toBeTruthy();
+    });
+
+    it('should throw error "Request timed out. Check connectivity and try again." after final retry', fakeAsync(() => {
+      client.get(DUMMY_ENDPOINT).subscribe({
+        error: (e) => {
+          expect(e).toEqual('Request timed out. Check connectivity and try again.');
+        }
+      });
+      const retryCount = 3;
+      for (var i = 0, c = retryCount; i < c; i++) {
+        tick(500);
+        let req = httpTestingController.expectOne(DUMMY_ENDPOINT);
+        req.flush('Deliberate 504 error', { status: 504, statusText: 'Gateway Timeout' });
+      }
+      flush();
+    }));
+
+    it('should cascade errors not in the retry list', (done) => {
+      client.get(DUMMY_ENDPOINT).subscribe({
+        error: (e) => {
+          const { error, status, statusText } = e;
+          expect(error).toEqual('Deliberate 401 error');
+          expect(status).toEqual(401);
+          expect(statusText).toEqual('401 Unauthorized');
+          done();
+        }
+      });
+      const req = httpTestingController.expectOne(DUMMY_ENDPOINT);
+      req.flush('Deliberate 401 error', { status: 401, statusText: '401 Unauthorized' });
+    });
+  });
+
+  describe('backoff', () => {
+    beforeEach(() => {
+      TestBed.overrideProvider(HttpRetryInterceptorConfig, { useValue: new HttpRetryInterceptorConfig({ count: 3, delay: 500, backoff: true }) });
+      client = TestBed.inject(HttpClient);
+      httpTestingController = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+      // After every test, assert that there are no more pending requests.
+      httpTestingController.verify();
+    });
+
+    it('should stagger retry requests', fakeAsync(() => {
+      client.get(DUMMY_ENDPOINT).subscribe({
+        error: (e) => {
+          expect(e).toEqual('Request timed out. Check connectivity and try again.');
+        }
+      });
+
+      const retryCount = 3;
+      for (var i = 0; i < retryCount; i++) {
+        tick(500 * (i + 1));
+        let req = httpTestingController.expectOne(DUMMY_ENDPOINT);
+        req.flush('Deliberate 504 error', { status: 504, statusText: 'Gateway Timeout' });
+      }
+      flush();
+    }));
   });
 });

--- a/src/app/interceptors/delayed-retry/delayed-retry.interceptor.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.interceptor.ts
@@ -1,0 +1,32 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, retry, timer } from 'rxjs';
+import { HttpRetryInterceptorConfig } from './delayed-retry.module';
+
+@Injectable()
+export class DelayedRetryInterceptor implements HttpInterceptor {
+  constructor(private config: HttpRetryInterceptorConfig) {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(request).pipe(
+      retry({
+        delay: (error: any, retryCount: number) => this.retryHandler(error, retryCount, this.config)
+      })
+    );
+  }
+
+  retryHandler(error: any, retryCount: number, config: HttpRetryInterceptorConfig) {
+    const { delay, count, httpStatusRetry } = config;
+    const { status } = error;
+
+    if (httpStatusRetry.includes(status)) {
+      if (retryCount < count) {
+        return timer(delay);
+      } else {
+        throw `Reached maximum number of attemps (${count}). Please try again later.`;
+      }
+    }
+
+    throw error;
+  }
+}

--- a/src/app/interceptors/delayed-retry/delayed-retry.interceptor.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.interceptor.ts
@@ -16,17 +16,17 @@ export class DelayedRetryInterceptor implements HttpInterceptor {
   }
 
   retryHandler(error: any, retryCount: number, config: HttpRetryInterceptorConfig) {
-    const { delay, count, httpStatusRetry } = config;
+    const { delay, count, httpStatusRetry, backoff } = config;
     const { status } = error;
 
-    if (httpStatusRetry.includes(status)) {
-      if (retryCount < count) {
-        return timer(delay);
-      } else {
-        throw `Request timed out. Check connectivity and try again.`;
-      }
+    if (httpStatusRetry && !httpStatusRetry.includes(status)) {
+      throw error;
     }
 
-    throw error;
+    if (retryCount >= count) {
+      throw 'Request timed out. Check connectivity and try again.';
+    }
+
+    return timer(backoff ? delay * retryCount : delay);
   }
 }

--- a/src/app/interceptors/delayed-retry/delayed-retry.interceptor.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.interceptor.ts
@@ -23,7 +23,7 @@ export class DelayedRetryInterceptor implements HttpInterceptor {
       if (retryCount < count) {
         return timer(delay);
       } else {
-        throw `Reached maximum number of attemps (${count}). Please try again later.`;
+        throw `Request timed out. Check connectivity and try again.`;
       }
     }
 

--- a/src/app/interceptors/delayed-retry/delayed-retry.module.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.module.ts
@@ -1,11 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { InjectionToken, ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
 import { DelayedRetryInterceptor } from './delayed-retry.interceptor';
 
-/**
- *
- */
+export const HTTP_RETRY_CONFIG = new InjectionToken<HttpRetryConfig>('HttpRetryConfig');
+
 export interface HttpRetryConfig {
   /**
    * The maximum number of times to retry.
@@ -23,25 +22,6 @@ export interface HttpRetryConfig {
    * If true, each retry delay will be multiplied by the current retry count.
    */
   backoff?: boolean;
-}
-
-export class HttpRetryInterceptorConfig implements HttpRetryConfig {
-  readonly count: number;
-  readonly delay: number;
-  readonly httpStatusRetry?: number[] | undefined;
-  readonly backoff: boolean;
-
-  private readonly defaultConfig = { count: 3, delay: 2000, backoff: false };
-
-  constructor(@Optional() private config?: HttpRetryConfig) {
-    this.count = this.config?.count ?? this.defaultConfig.count;
-    this.delay = this.config?.delay ?? this.defaultConfig.delay;
-    this.backoff = this.config?.backoff ?? this.defaultConfig.backoff;
-
-    if (this.config?.httpStatusRetry) {
-      this.httpStatusRetry = this.config.httpStatusRetry;
-    }
-  }
 }
 
 @NgModule({
@@ -62,10 +42,10 @@ export class DelayedRetryModule {
     }
   }
 
-  static forRoot(config: HttpRetryInterceptorConfig): ModuleWithProviders<DelayedRetryModule> {
+  static forRoot(config?: HttpRetryConfig): ModuleWithProviders<DelayedRetryModule> {
     return {
       ngModule: DelayedRetryModule,
-      providers: [{ provide: HttpRetryInterceptorConfig, useValue: config }]
+      providers: [{ provide: HTTP_RETRY_CONFIG, useValue: config }]
     };
   }
 }

--- a/src/app/interceptors/delayed-retry/delayed-retry.module.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.module.ts
@@ -1,0 +1,50 @@
+import { CommonModule } from '@angular/common';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { DelayedRetryInterceptor } from './delayed-retry.interceptor';
+
+export interface HttpRetryConfig {
+  count?: number;
+  delay?: number;
+  httpStatusRetry?: Array<number>;
+}
+
+export class HttpRetryInterceptorConfig implements HttpRetryConfig {
+  readonly count: number;
+  readonly delay: number;
+  readonly httpStatusRetry: number[];
+
+  private readonly defaultConfig = { count: 3, delay: 2000, httpStatusRetry: [] };
+
+  constructor(@Optional() private config?: HttpRetryConfig) {
+    this.count = this.config?.count ?? this.defaultConfig.count;
+    this.delay = this.config?.delay ?? this.defaultConfig.delay;
+    this.httpStatusRetry = this.config?.httpStatusRetry ?? this.defaultConfig.httpStatusRetry;
+  }
+}
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: DelayedRetryInterceptor,
+      multi: true
+    }
+  ]
+})
+export class DelayedRetryModule {
+  constructor(@Optional() @SkipSelf() parentModule?: DelayedRetryModule) {
+    if (parentModule) {
+      throw new Error('DelayedRetryModule is already loaded. Import it in the AppModule only');
+    }
+  }
+
+  static forRoot(config: HttpRetryInterceptorConfig): ModuleWithProviders<DelayedRetryModule> {
+    return {
+      ngModule: DelayedRetryModule,
+      providers: [{ provide: HttpRetryInterceptorConfig, useValue: config }]
+    };
+  }
+}

--- a/src/app/interceptors/delayed-retry/delayed-retry.module.ts
+++ b/src/app/interceptors/delayed-retry/delayed-retry.module.ts
@@ -3,23 +3,44 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
 import { DelayedRetryInterceptor } from './delayed-retry.interceptor';
 
+/**
+ *
+ */
 export interface HttpRetryConfig {
+  /**
+   * The maximum number of times to retry.
+   */
   count?: number;
+  /**
+   * The number of milliseconds to delay before retrying.
+   */
   delay?: number;
+  /**
+   * Array of http status codes to retry. If undefined, all requests are retried.
+   */
   httpStatusRetry?: Array<number>;
+  /**
+   * If true, each retry delay will be multiplied by the current retry count.
+   */
+  backoff?: boolean;
 }
 
 export class HttpRetryInterceptorConfig implements HttpRetryConfig {
   readonly count: number;
   readonly delay: number;
-  readonly httpStatusRetry: number[];
+  readonly httpStatusRetry?: number[] | undefined;
+  readonly backoff: boolean;
 
-  private readonly defaultConfig = { count: 3, delay: 2000, httpStatusRetry: [] };
+  private readonly defaultConfig = { count: 3, delay: 2000, backoff: false };
 
   constructor(@Optional() private config?: HttpRetryConfig) {
     this.count = this.config?.count ?? this.defaultConfig.count;
     this.delay = this.config?.delay ?? this.defaultConfig.delay;
-    this.httpStatusRetry = this.config?.httpStatusRetry ?? this.defaultConfig.httpStatusRetry;
+    this.backoff = this.config?.backoff ?? this.defaultConfig.backoff;
+
+    if (this.config?.httpStatusRetry) {
+      this.httpStatusRetry = this.config.httpStatusRetry;
+    }
   }
 }
 

--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -1,0 +1,9 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { DelayedRetryModule, HttpRetryInterceptorConfig } from './delayed-retry/delayed-retry.module';
+
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, DelayedRetryModule.forRoot(new HttpRetryInterceptorConfig({ count: 3, delay: 2000, httpStatusRetry: [404] }))]
+})
+export class InterceptorModule {}

--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { DelayedRetryModule, HttpRetryInterceptorConfig } from './delayed-retry/delayed-retry.module';
+import { DelayedRetryModule } from './delayed-retry/delayed-retry.module';
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, DelayedRetryModule.forRoot(new HttpRetryInterceptorConfig({ count: 3, delay: 2000, httpStatusRetry: [504], backoff: true }))]
+  imports: [CommonModule, DelayedRetryModule.forRoot({ count: 3, delay: 2000, httpStatusRetry: [504], backoff: true })]
 })
 export class InterceptorModule {}

--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -4,6 +4,6 @@ import { DelayedRetryModule } from './delayed-retry/delayed-retry.module';
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, DelayedRetryModule.forRoot({ count: 3, delay: 2000, httpStatusRetry: [404, 504], backoff: true })]
+  imports: [CommonModule, DelayedRetryModule.forRoot({ count: 3, delay: 2000, httpStatusRetry: [504], backoff: true })]
 })
 export class InterceptorModule {}

--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -4,6 +4,6 @@ import { DelayedRetryModule, HttpRetryInterceptorConfig } from './delayed-retry/
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, DelayedRetryModule.forRoot(new HttpRetryInterceptorConfig({ count: 3, delay: 2000, httpStatusRetry: [404] }))]
+  imports: [CommonModule, DelayedRetryModule.forRoot(new HttpRetryInterceptorConfig({ count: 3, delay: 2000, httpStatusRetry: [504] }))]
 })
 export class InterceptorModule {}

--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -4,6 +4,6 @@ import { DelayedRetryModule, HttpRetryInterceptorConfig } from './delayed-retry/
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, DelayedRetryModule.forRoot(new HttpRetryInterceptorConfig({ count: 3, delay: 2000, httpStatusRetry: [504] }))]
+  imports: [CommonModule, DelayedRetryModule.forRoot(new HttpRetryInterceptorConfig({ count: 3, delay: 2000, httpStatusRetry: [504], backoff: true }))]
 })
 export class InterceptorModule {}

--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -4,6 +4,6 @@ import { DelayedRetryModule } from './delayed-retry/delayed-retry.module';
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, DelayedRetryModule.forRoot({ count: 3, delay: 2000, httpStatusRetry: [504], backoff: true })]
+  imports: [CommonModule, DelayedRetryModule.forRoot({ count: 3, delay: 2000, httpStatusRetry: [404, 504], backoff: true })]
 })
 export class InterceptorModule {}

--- a/src/app/store/technical-records/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.ts
@@ -14,15 +14,21 @@ export class TechnicalRecordServiceEffects {
         this.technicalRecordService.getByVIN(action.vin).pipe(
           map((vehicleTechRecords) => getByVINSuccess({ vehicleTechRecords })),
           catchError((error) => {
-            let message = ''
-            switch(error.status){
-              case 404:
-                message = 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number'
-                break;
-              default:
-                message = 'There was a problem getting the Tech Record by VIN'
+            console.log(error);
+            console.log('Error is type of', typeof error);
+            let message = error;
+
+            if (typeof error === 'object') {
+              switch (error.status) {
+                case 404:
+                  message = 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number';
+                  break;
+                default:
+                  message = 'There was a problem getting the Tech Record by VIN';
+              }
             }
-            return of(getByVINFailure({ error: message, anchorLink: 'search-term' }))
+
+            return of(getByVINFailure({ error: message, anchorLink: 'search-term' }));
           })
         )
       )

--- a/src/app/store/technical-records/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.ts
@@ -14,8 +14,6 @@ export class TechnicalRecordServiceEffects {
         this.technicalRecordService.getByVIN(action.vin).pipe(
           map((vehicleTechRecords) => getByVINSuccess({ vehicleTechRecords })),
           catchError((error) => {
-            console.log(error);
-            console.log('Error is type of', typeof error);
             let message = error;
 
             if (typeof error === 'object') {


### PR DESCRIPTION
## BUG - Timeout error when searching for Tech Record

_The search for a Technical Record using a VIN can take a while to return a result and on occasions this can lead to timeouts. _
[link to ticket CB2-3615](https://jira.dvsacloud.uk/browse/CB2-3615)

- Added new Http Interceptor that retries API requests based on provided configuration.
- New interceptor module and supporting classes to make retry interceptor configurable.

## Outstanding

- Dependency on [CB2-3591](https://jira.dvsacloud.uk/browse/3591) to show errors in summary.

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
