### PR TITLE
CB2-3871: Fixed Spinner On No Test Results

### DIFF
--- a/src/app/store/spinner/reducers/spinner.reducer.ts
+++ b/src/app/store/spinner/reducers/spinner.reducer.ts
@@ -1,6 +1,7 @@
 import { createFeatureSelector, createReducer, createSelector, on } from '@ngrx/store';
 import * as TechnicalRecordServiceActions from '../../technical-records/technical-record-service.actions';
 import * as TestResultActions from '@store/test-records';
+import { fetchTestResultsBySystemIdSuccess } from '@store/test-records';
 
 export const STORE_SPINNER_KEY = 'Spinner';
 
@@ -19,7 +20,7 @@ export const spinnerState = createSelector(getSpinnerState, (state) => state.sho
 export const spinnerReducer = createReducer(
   initialSpinnerState,
   on(TechnicalRecordServiceActions.getByVIN, TestResultActions.fetchTestResults, TestResultActions.fetchTestResultsBySystemId, (state) => ({ ...state, showSpinner: true })),
-  on(TechnicalRecordServiceActions.getByVINFailure, TechnicalRecordServiceActions.getByVINSuccess,
+  on(TechnicalRecordServiceActions.getByVINFailure,
      TestResultActions.fetchTestResultsBySystemIdFailed, TestResultActions.fetchTestResultsBySystemIdSuccess,
      TestResultActions.fetchTestResultsFailed, TestResultActions.fetchTestResultsSuccess,
       (state) => ({ ...state, showSpinner: false })


### PR DESCRIPTION
## https://dvsa.atlassian.net/browse/CB2-3871

The spinner would deploy when searching for a technical record but would not remain when searching for the test records.
This would then show the technical records but no test results which later would become populated without any notification to the user.

This change removes the spinner listening to the on success of get by vin, this is because the test results has an effect on the getByVinSuccess so its better to have that effect to reverse the state.
