### PR TITLE
feat(cb2-4224): prevent HTML-compatible "number" inputs 

### DIFF
--- a/src/app/forms/components/autocomplete/autocomplete.component.ts
+++ b/src/app/forms/components/autocomplete/autocomplete.component.ts
@@ -19,7 +19,7 @@ import { BaseControlComponent } from '../base-control/base-control.component';
   ]
 })
 export class AutocompleteComponent extends BaseControlComponent implements OnInit {
-  @Input() options: String[] = [];
+  @Input() options: string[] = [];
 
   constructor(injector: Injector, @Inject(DOCUMENT) private document: Document) {
     super(injector)

--- a/src/app/forms/components/autocomplete/autocomplete.component.ts
+++ b/src/app/forms/components/autocomplete/autocomplete.component.ts
@@ -4,12 +4,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import accessibleAutocomplete from 'accessible-autocomplete/dist/accessible-autocomplete.min';
 import { BaseControlComponent } from '../base-control/base-control.component';
 
-
-
 @Component({
   selector: 'app-autocomplete',
   templateUrl: './autocomplete.component.html',
-  styleUrls: ['./autocomplete.component.scss'],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -22,19 +19,18 @@ export class AutocompleteComponent extends BaseControlComponent implements OnIni
   @Input() options: string[] = [];
 
   constructor(injector: Injector, @Inject(DOCUMENT) private document: Document) {
-    super(injector)
+    super(injector);
   }
 
   ngOnInit(): void {
     this.name = this.name || 'autocomplete';
     accessibleAutocomplete({
       element: this.document.querySelector('#' + this.name + '-wrapper'),
-      id: `${ this.name }-autocomplete`, //this matches the relevant label
+      id: `${this.name}-autocomplete`, //this matches the relevant label
       source: this.options, //this needs an array of values to have in the search box otherwise you'll get no results found
-      onConfirm: (value)=>this.onChange(value),
+      onConfirm: (value) => this.onChange(value),
       confirmOnBlur: false,
       required: true
     });
-
   }
 }

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
@@ -5,6 +5,14 @@
         <app-autocomplete [label]="control.value.meta.label" [id]="control.value.meta.name + '-wrapper'" [name]="control.value.meta.name" [options]="options" [formControlName]="control.key"> </app-autocomplete>
       </ng-container>
 
+      <ng-container *ngSwitchCase="formNodeEditTypes.NUMBER">
+        <app-number-input [label]="control.value.meta.label" [name]="control.value.meta.name" [formControlName]="control.key"></app-number-input>
+      </ng-container>
+
+      <ng-container *ngSwitchCase="formNodeEditTypes.TEXTAREA">
+        <app-text-area [label]="control.value.meta.label" [name]="control.value.meta.name" [formControlName]="control.key"></app-text-area>
+      </ng-container>
+
       <ng-container *ngSwitchDefault>
         <app-text-input [label]="control.value.meta.label" [name]="control.value.meta.name" [formControlName]="control.key"></app-text-input>
       </ng-container>

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
@@ -1,0 +1,13 @@
+<ng-container [formGroup]="form">
+  <ng-container *ngIf="control">
+    <ng-container [ngSwitch]="control.value.meta.editType">
+      <ng-container *ngSwitchCase="formNodeEditTypes.AUTOCOMPLETE">
+        <app-autocomplete [label]="control.value.meta.label" [id]="control.value.meta.name + '-wrapper'" [name]="control.value.meta.name" [options]="options" [formControlName]="control.key"> </app-autocomplete>
+      </ng-container>
+
+      <ng-container *ngSwitchDefault>
+        <app-text-input [label]="control.value.meta.label" [name]="control.value.meta.name" [formControlName]="control.key"></app-text-input>
+      </ng-container>
+    </ng-container>
+  </ng-container>
+</ng-container>

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.spec.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DynamicFormFieldComponent } from './dynamic-form-field.component';
+
+describe('DynamicFormFieldComponent', () => {
+  let component: DynamicFormFieldComponent;
+  let fixture: ComponentFixture<DynamicFormFieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DynamicFormFieldComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DynamicFormFieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -1,0 +1,26 @@
+import { KeyValue } from '@angular/common';
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { CustomFormControl, FormNode, FormNodeEditTypes } from '@forms/services/dynamic-form.types';
+
+@Component({
+  selector: 'app-dynamic-form-field',
+  templateUrl: './dynamic-form-field.component.html',
+  styleUrls: ['./dynamic-form-field.component.scss']
+})
+export class DynamicFormFieldComponent {
+  @Input() control?: KeyValue<string, CustomFormControl>;
+  @Input() form: FormGroup = {} as FormGroup;
+  constructor() { }
+
+
+
+  get formNodeEditTypes(): typeof FormNodeEditTypes {
+    return FormNodeEditTypes;
+  }
+
+  get options(): string[] {
+    return (this.control?.value.meta.options as string[]) || [];
+  }
+
+}

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -5,15 +5,12 @@ import { CustomFormControl, FormNode, FormNodeEditTypes } from '@forms/services/
 
 @Component({
   selector: 'app-dynamic-form-field',
-  templateUrl: './dynamic-form-field.component.html',
-  styleUrls: ['./dynamic-form-field.component.scss']
+  templateUrl: './dynamic-form-field.component.html'
 })
 export class DynamicFormFieldComponent {
   @Input() control?: KeyValue<string, CustomFormControl>;
   @Input() form: FormGroup = {} as FormGroup;
-  constructor() { }
-
-
+  constructor() {}
 
   get formNodeEditTypes(): typeof FormNodeEditTypes {
     return FormNodeEditTypes;
@@ -22,5 +19,4 @@ export class DynamicFormFieldComponent {
   get options(): string[] {
     return (this.control?.value.meta.options as string[]) || [];
   }
-
 }

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
@@ -44,7 +44,7 @@
   <ng-container [formGroup]="formGroup">
     <ng-container *ngIf="control.value.meta && !control.value.meta.hide" [ngSwitch]="edit">
       <app-view-list-item *ngSwitchCase="false" [label]="control.value.meta.label" [name]="control.value.meta.name" [viewType]="control.value.meta.viewType" [formControlName]="control.key" class="govuk-summary-list"></app-view-list-item>
-      <app-text-input *ngSwitchCase="true" [label]="control.value.meta.label" [name]="control.value.meta.name" [viewType]="control.value.meta.viewType" [formControlName]="control.key"></app-text-input>
+      <app-dynamic-form-field *ngSwitchCase="true" [control]="control" [form]="formGroup"></app-dynamic-form-field>
     </ng-container>
   </ng-container>
 </ng-template>

--- a/src/app/forms/components/number-input/number-input.component.html
+++ b/src/app/forms/components/number-input/number-input.component.html
@@ -4,5 +4,5 @@
   </h1>
   <p *ngIf="errorMessage" id="{{ name }}-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> {{ errorMessage }}</p>
   <div *ngIf="hint" id="{{ name }}-hint" class="govuk-hint">{{ hint }}</div>
-  <input class="govuk-input" id="{{ name }}" name="{{ name }}" type="number" [(ngModel)]="value" [disabled]="disabled ?? false" (ngModelChange)="onChange($event)" (blur)="onTouched(); handleEvent($event)" (focus)="handleEvent($event)" />
+  <input class="govuk-input" id="{{ name }}" name="{{ name }}" type="number" [(ngModel)]="value" [disabled]="disabled ?? false" (ngModelChange)="onChange($event)" (blur)="onTouched(); handleEvent($event)" (focus)="handleEvent($event)" appNumberOnly />
 </div>

--- a/src/app/forms/components/number-input/number-input.component.html
+++ b/src/app/forms/components/number-input/number-input.component.html
@@ -1,0 +1,8 @@
+<div class="govuk-form-group">
+  <h1 *ngIf="label" class="govuk-label-wrapper">
+    <label class="govuk-label govuk-label--m" for="{{ name }}">{{ label }}</label>
+  </h1>
+  <p *ngIf="errorMessage" id="{{ name }}-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> {{ errorMessage }}</p>
+  <div *ngIf="hint" id="{{ name }}-hint" class="govuk-hint">{{ hint }}</div>
+  <input class="govuk-input" id="{{ name }}" name="{{ name }}" type="number" [(ngModel)]="value" [disabled]="disabled ?? false" (ngModelChange)="onChange($event)" (blur)="onTouched(); handleEvent($event)" (focus)="handleEvent($event)" />
+</div>

--- a/src/app/forms/components/number-input/number-input.component.spec.ts
+++ b/src/app/forms/components/number-input/number-input.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NumberInputComponent } from './number-input.component';
+
+describe('NumberInputComponent', () => {
+  let component: NumberInputComponent;
+  let fixture: ComponentFixture<NumberInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ NumberInputComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NumberInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/forms/components/number-input/number-input.component.spec.ts
+++ b/src/app/forms/components/number-input/number-input.component.spec.ts
@@ -1,20 +1,34 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { FormGroup } from '@angular/forms';
+import { CustomFormControl, FormNodeTypes } from '../../services/dynamic-form.types';
 import { NumberInputComponent } from './number-input.component';
 
+@Component({
+  selector: 'app-host-component',
+  template: `<form [formGroup]="form">
+    <app-text-input name="foo" formControlName="foo"></app-text-input>
+  </form> `,
+  styles: []
+})
+class HostComponent {
+  form = new FormGroup({
+    foo: new CustomFormControl({ name: 'foo', type: FormNodeTypes.CONTROL, children: [] }, '')
+  });
+}
+
 describe('NumberInputComponent', () => {
-  let component: NumberInputComponent;
-  let fixture: ComponentFixture<NumberInputComponent>;
+  let component: HostComponent;
+  let fixture: ComponentFixture<HostComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ NumberInputComponent ]
-    })
-    .compileComponents();
+      declarations: [NumberInputComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(NumberInputComponent);
+    fixture = TestBed.createComponent(HostComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/forms/components/number-input/number-input.component.ts
+++ b/src/app/forms/components/number-input/number-input.component.ts
@@ -1,0 +1,20 @@
+import { Component, Injector } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { BaseControlComponent } from '../base-control/base-control.component';
+
+@Component({
+  selector: 'app-number-input',
+  templateUrl: './number-input.component.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: NumberInputComponent,
+      multi: true
+    }
+  ]
+})
+export class NumberInputComponent extends BaseControlComponent {
+  constructor(injector: Injector) {
+    super(injector);
+  }
+}

--- a/src/app/forms/components/text-area/text-area.component.html
+++ b/src/app/forms/components/text-area/text-area.component.html
@@ -1,0 +1,8 @@
+<div class="govuk-form-group">
+  <h1 *ngIf="label" class="govuk-label-wrapper">
+    <label class="govuk-label govuk-label--m" for="{{ name }}">{{ label }}</label>
+  </h1>
+  <p *ngIf="errorMessage" id="{{ name }}-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> {{ errorMessage }}</p>
+  <div *ngIf="hint" id="{{ name }}-hint" class="govuk-hint">{{ hint }}</div>
+  <textarea class="govuk-textarea" rows="5" id="{{ name }}" name="{{ name }}" type="text" [(ngModel)]="value" [disabled]="disabled ?? false" (ngModelChange)="onChange($event)" (blur)="onTouched(); handleEvent($event)" (focus)="handleEvent($event)"></textarea>
+</div>

--- a/src/app/forms/components/text-area/text-area.component.spec.ts
+++ b/src/app/forms/components/text-area/text-area.component.spec.ts
@@ -2,12 +2,12 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup } from '@angular/forms';
 import { CustomFormControl, FormNodeTypes } from '../../services/dynamic-form.types';
-import { NumberInputComponent } from './number-input.component';
+import { TextAreaComponent } from './text-area.component';
 
 @Component({
   selector: 'app-host-component',
   template: `<form [formGroup]="form">
-    <app-number-input name="foo" formControlName="foo"></app-number-input>
+    <app-text-area name="foo" formControlName="foo"></app-text-area>
   </form> `,
   styles: []
 })
@@ -17,13 +17,13 @@ class HostComponent {
   });
 }
 
-describe('NumberInputComponent', () => {
+describe('TextAreaComponent', () => {
   let component: HostComponent;
   let fixture: ComponentFixture<HostComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [NumberInputComponent]
+      declarations: [TextAreaComponent]
     }).compileComponents();
   });
 

--- a/src/app/forms/components/text-area/text-area.component.ts
+++ b/src/app/forms/components/text-area/text-area.component.ts
@@ -1,0 +1,20 @@
+import { Component, Injector } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { BaseControlComponent } from '../base-control/base-control.component';
+
+@Component({
+  selector: 'app-text-area',
+  templateUrl: './text-area.component.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: TextAreaComponent,
+      multi: true
+    }
+  ]
+})
+export class TextAreaComponent extends BaseControlComponent {
+  constructor(injector: Injector) {
+    super(injector);
+  }
+}

--- a/src/app/forms/directives/app-number-only.directive.spec.ts
+++ b/src/app/forms/directives/app-number-only.directive.spec.ts
@@ -1,0 +1,40 @@
+import { Component, DebugElement, ElementRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { NumberOnlyDirective } from './app-number-only.directive';
+
+@Component({
+  template: ` <input type="number" appNumberOnly />`
+})
+class TestComponent {}
+
+describe('NumberOnlyDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    fixture = TestBed.configureTestingModule({
+      declarations: [NumberOnlyDirective, TestComponent],
+      imports: [ReactiveFormsModule]
+    }).createComponent(TestComponent);
+    fixture.detectChanges();
+
+    input = fixture.debugElement.query(By.directive(NumberOnlyDirective)).nativeElement;
+  });
+  it('should create an instance', () => {
+    expect(input).toBeTruthy();
+  });
+
+  it('should prevent default event behaviour if a prohibited key is pressed', () => {
+    const $event = new KeyboardEvent('keydown', { key: 'e', cancelable: true });
+    expect(input.dispatchEvent($event)).toBe(false);
+    expect($event.defaultPrevented).toBe(true);
+  });
+
+  it('should not prevent default event behaviour if a prohibited key is pressed', () => {
+    const $event = new KeyboardEvent('keydown', { key: '6', cancelable: true });
+    expect(input.dispatchEvent($event)).toBe(true);
+    expect($event.defaultPrevented).toBe(false);
+  });
+});

