### PR TITLE
refactor(cb2-3354): refactoring dynamic template

### DIFF
--- a/src/app/features/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record-summary/tech-record-summary.component.html
@@ -1,5 +1,6 @@
 <section>
   <app-dynamic-form-group *ngIf="template" [template]="template" [data]="currentRecord" class="govuk-summary-list"></app-dynamic-form-group>
+  <app-dynamic-form-group *ngIf="approvalTypeTemplate" [template]="approvalTypeTemplate" [data]="currentRecord" class="govuk-summary-list"></app-dynamic-form-group>
   <app-dynamic-form-group *ngIf="brakeTemplate" [template]="brakeTemplate" [data]="currentBrakeRecord" class="govuk-summary-list"></app-dynamic-form-group>
   <app-dynamic-form-group *ngIf="brakeTemplateWheelsNotLocked" [template]="brakeTemplateWheelsNotLocked" [data]="currentBrakeRecord" class="govuk-summary-list"></app-dynamic-form-group>
   <app-dynamic-form-group *ngIf="brakeTemplateWheelsHalfLocked" [template]="brakeTemplateWheelsHalfLocked" [data]="currentBrakeRecord" class="govuk-summary-list"></app-dynamic-form-group>

--- a/src/app/features/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record-summary/tech-record-summary.component.ts
@@ -7,6 +7,7 @@ import { FormNode } from '../../forms/services/dynamic-form.types';
 import { PsvBrakeSection } from '@forms/templates/psv/psv-brake.template';
 import { PsvBrakeSectionWheelsNotLocked } from '@forms/templates/psv/psv-brake-wheels-not-locked.template';
 import { PsvBrakeSectionWheelsHalfLocked } from '@forms/templates/psv/psv-brake-wheels-half-locked.template';
+import { PsvApprovalTypeSection } from '@forms/templates/psv/psv-approval-type.template';
 
 @Component({
   selector: 'app-tech-record-summary',
@@ -20,14 +21,14 @@ export class TechRecordSummaryComponent implements OnInit {
   brakeTemplate!: FormNode;
   brakeTemplateWheelsNotLocked!: FormNode;
   brakeTemplateWheelsHalfLocked!: FormNode;
+  approvalTypeTemplate!: FormNode;
   currentRecord?: TechRecordModel;
   currentBrakeRecord?: Brakes;
-
 
   ngOnInit(): void {
     this.vehicleTemplate();
     this.currentRecord = this.viewableTechRecord(this.vehicleTechRecord);
-    this.currentBrakeRecord = this.currentRecord?.brakes
+    this.currentBrakeRecord = this.currentRecord?.brakes;
   }
 
   constructor() {}
@@ -58,6 +59,7 @@ export class TechRecordSummaryComponent implements OnInit {
     switch (viewableRecord?.vehicleType) {
       case 'psv': {
         this.template = PsvTechRecord;
+        this.approvalTypeTemplate = PsvApprovalTypeSection;
         this.brakeTemplate = PsvBrakeSection;
         this.brakeTemplateWheelsNotLocked = PsvBrakeSectionWheelsNotLocked;
         this.brakeTemplateWheelsHalfLocked = PsvBrakeSectionWheelsHalfLocked;

--- a/src/app/forms/templates/psv/psv-approval-type.template.ts
+++ b/src/app/forms/templates/psv/psv-approval-type.template.ts
@@ -1,0 +1,51 @@
+import { FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
+
+export const PsvApprovalTypeSection: FormNode = {
+  name: 'approvalSection',
+  label: 'Type approval',
+  type: FormNodeTypes.GROUP,
+  viewType: FormNodeViewTypes.SUBHEADING,
+  children: [
+    {
+      name: 'approvalType',
+      label: 'Approval type',
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'approvalTypeNumber',
+      label: 'Approval type tumber',
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'ntaNumber',
+      label: 'National type number',
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'coifSerialNumber',
+      label: 'COIF Serial number',
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'coifCertifierName',
+      label: 'COIF Certifier name',
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'coifDate',
+      label: 'COIF Certifier date',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.DATE
+    },
+    {
+      name: 'variantNumber',
+      label: 'Variant number',
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'variantVersionNumber',
+      label: 'Variant version number',
+      type: FormNodeTypes.CONTROL
+    }
+  ]
+};

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -205,52 +205,6 @@ export const PsvTechRecord: FormNode = {
 
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.STRING
-    },
-    {
-      name: 'approvalSection',
-      label: 'Type approval',
-      type: FormNodeTypes.SECTION
-    },
-    {
-      name: 'approvalType',
-      label: 'Approval type',
-      type: FormNodeTypes.CONTROL
-    },
-    {
-      name: 'approvalTypeNumber',
-      label: 'Approval type tumber',
-      type: FormNodeTypes.CONTROL
-    },
-    {
-      name: 'ntaNumber',
-      label: 'National type number',
-      type: FormNodeTypes.CONTROL
-    },
-    {
-      name: 'coifSerialNumber',
-      label: 'COIF Serial number',
-      type: FormNodeTypes.CONTROL
-    },
-    {
-      name: 'coifCertifierName',
-      label: 'COIF Certifier name',
-      type: FormNodeTypes.CONTROL
-    },
-    {
-      name: 'coifDate',
-      label: 'COIF Certifier date',
-      type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.DATE
-    },
-    {
-      name: 'variantNumber',
-      label: 'Variant number',
-      type: FormNodeTypes.CONTROL
-    },
-    {
-      name: 'variantVersionNumber',
-      label: 'Variant version number',
-      type: FormNodeTypes.CONTROL
     }
   ]
 };


### PR DESCRIPTION
## Viewing Type Approval section of PSV Tech Record

Refactoring to use a separate dynamic form template for the _type approval_ section created in [#317](https://github.com/dvsa/cvs-app-vtm/pull/317). Following the current direction to use multiple dynamic form templates, as in [#315](https://github.com/dvsa/cvs-app-vtm/pull/315) and [#316](https://github.com/dvsa/cvs-app-vtm/pull/316).

[CB2-3354](https://dvsa.atlassian.net/browse/CB2-3354)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
