### PR TITLE
CB2-396: added semi long trailer to enum

### DIFF
--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -58,7 +58,8 @@ export enum VehicleConfigurations {
   DRAWBAR = 'drawbar',
   FOUR_IN_LINE = 'four-in-line',
   DOLLY = 'dolly',
-  FULL_DRAWBAR = 'full drawbar'
+  FULL_DRAWBAR = 'full drawbar',
+  LONG_SEMI_TRAILER = 'long semi-trailer'
 }
 
 export enum FrameDescriptions {


### PR DESCRIPTION
Feature to add the semi long trailer type for [techRecord].vehicleConfiguration field


@andrewf-bjss  to confirm this is the correct branch to merge into please.