--- a/src/app/forms/directives/app-number-only.directive.ts
+++ b/src/app/forms/directives/app-number-only.directive.ts
@@ -1,0 +1,20 @@
+import { Directive, ElementRef, HostListener, OnChanges, SimpleChanges } from '@angular/core';
+
+@Directive({
+  selector: '[appNumberOnly]'
+})
+export class NumberOnlyDirective {
+  inputElement: HTMLInputElement;
+
+  constructor(public el: ElementRef) {
+    this.inputElement = el.nativeElement;
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeyDown(e: KeyboardEvent): void {
+    const exclude = ['+', '-', 'e', '.'];
+    if (exclude.includes(e.key)) {
+      e.preventDefault();
+    }
+  }
+}

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -14,9 +14,12 @@ import { TextInputComponent } from './components/text-input/text-input.component
 import { ViewCombinationComponent } from './components/view-combination/view-combination.component';
 import { ViewListItemComponent } from './components/view-list-item/view-list-item.component';
 import { DynamicFormFieldComponent } from './components/dynamic-form-field/dynamic-form-field.component';
+import { NumberInputComponent } from './components/number-input/number-input.component';
+import { TextAreaComponent } from './components/text-area/text-area.component';
+
 @NgModule({
-  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, NumberInputComponent, DynamicFormFieldComponent],
+  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent, NumberInputComponent, TextAreaComponent],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
-  exports: [TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent]
+  exports: [TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent, NumberInputComponent]
 })
 export class DynamicFormsModule {}

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -13,10 +13,11 @@ import { RadioGroupComponent } from './components/radio-group/radio-group.compon
 import { TextInputComponent } from './components/text-input/text-input.component';
 import { ViewCombinationComponent } from './components/view-combination/view-combination.component';
 import { ViewListItemComponent } from './components/view-list-item/view-list-item.component';
