### PR TITLE
fix(cb2-4163): make max train weight visible

### DIFF
--- a/src/app/forms/templates/hgv/hgv-max-train-weights.template.ts
+++ b/src/app/forms/templates/hgv/hgv-max-train-weights.template.ts
@@ -7,5 +7,5 @@ export const HgvMaxTrainWeight: FormNode = {
   value: '',
   type: FormNodeTypes.GROUP,
   viewType: FormNodeViewTypes.SUBHEADING,
-  children: generateWeights(true, 'hgv', 'max')
+  children: generateWeights(true, 'hgv', 'maxTrain')
 };


### PR DESCRIPTION
## View Weights section of HGV and trailer Tech Record

Previous PR for this was not correctly reading data from database as it was trying to find maxEecWeight, maxGbWeight, etc... instead of maxTrainEecWeight, maxTrainGbWeight, etc...

**Before:**
![image](https://user-images.githubusercontent.com/92087051/175326473-7d6d6ace-8842-4f9a-954b-8fd7283f3e9c.png)

**After :**
![image](https://user-images.githubusercontent.com/92087051/175326032-af66abfe-3c5e-4782-8145-3f4367b2f932.png)

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-4163)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
