### PR TITLE
bugfix(CB2-4243): Fix the Header Sign Out Link

### DIFF
--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -8,7 +8,7 @@
       </div>
       <div class="govuk-grid-column-one-half govuk-!-text-align-right govuk-!-font-size-19">
         <span id="username">{{ username }}</span>
-        <a id="sign-out" class="govuk-link govuk-link--inverse govuk-!-font-weight-bold" href="#" (click)="logout()">Sign out</a>
+        <a id="sign-out" class="govuk-link govuk-link--inverse govuk-!-font-weight-bold" (click)="logout()">Sign out</a>
       </div>
     </div>
   </div>

--- a/src/app/core/components/header/header.component.scss
+++ b/src/app/core/components/header/header.component.scss
@@ -1,3 +1,7 @@
+a {
+  cursor: pointer;
+}
+
 #sign-out {
   margin-left: 1rem;
 }


### PR DESCRIPTION
## Sign Out Issue

- Remove the `href` attribute from the `<a>` element to prevent navigation to the home page. 
- Add basic CSS to still display a cursor when hovering over the link.
[CB2-4243](https://dvsa.atlassian.net/browse/CB2-4243)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