+import { DynamicFormFieldComponent } from './components/dynamic-form-field/dynamic-form-field.component';
 
 @NgModule({
-  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent],
+  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
-  exports: [TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent]
+  exports: [TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent]
 })
 export class DynamicFormsModule {}

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -16,9 +16,10 @@ import { ViewListItemComponent } from './components/view-list-item/view-list-ite
 import { DynamicFormFieldComponent } from './components/dynamic-form-field/dynamic-form-field.component';
 import { NumberInputComponent } from './components/number-input/number-input.component';
 import { TextAreaComponent } from './components/text-area/text-area.component';
+import { NumberOnlyDirective } from './directives/app-number-only.directive';
 
 @NgModule({
-  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent, NumberInputComponent, TextAreaComponent],
+  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent, NumberInputComponent, TextAreaComponent, NumberOnlyDirective],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
   exports: [TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent, NumberInputComponent]
 })

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -14,9 +14,8 @@ import { TextInputComponent } from './components/text-input/text-input.component
 import { ViewCombinationComponent } from './components/view-combination/view-combination.component';
 import { ViewListItemComponent } from './components/view-list-item/view-list-item.component';
 import { DynamicFormFieldComponent } from './components/dynamic-form-field/dynamic-form-field.component';
-
 @NgModule({
-  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent],
+  declarations: [BaseControlComponent, TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, NumberInputComponent, DynamicFormFieldComponent],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
   exports: [TextInputComponent, ViewListItemComponent, DynamicFormGroupComponent, ViewCombinationComponent, CheckboxGroupComponent, RadioGroupComponent, DefectComponent, DefectsComponent, AutocompleteComponent, DynamicFormFieldComponent]
 })

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -19,6 +19,12 @@ export enum FormNodeTypes {
   COMBINATION = 'combination'
 }
 
