### PR TITLE
fix(cb2-4023): change sonar lcov report path

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,4 +16,4 @@ sonar.sources=src/app
 sonar.exclusions=test-config/**, cypress/**, dist/**, .nyc_output/**, .scannerwork/**, coverage/**, **/*.module.ts, **/*.routes.ts, **/*.state.ts, **/utils.ts
 sonar.test.inclusions=**/*.spec.ts
 sonar.tslint.reportPaths=.reports/lint_issues.json
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/cvs-app-vtm/lcov.info


### PR DESCRIPTION
## Resolve sonar code coverage being zero

SonarQube is currently showing 0% code coverage, this was previously an issue with the lcov.info report file not being produced, this PR resolves the path to that `lcov.info` file as the pipelines were unable to find it as the coverage directory was not the usual `/coverage/lcov.info`.

Jenkins Error:
![image](https://user-images.githubusercontent.com/92087051/170459887-ee41bfda-d42e-432f-8396-efe6efe63e67.png)

Report file location:
![image](https://user-images.githubusercontent.com/92087051/170459466-2819c9b7-987b-4082-9f8f-99679bc8df87.png)
![image](https://user-images.githubusercontent.com/92087051/170459534-174d92cc-31e3-4aa2-a81a-14083ffebd9c.png)


## Checklist

- [X] Branch is rebased against the latest develop/common
- [X] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [X] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [X] Delete branch after merge
