### PR TITLE
fix(cb2-3612): remove error message when no tests results found

### DIFF
--- a/src/app/store/spinner/reducers/spinner.reducer.spec.ts
+++ b/src/app/store/spinner/reducers/spinner.reducer.spec.ts
@@ -1,5 +1,6 @@
 import { spinnerReducer, initialSpinnerState } from '@store/spinner/reducers/spinner.reducer';
 import { getByVIN, getByVINFailure, getByVINSuccess } from '@store/technical-records';
+import  *  as TestResultsActions from '@store/test-records';
 
 describe('Spinner Reducer', () => {
 
@@ -37,4 +38,54 @@ describe('Spinner Reducer', () => {
       expect(state).not.toBe(expectedValue);
     });
   });
+
+  describe('Start Loading', () => {
+    it.each([TestResultsActions.fetchTestResultsBySystemId])('should start the loading state', (actionMethod) => {
+      const expectedValue = { ...initialSpinnerState, showSpinner: true };
+      const action = actionMethod({} as any);
+
+      const state = spinnerReducer(initialSpinnerState, action);
+
+      expect(state).toEqual(expectedValue);
+      expect(state).not.toBe(expectedValue);
+    });
+  });
+
+  describe('Stop Loading', () => {
+    it.each([TestResultsActions.fetchTestResultsBySystemIdFailed, TestResultsActions.fetchTestResultsBySystemIdSuccess])('should stop the loading state', (actionMethod) => {
+      const expectedValue = { ...initialSpinnerState, showSpinner: false };
+      const action = actionMethod({} as any);
+
+      const state = spinnerReducer(initialSpinnerState, action);
+
+      expect(state).toEqual(expectedValue);
+      expect(state).not.toBe(expectedValue);
+    });
+  });
+
+  describe('Start Loading', () => {
+    it.each([TestResultsActions.fetchTestResults])('should start the loading state', (actionMethod) => {
+      const expectedValue = { ...initialSpinnerState, showSpinner: true };
+      const action = actionMethod();
+
+      const state = spinnerReducer(initialSpinnerState, action);
+
+      expect(state).toEqual(expectedValue);
+      expect(state).not.toBe(expectedValue);
+    });
+  });
+
+  describe('Stop Loading', () => {
+    it.each([TestResultsActions.fetchTestResultsFailed, TestResultsActions.fetchTestResultsSuccess])('should stop the loading state', (actionMethod) => {
+      const expectedValue = { ...initialSpinnerState, showSpinner: false };
+      const action = actionMethod({} as any);
+
+      const state = spinnerReducer(initialSpinnerState, action);
+
+      expect(state).toEqual(expectedValue);
+      expect(state).not.toBe(expectedValue);
+    });
+  });
+
+
 });

--- a/src/app/store/spinner/reducers/spinner.reducer.ts
+++ b/src/app/store/spinner/reducers/spinner.reducer.ts
@@ -19,5 +19,9 @@ export const spinnerState = createSelector(getSpinnerState, (state) => state.sho
 export const spinnerReducer = createReducer(
   initialSpinnerState,
   on(TechnicalRecordServiceActions.getByVIN, (state) => ({ ...state, showSpinner: true })),
-  on(TechnicalRecordServiceActions.getByVINFailure, TechnicalRecordServiceActions.getByVINSuccess, (state) => ({ ...state, showSpinner: false }))
+  on(TechnicalRecordServiceActions.getByVINFailure, TechnicalRecordServiceActions.getByVINSuccess, (state) => ({ ...state, showSpinner: false })),
+  on(TestResultActions.fetchTestResultsBySystemId, (state) => ({...state, showSpinner: true})),
+  on(TestResultActions.fetchTestResultsBySystemIdFailed, TestResultActions.fetchTestResultsBySystemIdSuccess, (state) => ({...state, showSpinner: false})),
+  on(TestResultActions.fetchTestResults, (state) => ({...state, showSpinner: true})),
+  on(TestResultActions.fetchTestResultsFailed, TestResultActions.fetchTestResultsSuccess, (state) => ({...state, showSpinner: false}))
 );

--- a/src/app/store/spinner/reducers/spinner.reducer.ts
+++ b/src/app/store/spinner/reducers/spinner.reducer.ts
@@ -18,10 +18,10 @@ export const spinnerState = createSelector(getSpinnerState, (state) => state.sho
 
 export const spinnerReducer = createReducer(
   initialSpinnerState,
-  on(TechnicalRecordServiceActions.getByVIN, (state) => ({ ...state, showSpinner: true })),
-  on(TechnicalRecordServiceActions.getByVINFailure, TechnicalRecordServiceActions.getByVINSuccess, (state) => ({ ...state, showSpinner: false })),
-  on(TestResultActions.fetchTestResultsBySystemId, (state) => ({...state, showSpinner: true})),
-  on(TestResultActions.fetchTestResultsBySystemIdFailed, TestResultActions.fetchTestResultsBySystemIdSuccess, (state) => ({...state, showSpinner: false})),
-  on(TestResultActions.fetchTestResults, (state) => ({...state, showSpinner: true})),
-  on(TestResultActions.fetchTestResultsFailed, TestResultActions.fetchTestResultsSuccess, (state) => ({...state, showSpinner: false}))
+  on(TechnicalRecordServiceActions.getByVIN, TestResultActions.fetchTestResults, TestResultActions.fetchTestResultsBySystemId, (state) => ({ ...state, showSpinner: true })),
+  on(TechnicalRecordServiceActions.getByVINFailure, TechnicalRecordServiceActions.getByVINSuccess,
+     TestResultActions.fetchTestResultsBySystemIdFailed, TestResultActions.fetchTestResultsBySystemIdSuccess,
+     TestResultActions.fetchTestResultsFailed, TestResultActions.fetchTestResultsSuccess,
+      (state) => ({ ...state, showSpinner: false })
+  ),
 );

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -8,7 +8,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { initialAppState } from '@store/.';
 import { getByVINSuccess } from '@store/technical-records';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mockTestResultList } from '../../../../mocks/mock-test-result';
 import { fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsBySystemIdSuccess } from '../actions/test-records.actions';
@@ -67,6 +67,20 @@ describe('TestResultsEffects', () => {
         expectObservable(effects.fetchTestResultsBySystemNumber$).toBe('---b', { b: fetchTestResultsBySystemIdFailed({ error: 'Http failure response for (unknown url): 500 Internal server error' }) });
       });
     });
