### PR TITLE
Extra unit tests for technical-record-service effects CB2-3591

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,6 +7,7 @@ import { AppComponent } from './app.component';
 import { GlobalErrorComponent } from './features/global-error/global-error.component';
 import { FooterComponent } from './layout/footer/footer.component';
 import { HeaderComponent } from './layout/header/header.component';
+import { SpinnerComponent } from './layout/spinner/spinner.component';
 import { UserService } from './services/user-service/user-service';
 
 describe('AppComponent', () => {
@@ -17,7 +18,7 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, StoreModule.forRoot({}), MsalModule],
-      declarations: [AppComponent, HeaderComponent, FooterComponent, GlobalErrorComponent],
+      declarations: [AppComponent, HeaderComponent, FooterComponent, GlobalErrorComponent, SpinnerComponent],
       providers: [{ provide: UserService, useValue: MockUserService }]
     }).compileComponents();
   });

--- a/src/app/store/technical-records/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.spec.ts
@@ -34,29 +34,29 @@ describe('TechnicalRecordServiceEffects', () => {
     });
   });
 
-  describe('return error messages', () => {
-    it('should return getByVIN action on successfull API call', () => {
+  describe('getByVin$', () => {
+    it('should return a technical record on successfull API call', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
-        const testResults = mockVehicleTechnicalRecordList();
+        const techicalRecord = mockVehicleTechnicalRecordList();
 
         // mock action to trigger effect
         actions$ = hot('-a--', { a: getByVIN });
 
         // mock service call
-        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--a|', { a: testResults }));
+        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--a|', { a: techicalRecord }));
 
         // expect effect to return success action
         expectObservable(effects.getByVin$).toBe('---b', {
-          b: getByVINSuccess({ vehicleTechRecords: testResults })
+          b: getByVINSuccess({ vehicleTechRecords: techicalRecord })
         });
       });
     });
 
     it('should return generic error message if not not found', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
-        const vehicleTechRecords = {vin: 'vin'};
+        const vin = {vin: 'vin'};
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVIN( vehicleTechRecords ) });
+        actions$ = hot('-a--', { a: getByVIN( vin ) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({
@@ -71,9 +71,9 @@ describe('TechnicalRecordServiceEffects', () => {
 
     it('should return not found error message if not found', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
-        const vehicleTechRecords = {vin: 'vin'};
+        const vin = {vin: 'vin'};
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVIN( vehicleTechRecords ) });
+        actions$ = hot('-a--', { a: getByVIN( vin ) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({

--- a/src/app/store/technical-records/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.spec.ts
@@ -37,17 +37,17 @@ describe('TechnicalRecordServiceEffects', () => {
   describe('getByVin$', () => {
     it('should return a technical record on successfull API call', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
-        const techicalRecord = mockVehicleTechnicalRecordList();
+        const technicalRecord = mockVehicleTechnicalRecordList();
 
         // mock action to trigger effect
         actions$ = hot('-a--', { a: getByVIN });
 
         // mock service call
-        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--a|', { a: techicalRecord }));
+        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--a|', { a: technicalRecord }));
 
         // expect effect to return success action
         expectObservable(effects.getByVin$).toBe('---b', {
-          b: getByVINSuccess({ vehicleTechRecords: techicalRecord })
+          b: getByVINSuccess({ vehicleTechRecords: technicalRecord })
         });
       });
     });

--- a/src/app/store/technical-records/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.spec.ts
@@ -85,5 +85,19 @@ describe('TechnicalRecordServiceEffects', () => {
         expectObservable(effects.getByVin$).toBe('---b', { b: getByVINFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
       });
     });
+
+    it('should return error message if error is a string', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vin = {vin: 'vin'};
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVIN( vin ) });
+
+        // mock service call
+        const expectedError = 'string';
+        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.getByVin$).toBe('---b', { b: getByVINFailure({ error: 'string', anchorLink: 'search-term' }) });
+      });
+    });
   });
 });

--- a/src/app/store/technical-records/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.spec.ts
@@ -1,6 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { mockVehicleTechnicalRecordList } from '@mocks/mock-vehicle-technical-record.mock';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -8,7 +9,7 @@ import { TechnicalRecordService } from '@services/technical-record/technical-rec
 import { initialAppState } from '@store/.';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { getByVIN, getByVINFailure } from './technical-record-service.actions';
+import { getByVIN, getByVINFailure, getByVINSuccess } from './technical-record-service.actions';
 import { TechnicalRecordServiceEffects } from './technical-record-service.effects';
 
 describe('TechnicalRecordServiceEffects', () => {
@@ -34,9 +35,26 @@ describe('TechnicalRecordServiceEffects', () => {
   });
 
   describe('return error messages', () => {
+    it('should return getByVIN action on successfull API call', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const testResults = mockVehicleTechnicalRecordList();
+
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVIN });
+
+        // mock service call
+        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--a|', { a: testResults }));
+
+        // expect effect to return success action
+        expectObservable(effects.getByVin$).toBe('---b', {
+          b: getByVINSuccess({ vehicleTechRecords: testResults })
+        });
+      });
+    });
+
     it('should return generic error message if not not found', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
-        const vehicleTechRecords = {vin: 'heuie'};
+        const vehicleTechRecords = {vin: 'vin'};
         // mock action to trigger effect
         actions$ = hot('-a--', { a: getByVIN( vehicleTechRecords ) });
 
@@ -53,7 +71,7 @@ describe('TechnicalRecordServiceEffects', () => {
 
     it('should return not found error message if not found', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
-        const vehicleTechRecords = {vin: 'heuie'};
+        const vehicleTechRecords = {vin: 'vin'};
         // mock action to trigger effect
         actions$ = hot('-a--', { a: getByVIN( vehicleTechRecords ) });
 

--- a/src/app/store/technical-records/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.spec.ts
@@ -1,0 +1,71 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { initialAppState } from '@store/.';
+import { Observable } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { getByVIN, getByVINFailure } from './technical-record-service.actions';
+import { TechnicalRecordServiceEffects } from './technical-record-service.effects';
+
+describe('TechnicalRecordServiceEffects', () => {
+  let effects: TechnicalRecordServiceEffects;
+  let actions$ = new Observable<Action>();
+  let testScheduler: TestScheduler;
+  let technicalRecordService: TechnicalRecordService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [TechnicalRecordServiceEffects, provideMockActions(() => actions$), TechnicalRecordService, provideMockStore({ initialState: initialAppState })]
+    });
+
+    effects = TestBed.inject(TechnicalRecordServiceEffects);
+    technicalRecordService = TestBed.inject(TechnicalRecordService);
+  });
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('return error messages', () => {
+    it('should return generic error message if not not found', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vehicleTechRecords = {vin: 'heuie'};
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVIN( vehicleTechRecords ) });
+
+        // mock service call
+        const expectedError = new HttpErrorResponse({
+          status: 500,
+          statusText: 'Internal server error'
+        });
+        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.getByVin$).toBe('---b', { b: getByVINFailure({ error: 'There was a problem getting the Tech Record by VIN', anchorLink: 'search-term' }) });
+      });
+    });
+
+    it('should return not found error message if not found', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vehicleTechRecords = {vin: 'heuie'};
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVIN( vehicleTechRecords ) });
+
+        // mock service call
+        const expectedError = new HttpErrorResponse({
+          status: 404,
+          statusText: 'Vehicle not found'
+        });
+        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.getByVin$).toBe('---b', { b: getByVINFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Ticket title

Added some extra unit tests for technical-record-service effects introduced in [PR 299](https://github.com/dvsa/cvs-app-vtm/pull/299). Insures the functionality in [CB2-3591](https://jira.dvsacloud.uk/browse/CB2-3591) is implemented.

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
