### PR TITLE
fix(cb2-4134): removes odometer from trailer test results

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/trl-annual.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/trl-annual.template.ts
@@ -46,32 +46,6 @@ export const TrlAnnual: FormNode = {
       type: FormNodeTypes.CONTROL
     },
     {
-      name: 'odometerCombination',
-      label: 'Odometer',
-      type: FormNodeTypes.COMBINATION,
-      options: {
-        leftComponentName: 'odometerReading',
-        rightComponentName: 'odometerReadingUnits',
-        separator: ' '
-      }
-    },
-    {
-      name: 'odometerReading',
-      label: 'Odometer Reading',
-      value: '',
-
-      type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.HIDDEN
-    },
-    {
-      name: 'odometerReadingUnits',
-      label: 'Odometer Reading Units',
-      value: '',
-
-      type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.HIDDEN
-    },
-    {
       name: 'preparerCombination',
       label: 'Preparer',
       type: FormNodeTypes.COMBINATION,


### PR DESCRIPTION
## Removes odometer fields from trailer test results

[https://dvsa.atlassian.net/browse/CB2-4134](CB2-4134)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [x] Delete branch after merge