+
+    it('should return fetchTestResultsBySystemIdFailed action on API error', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        actions$ = hot('-a--', { a: fetchTestResultsBySystemId });
+
+        const expectedError = new HttpErrorResponse({
+          status: 404,
+          statusText: 'Not found'
+        });
+        jest.spyOn(testResultsService, 'fetchTestResultbySystemId').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.fetchTestResultsBySystemNumber$).toBe('---b', { b: fetchTestResultsBySystemIdFailed({ error: 'Http failure response for (unknown url): 404 Not found' }) });
+      });
+    });
   });
 
   describe('fetchTestResultsBySystemNumberAfterSearchByVinSucces$', () => {
@@ -87,7 +101,7 @@ describe('TestResultsEffects', () => {
       });
     });
 
-    it('should return fetchTestResultBySystemIdSuccess action', () => {
+    it('should return fetchTestResultsBySystemIdFailed', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vehicleTechRecords = [{ systemNumber: 'systemSumber' }] as VehicleTechRecordModel[];
         // mock action to trigger effect
@@ -101,6 +115,23 @@ describe('TestResultsEffects', () => {
         jest.spyOn(testResultsService, 'fetchTestResultbySystemId').mockReturnValue(cold('--#|', {}, expectedError));
 
         expectObservable(effects.fetchTestResultsBySystemNumberAfterSearchByVinSucces$).toBe('---b', { b: fetchTestResultsBySystemIdFailed({ error: 'Http failure response for (unknown url): 500 Internal server error' }) });
+      });
+    });
+
+    it('should not return fetchTestResultsBySystemIdFailed when not found a test record', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vehicleTechRecords = [{ systemNumber: 'systemSumber' }] as VehicleTechRecordModel[];
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVINSuccess({ vehicleTechRecords }) });
+
+        // mock service call
+        const expectedError = new HttpErrorResponse({
+          status: 404,
+          statusText: 'Not found'
+        });
+        jest.spyOn(testResultsService, 'fetchTestResultbySystemId').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.fetchTestResultsBySystemNumberAfterSearchByVinSucces$).toBe('');
       });
     });
   });

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -131,7 +131,9 @@ describe('TestResultsEffects', () => {
         });
         jest.spyOn(testResultsService, 'fetchTestResultbySystemId').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.fetchTestResultsBySystemNumberAfterSearchByVinSucces$).toBe('');
+        expectObservable(effects.fetchTestResultsBySystemNumberAfterSearchByVinSucces$).toBe('---b', {
+          b: fetchTestResultsBySystemIdSuccess({ payload: [] })
+        });
       });
     });
   });

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -8,7 +8,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { initialAppState } from '@store/.';
 import { getByVINSuccess } from '@store/technical-records';
-import { Observable, of } from 'rxjs';
+import { Observable} from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mockTestResultList } from '../../../../mocks/mock-test-result';
 import { fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsBySystemIdSuccess } from '../actions/test-records.actions';

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -8,7 +8,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { initialAppState } from '@store/.';
 import { getByVINSuccess } from '@store/technical-records';
-import { Observable} from 'rxjs';
+import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mockTestResultList } from '../../../../mocks/mock-test-result';
 import { fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsBySystemIdSuccess } from '../actions/test-records.actions';

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { getByVINSuccess } from '@store/technical-records';
-import { catchError, map, mergeMap, of } from 'rxjs';
+import { catchError, EMPTY, map, mergeMap, of } from 'rxjs';
 import { fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsBySystemIdSuccess } from '../actions/test-records.actions';
 
 @Injectable()
@@ -25,7 +25,13 @@ export class TestResultsEffects {
       mergeMap((action) =>
         this.testRecordsService.fetchTestResultbySystemId(action.vehicleTechRecords[0].systemNumber).pipe(
           map((vehicleTestRecords) => fetchTestResultsBySystemIdSuccess({ payload: vehicleTestRecords })),
-          catchError((e) => of(fetchTestResultsBySystemIdFailed({ error: e.message })))
+          catchError((e) => {
+            if (e.status != 404) {
+              return of(fetchTestResultsBySystemIdFailed({ error: e.message }))
+            } else {
+              return EMPTY
+            }
+          })
         )
       )
     )

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -29,7 +29,7 @@ export class TestResultsEffects {
             if (e.status != 404) {
               return of(fetchTestResultsBySystemIdFailed({ error: e.message }))
             } else {
-              return EMPTY
+              return of(fetchTestResultsBySystemIdSuccess({payload: []}))
             }
           })
         )

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { getByVINSuccess } from '@store/technical-records';
-import { catchError, EMPTY, map, mergeMap, of } from 'rxjs';
+import { catchError, map, mergeMap, of } from 'rxjs';
 import { fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsBySystemIdSuccess } from '../actions/test-records.actions';
 
 @Injectable()


### PR DESCRIPTION
## CB2-3612 showing wrong error record with no test records

_Removing the error message for valid VINs with no test records when searching by VIN_
Also added the spinner when searching for test records
[CB2-3612](https://dvsa.atlassian.net/browse/CB2-3612)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
