### PR TITLE
fix(cb2-4023): fixes sonarqube code coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "npm run config -- --environment=dev && ng serve",
     "build": "ng build --build-optimizer --delete-output-path --optimization --progress --vendor-chunk --aot",
     "watch": "ng build --watch",
-    "sonar-scanner": "sonar-scanner",
+    "sonar-scanner": "npm run test && sonar-scanner",
     "security-checks": "git secrets --scan",
     "lint": "npx eslint 'src/**/*.{js,jsx,ts,tsx,html,css,scss}'",
     "format": "npx prettier 'src/**/*.{js,jsx,ts,tsx,html,css,scss}' --write",


### PR DESCRIPTION
## CB2-4023 - SonarQube code coverage metrics aren't being reported

SonarQube (`sonar-scanner`) requires the output of unit test code coverage, and the deployment pipeline doesn't explicitly run the unit tests first.

[CB2-4023](https://dvsa.atlassian.net/browse/CB2-4023)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [x] Delete branch after merge
