### PR TITLE
bugfix(cb2-4343): Correct Caption Name for Vehicle Approval Type

### DIFF
--- a/src/app/forms/templates/psv/psv-approval-type.template.ts
+++ b/src/app/forms/templates/psv/psv-approval-type.template.ts
@@ -13,7 +13,7 @@ export const PsvApprovalTypeSection: FormNode = {
     },
     {
       name: 'approvalTypeNumber',
-      label: 'Approval type tumber',
+      label: 'Approval type number',
       type: FormNodeTypes.CONTROL
     },
     {


### PR DESCRIPTION
## Caption name is wrong for approval type number in Approval type details for tech summary of the vehicle

Pretty self-explanatory.
[CB2-4343](https://dvsa.atlassian.net/browse/CB2-4343)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