+export enum FormNodeEditTypes {
+  TEXT = 'text',
+  AUTOCOMPLETE = 'autocomplete',
+  NUMBER = 'number'
+}
+
 export interface FormNodeOption<T> {
   value: T;
   label: string;
@@ -29,10 +35,11 @@ export interface FormNode {
   children?: FormNode[];
   type: FormNodeTypes; // maybe updateType?
   viewType?: FormNodeViewTypes;
+  editType?: FormNodeEditTypes;
   label?: string;
   value?: string;
   path?: string;
-  options?: FormNodeOption<string | number | boolean>[] | FormNodeCombinationOptions;
+  options?: FormNodeOption<string | number | boolean>[] | FormNodeCombinationOptions | string[];
   validators?: { name: string; args?: any }[];
   disabled?: boolean;
   readonly?: boolean;

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -22,7 +22,8 @@ export enum FormNodeTypes {
 export enum FormNodeEditTypes {
   TEXT = 'text',
   AUTOCOMPLETE = 'autocomplete',
-  NUMBER = 'number'
+  NUMBER = 'number',
+  TEXTAREA = 'textarea'
 }
 
 export interface FormNodeOption<T> {

--- a/src/app/forms/templates/test-records/section-templates/notes/notes-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/notes/notes-section.template.ts
@@ -1,4 +1,4 @@
-import { FormNode, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
 
 export const NotesSection: FormNode = {
   name: 'notesSection',
@@ -9,7 +9,8 @@ export const NotesSection: FormNode = {
     {
       name: 'additionalNotesRecorded',
       label: 'Additional Notes',
-      type: FormNodeTypes.CONTROL
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.TEXTAREA
     }
   ]
 };

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
@@ -49,6 +49,8 @@ export const VehicleSectionDefaultPsvHgv: FormNode = {
       name: 'odometerReading',
       label: 'Odometer Reading',
       value: '',
+      validators: [{ name: 'numeric' }, { name: 'required' }],
+      editType: FormNodeEditTypes.NUMBER,
 
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
@@ -1,4 +1,4 @@
-import { FormNode, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
 
 export const VehicleSectionDefaultPsvHgv: FormNode = {
   name: 'vehicleSection',
@@ -24,6 +24,7 @@ export const VehicleSectionDefaultPsvHgv: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
 
       type: FormNodeTypes.CONTROL
     },

--- a/src/app/forms/validators/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators.spec.ts
@@ -100,9 +100,9 @@ describe('numeric', () => {
     [null, 123456789],
     [null, 0],
     [null, ''],
-    [{ customPattern: { message: 'must be a number' } }, 'foobar'],
-    [{ customPattern: { message: 'must be a number' } }, '123456bar'],
-    [{ customPattern: { message: 'must be a number' } }, 'foo123456'],
+    [{ customPattern: { message: 'must be a whole number' } }, 'foobar'],
+    [{ customPattern: { message: 'must be a whole number' } }, '123456bar'],
+    [{ customPattern: { message: 'must be a whole number' } }, 'foo123456'],
     [null, '123546789'],
     [null, null]
   ])('should return %o for %r', (expected: null | CustomPatternMessage, input: any) => {

--- a/src/app/forms/validators/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators.spec.ts
@@ -103,7 +103,8 @@ describe('numeric', () => {
     [{ customPattern: { message: 'must be a number' } }, 'foobar'],
     [{ customPattern: { message: 'must be a number' } }, '123456bar'],
     [{ customPattern: { message: 'must be a number' } }, 'foo123456'],
-    [null, '123546789']
+    [null, '123546789'],
+    [null, null]
   ])('should return %o for %r', (expected: null | CustomPatternMessage, input: any) => {
     const numberValidator = CustomValidators.numeric();
     expect(numberValidator(new FormControl(input))).toEqual(expected);
@@ -115,7 +116,8 @@ describe('customPattern', () => {
     [null, 123456789, '.*', 'this should always pass'],
     [null, 'jkl', 'c*', 'this should be a character'],
     [{ customPattern: { message: 'this should not be a number' } }, 123456789, '\\D+', 'this should not be a number'],
-    [null, '%^', '^\\W+$', 'this should be a symbol']
+    [null, '%^', '^\\W+$', 'this should be a symbol'],
+    [null, null, '.*', 'pass on null']
   ])('should return %o for %r', (expected: null | CustomPatternMessage, input: any, regex: string, msg: string) => {
     const customPattern = CustomValidators.customPattern([regex, msg]);
     const validation = customPattern(new FormControl(input));

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -54,7 +54,7 @@ export class CustomValidators {
   };
 
   static numeric(): ValidatorFn {
-    return this.customPattern(['^\\d*$', 'must be a number']);
+    return this.customPattern(['^\\d*$', 'must be a whole number']);
   }
 
   static customPattern([regEx, message]: string[]): ValidatorFn {

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -59,6 +59,9 @@ export class CustomValidators {
 
   static customPattern([regEx, message]: string[]): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
+      if (!control.value) {
+        return null;
+      }
       const valid = new RegExp(regEx).test(control.value);
       return valid ? null : { customPattern: { message } };
     };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,3 +2,7 @@
 .section {
   margin-top: 1rem;
 }
+
+.autocomplete__wrapper {
+  margin-bottom: 30px;
+}


### PR DESCRIPTION
## Create number input component

_After creating the number input component, it was found the HTML element allows values such as `e`, `+`, `-` and `.` in the number input by default_
[CB2-4224](https://dvsa.atlassian.net/browse/CB2-4224)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
