### PR TITLE
feature(CB2-2892): Enable Retrieving Tech Records by VRM

### DIFF
--- a/src/app/features/search/multiple-search-results/multiple-search-results.component.ts
+++ b/src/app/features/search/multiple-search-results/multiple-search-results.component.ts
@@ -26,7 +26,7 @@ export class MultipleSearchResultsComponent implements OnDestroy {
 
           if (searchTerm && Object.values(SEARCH_TYPES).includes(type as SEARCH_TYPES)) {
             this.globalErrorService.clearError();
-            this.technicalRecordService.searchBy({ type, searchTerm });
+            this.technicalRecordService.searchBy(type, searchTerm);
           }
         }
       });

--- a/src/app/features/search/search.component.spec.ts
+++ b/src/app/features/search/search.component.spec.ts
@@ -46,19 +46,19 @@ describe('SearchComponent', () => {
       it('should navigate to vin search result', () => {
         const navigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
 
-        const vin = 'someVin';
-        component.navigateSearch(vin, SEARCH_TYPES.VIN);
+        const expectedVin = 'someVin';
+        component.navigateSearch(expectedVin, SEARCH_TYPES.VIN);
 
-        expect(navigateSpy).toHaveBeenCalledWith(['/search/results'], { queryParams: { vin: 'someVin' } });
+        expect(navigateSpy).toHaveBeenCalledWith(['/search/results'], { queryParams: { vin: expectedVin } });
       });
 
       it('should navigate to partialVin search result', () => {
         const navigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
 
-        const partialVin = 'somePartialVin';
-        component.navigateSearch(partialVin, SEARCH_TYPES.PARTIAL_VIN);
+        const expectedPartialVin = 'somePartialVin';
+        component.navigateSearch(expectedPartialVin, SEARCH_TYPES.PARTIAL_VIN);
 
-        expect(navigateSpy).toHaveBeenCalledWith(['/search/results'], { queryParams: { partialVin: 'somePartialVin' } });
+        expect(navigateSpy).toHaveBeenCalledWith(['/search/results'], { queryParams: { partialVin: expectedPartialVin } });
       });
 
       it('should add error', () => {
@@ -66,7 +66,7 @@ describe('SearchComponent', () => {
 
         component.navigateSearch('', '');
 
-        expect(addErrorSpy).toHaveBeenCalledWith({ error: component.searchErrorMessage, anchorLink: 'search-term' });
+        expect(addErrorSpy).toHaveBeenCalledWith({ error: component.missingTermErrorMessage, anchorLink: 'search-term' });
       });
     });
   });

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { NavigationExtras, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { SEARCH_TYPES } from '@services/technical-record/technical-record.service';
@@ -10,33 +10,21 @@ import { map, Observable } from 'rxjs';
   templateUrl: './search.component.html'
 })
 export class SearchComponent {
-  searchErrorMessage = 'You must provide a vehicle registration mark, trailer ID or vehicle identification number.';
-  missingCriteriaErrorMessage = 'You must select a valid search criteria';
+  missingTermErrorMessage = 'You must provide a vehicle registration mark, trailer ID or vehicle identification number.';
+  missingTypeErrorMessage = 'You must select a valid search criteria';
 
   constructor(public globalErrorService: GlobalErrorService, private router: Router) {}
 
-  public navigateSearch(term: string, type: string): void {
+  navigateSearch(term: string, type: string): void {
     this.globalErrorService.clearError();
-
     term = term.trim();
 
-    let extras: NavigationExtras;
-    if (term) {
-      switch (type) {
-        case SEARCH_TYPES.VIN:
-          extras = { queryParams: { vin: term } };
-          break;
-        case SEARCH_TYPES.PARTIAL_VIN:
-          extras = { queryParams: { partialVin: term } };
-          break;
-        default:
-          this.globalErrorService.addError({ error: this.missingCriteriaErrorMessage, anchorLink: 'search-type' });
-          return;
-      }
-
-      this.router.navigate(['/search/results'], extras);
+    if (!term) {
+      this.globalErrorService.addError({ error: this.missingTermErrorMessage, anchorLink: 'search-term' });
+    } else if (!Object.values(SEARCH_TYPES).includes(type as SEARCH_TYPES)) {
+      this.globalErrorService.addError({ error: this.missingTypeErrorMessage, anchorLink: 'search-type' });
     } else {
-      this.globalErrorService.addError({ error: this.searchErrorMessage, anchorLink: 'search-term' });
+      this.router.navigate(['/search/results'], { queryParams: { [type]: term } });
     }
   }
 

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { TestResultModel } from '@models/test-result.model';
 import { TechRecordModel, VehicleTechRecordModel, Vrm } from '@models/vehicle-tech-record.model';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -9,15 +9,18 @@ import { Observable, Subject } from 'rxjs';
   selector: 'app-vehicle-technical-record',
   templateUrl: './vehicle-technical-record.component.html'
 })
-export class VehicleTechnicalRecordComponent implements OnDestroy {
+export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
   @Input() vehicleTechRecord?: VehicleTechRecordModel;
-  currentTechRecord: Observable<TechRecordModel | undefined>;
+  currentTechRecord?: Observable<TechRecordModel | undefined>;
   records: Observable<TestResultModel[]>;
   ngDestroy$ = new Subject();
 
   constructor(testRecordService: TestRecordsService, private technicalRecordService: TechnicalRecordService) {
-    this.currentTechRecord = this.technicalRecordService.viewableTechRecord$(this.vehicleTechRecord!, this.ngDestroy$);
     this.records = testRecordService.testRecords$;
+  }
+
+  ngOnInit(): void {
+    this.currentTechRecord = this.technicalRecordService.viewableTechRecord$(this.vehicleTechRecord!, this.ngDestroy$);
   }
 
   get currentVrm(): string | undefined {

--- a/src/app/features/tech-record/tech-record.component.ts
+++ b/src/app/features/tech-record/tech-record.component.ts
@@ -16,12 +16,15 @@ export class TechRecordComponent implements OnDestroy {
   ngDestroy$ = new Subject();
 
   constructor(private technicalRecordService: TechnicalRecordService, private store: Store, public spinnerService: SpinnerService) {
-    this.store.pipe(select(selectRouteNestedParams), takeUntil(this.ngDestroy$)).subscribe((params) => {
-      const vin = params['vin'];
-      if (vin) {
-        this.technicalRecordService.searchBy({ type: SEARCH_TYPES.VIN, searchTerm: vin });
-      }
-    });
+    this.store
+      .pipe(select(selectRouteNestedParams), takeUntil(this.ngDestroy$))
+      .subscribe((params) => {
+        const vin = params['vin'];
+        if (vin) {
+          this.technicalRecordService.searchBy(SEARCH_TYPES.VIN, vin);
+        }
+      });
+
     this.vehicleTechRecord$ = this.technicalRecordService.selectedVehicleTechRecord$;
   }
 

--- a/src/app/services/technical-record/technical-record.service.spec.ts
+++ b/src/app/services/technical-record/technical-record.service.spec.ts
@@ -31,11 +31,11 @@ describe('TechnicalRecordService', () => {
   });
 
   describe('API', () => {
-    describe('getByVIN', () => {
+    describe('getByVin', () => {
       it('should get an array of matching results', () => {
         const searchParams = { searchTerm: 'A_VIN', type: 'vin' };
         const mockData = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 1);
-        service.getByVIN(searchParams.searchTerm).subscribe((response) => {
+        service.getByVin(searchParams.searchTerm).subscribe((response) => {
           expect(response).toEqual(mockData);
         });
 
@@ -50,7 +50,7 @@ describe('TechnicalRecordService', () => {
       it('should handle errors', () => {
         const searchParams = { searchTerm: 'A_VIN', type: 'vin' };
         const mockData = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 1);
-        service.getByVIN(searchParams.searchTerm).subscribe((response) => {
+        service.getByVin(searchParams.searchTerm).subscribe((response) => {
           expect(response).toEqual(mockData);
         });
 
@@ -63,11 +63,11 @@ describe('TechnicalRecordService', () => {
       });
     });
 
-    describe('getByPartialVIN', () => {
+    describe('getByPartialVin', () => {
       it('should get an array of matching results', () => {
         const searchParams = { searchTerm: 'A_VIN', type: 'partialVin' };
         const mockData = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 1);
-        service.getByPartialVIN(searchParams.searchTerm).subscribe((response) => {
+        service.getByPartialVin(searchParams.searchTerm).subscribe((response) => {
           expect(response).toEqual(mockData);
         });
 
@@ -82,12 +82,42 @@ describe('TechnicalRecordService', () => {
       it('should handle errors', () => {
         const searchParams = { searchTerm: 'A_VIN', type: 'partialVin' };
         const mockData = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 1);
-        service.getByPartialVIN(searchParams.searchTerm).subscribe((response) => {
+        service.getByPartialVin(searchParams.searchTerm).subscribe((response) => {
           expect(response).toEqual(mockData);
         });
 
         // Check for correct requests: should have made one request to search from expected URL
         const req = httpTestingController.expectOne(`${environment.VTM_API_URI}/vehicles/${searchParams.searchTerm}/tech-records?status=all&metadata=true&searchCriteria=partialVin`);
+        expect(req.request.method).toEqual('GET');
+
+        // Respond with mock error
+        req.flush('Deliberate 500 error', { status: 500, statusText: 'Server Error' });
+      });
+    });
+
+    describe('getByVrm', () => {
+      it('should get an array of matching results', () => {
+        const params = { term: 'A_VRM', type: 'vrm' };
+        const mockData = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 1);
+        service.getByVrm(params.term)
+          .subscribe(response => expect(response).toEqual(mockData));
+
+        // Check for correct requests: should have made one request to search from expected URL
+        const req = httpTestingController.expectOne(`${environment.VTM_API_URI}/vehicles/${params.term}/tech-records?status=all&metadata=true&searchCriteria=${params.type}`);
+        expect(req.request.method).toEqual('GET');
+
+        // Provide each request with a mock response
+        req.flush(mockData);
+      });
+
+      it('should handle errors', () => {
+        const params = { term: 'A_VRM', type: 'vrm' };
+        const mockData = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 1);
+        service.getByVrm(params.term)
+          .subscribe(response => expect(response).toEqual(mockData));
+
+        // Check for correct requests: should have made one request to search from expected URL
+        const req = httpTestingController.expectOne(`${environment.VTM_API_URI}/vehicles/${params.term}/tech-records?status=all&metadata=true&searchCriteria=${params.type}`);
         expect(req.request.method).toEqual('GET');
 
         // Respond with mock error

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -3,25 +3,30 @@ import { Injectable } from '@angular/core';
 import { StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
 import { select, Store } from '@ngrx/store';
 import { selectRouteNestedParams } from '@store/router/selectors/router.selectors';
-import { getByVIN, getByPartialVIN, selectVehicleTechnicalRecordsByVin, vehicleTechRecords } from '@store/technical-records';
+import { getByVin, getByPartialVin, selectVehicleTechnicalRecordsByVin, vehicleTechRecords, getByVrm } from '@store/technical-records';
 import { map, Observable, Subject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 export enum SEARCH_TYPES {
   VIN = 'vin',
-  PARTIAL_VIN = 'partialVin'
+  PARTIAL_VIN = 'partialVin',
+  VRM = 'vrm'
 }
 
 @Injectable({ providedIn: 'root' })
 export class TechnicalRecordService {
   constructor(private store: Store, private http: HttpClient) {}
 
-  getByVIN(vin: string): Observable<VehicleTechRecordModel[]> {
+  getByVin(vin: string): Observable<VehicleTechRecordModel[]> {
     return this.getVehicleTechRecordModels(vin, SEARCH_TYPES.VIN);
   }
 
-  getByPartialVIN(partialVin: string): Observable<VehicleTechRecordModel[]> {
+  getByPartialVin(partialVin: string): Observable<VehicleTechRecordModel[]> {
     return this.getVehicleTechRecordModels(partialVin, SEARCH_TYPES.PARTIAL_VIN);
+  }
+
+  getByVrm(vrm: string): Observable<VehicleTechRecordModel[]> {
+    return this.getVehicleTechRecordModels(vrm, SEARCH_TYPES.VRM);
   }
 
   private getVehicleTechRecordModels(identifier: string, type: SEARCH_TYPES) {
@@ -39,15 +44,16 @@ export class TechnicalRecordService {
     return this.store.pipe(select(selectVehicleTechnicalRecordsByVin));
   }
 
-  searchBy(criteria: { type: SEARCH_TYPES; searchTerm: string }) {
-    const { type, searchTerm } = criteria;
-
+  searchBy(type: SEARCH_TYPES, searchTerm: string) {
     switch (type) {
       case SEARCH_TYPES.VIN:
-        this.store.dispatch(getByVIN({ [type]: searchTerm }));
+        this.store.dispatch(getByVin({ [type]: searchTerm }));
         break;
       case SEARCH_TYPES.PARTIAL_VIN:
-        this.store.dispatch(getByPartialVIN({ [type]: searchTerm }));
+        this.store.dispatch(getByPartialVin({ [type]: searchTerm }));
+        break;
+      case SEARCH_TYPES.VRM:
+        this.store.dispatch(getByVrm({ [type]: searchTerm }));
         break;
     }
   }

--- a/src/app/store/global-error/reducers/global-error-service.reducer.spec.ts
+++ b/src/app/store/global-error/reducers/global-error-service.reducer.spec.ts
@@ -1,6 +1,6 @@
 import { globalErrorReducer, GlobalErrorState, initialGlobalErrorState } from '@store/global-error/reducers/global-error-service.reducer';
 import { fetchTestResults, fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsFailed, fetchTestResultsSuccess, initialTestResultsState, testResultsReducer } from '@store/test-records';
-import { getByVIN, getByVINFailure } from '@store/technical-records';
+import { getByVin, getByVinFailure } from '@store/technical-records';
 
 describe('Global Error Reducer', () => {
   describe('unknown action', () => {
@@ -15,7 +15,7 @@ describe('Global Error Reducer', () => {
   });
 
   describe('Fail action', () => {
-    it.each([fetchTestResultsBySystemIdFailed, fetchTestResultsFailed, getByVINFailure])('should return the error state', (actionMethod) => {
+    it.each([fetchTestResultsBySystemIdFailed, fetchTestResultsFailed, getByVinFailure])('should return the error state', (actionMethod) => {
       const error = 'fetching test records failed';
       const newState: GlobalErrorState = { ...initialGlobalErrorState, globalError: [{error: error, anchorLink: undefined}] };
       const action = actionMethod({ error });
@@ -27,7 +27,7 @@ describe('Global Error Reducer', () => {
   });
 
   describe('Success action', () => {
-    it.each([fetchTestResultsBySystemId, getByVIN, fetchTestResults])('should reset the error state', (actionMethod) => {
+    it.each([fetchTestResultsBySystemId, getByVin, fetchTestResults])('should reset the error state', (actionMethod) => {
       const newState = { ...initialGlobalErrorState, globalError: [] };
       //all props must be supplied here
       const action = actionMethod({ systemId: '', vin: '' });

--- a/src/app/store/global-error/reducers/global-error-service.reducer.ts
+++ b/src/app/store/global-error/reducers/global-error-service.reducer.ts
@@ -20,6 +20,6 @@ export const globalErrorState = createSelector(getGlobalErrorState, (state) => s
 
 export const globalErrorReducer = createReducer(
   initialGlobalErrorState,
-  on(GlobalErrorActions.clearError, TechnicalRecordServiceActions.getByVIN, TestResultActions.fetchTestResults, TestResultActions.fetchTestResultsBySystemId, TestResultActions.fetchSelectedTestResult, (state) => ({ ...state, globalError: [] })),
-  on(GlobalErrorActions.addError, TechnicalRecordServiceActions.getByVINFailure, TestResultActions.fetchTestResultsFailed, TestResultActions.fetchTestResultsBySystemIdFailed, TestResultActions.fetchSelectedTestResultFailed, (state, { error, anchorLink }) => ({ ...state, globalError: [...state.globalError, { error: error, anchorLink: anchorLink }] }))
+  on(GlobalErrorActions.clearError, TechnicalRecordServiceActions.getByVin, TestResultActions.fetchTestResults, TestResultActions.fetchTestResultsBySystemId, TestResultActions.fetchSelectedTestResult, (state) => ({ ...state, globalError: [] })),
+  on(GlobalErrorActions.addError, TechnicalRecordServiceActions.getByVinFailure, TestResultActions.fetchTestResultsFailed, TestResultActions.fetchTestResultsBySystemIdFailed, TestResultActions.fetchSelectedTestResultFailed, (state, { error, anchorLink }) => ({ ...state, globalError: [...state.globalError, { error: error, anchorLink: anchorLink }] }))
 );

--- a/src/app/store/technical-records/actions/technical-record-service.actions.spec.ts
+++ b/src/app/store/technical-records/actions/technical-record-service.actions.spec.ts
@@ -1,12 +1,24 @@
-import { getByVIN, getByVINSuccess, getByVINFailure, getByPartialVINSuccess, getByPartialVINFailure, getByPartialVIN } from './technical-record-service.actions';
+import { getByVin, getByVinSuccess, getByVinFailure, getByPartialVinSuccess, getByPartialVinFailure, getByPartialVin, getByVrm, getByVrmSuccess, getByVrmFailure } from './technical-record-service.actions';
+
+const SUCCESS = ' Success';
+const FAILURE = ' Failure';
 
 describe('Technical record actions', () => {
   it('should have correct types', () => {
-    expect(getByVIN.type).toBe('[Technical Record Service] GetByVIN');
-    expect(getByVINSuccess.type).toBe('[Technical Record Service] GetByVIN Success');
-    expect(getByVINFailure.type).toBe('[Technical Record Service] GetByVIN Failure');
-    expect(getByPartialVIN.type).toBe('[Technical Record Service] GetByPartialVIN');
-    expect(getByPartialVINSuccess.type).toBe('[Technical Record Service] GetByPartialVIN Success');
-    expect(getByPartialVINFailure.type).toBe('[Technical Record Service] GetByPartialVIN Failure');
+    expect(getByVin.type).toBe(getMessage('getByVin'));
+    expect(getByVinSuccess.type).toBe(getMessage('getByVin', SUCCESS));
+    expect(getByVinFailure.type).toBe(getMessage('getByVin', FAILURE));
+
+    expect(getByPartialVin.type).toBe(getMessage('getByPartialVin'));
+    expect(getByPartialVinSuccess.type).toBe(getMessage('getByPartialVin', SUCCESS));
+    expect(getByPartialVinFailure.type).toBe(getMessage('getByPartialVin', FAILURE));
+
+    expect(getByVrm.type).toBe(getMessage('getByVrm'));
+    expect(getByVrmSuccess.type).toBe(getMessage('getByVrm', SUCCESS));
+    expect(getByVrmFailure.type).toBe(getMessage('getByVrm', FAILURE));
   });
 });
+
+function getMessage(title: string, suffix: string = '') {
+  return `[Technical Record Service] ${title}${suffix}`;
+}

--- a/src/app/store/technical-records/actions/technical-record-service.actions.ts
+++ b/src/app/store/technical-records/actions/technical-record-service.actions.ts
@@ -1,11 +1,29 @@
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { createAction, props } from '@ngrx/store';
+import { ActionCreator, ActionCreatorProps } from '@ngrx/store/src/models';
 import { VehicleTechRecordModel } from '../../../models/vehicle-tech-record.model';
 
-export const getByVIN = createAction('[Technical Record Service] GetByVIN', props<{ vin: string }>());
-export const getByVINSuccess = createAction('[Technical Record Service] GetByVIN Success', props<{ vehicleTechRecords: Array<VehicleTechRecordModel> }>());
-export const getByVINFailure = createAction('[Technical Record Service] GetByVIN Failure', props<GlobalError>());
+const prefix = '[Technical Record Service]'
 
-export const getByPartialVIN = createAction('[Technical Record Service] GetByPartialVIN', props<{ partialVin: string }>());
-export const getByPartialVINSuccess = createAction('[Technical Record Service] GetByPartialVIN Success', props<{ vehicleTechRecords: Array<VehicleTechRecordModel> }>());
-export const getByPartialVINFailure = createAction('[Technical Record Service] GetByPartialVIN Failure', props<GlobalError>());
+export const getByVin = createAction(`${prefix} getByVin`, props<{ vin: string }>());
+export const getByVinSuccess = createOutcomeAction('getByVin', true);
+export const getByVinFailure = createOutcomeAction('getByVin');
+
+export const getByPartialVin = createAction(`${prefix} getByPartialVin`, props<{ partialVin: string }>());
+export const getByPartialVinSuccess = createOutcomeAction('getByPartialVin', true);
+export const getByPartialVinFailure = createOutcomeAction('getByPartialVin');
+
+export const getByVrm = createAction(`${prefix} getByVrm`, props<{ vrm: string }>());
+export const getByVrmSuccess = createOutcomeAction('getByVrm', true);
+export const getByVrmFailure = createOutcomeAction('getByVrm');
+
+function createOutcomeAction(title: string, isSuccess: boolean = false): ActionCreator<string, (props: any) => any> {
+  const suffix = isSuccess ? 'Success' : 'Failure';
+  const type = `${prefix} ${title} ${suffix}`;
+
+  const actionCreator: ActionCreatorProps<any> = isSuccess
+    ? props<{ vehicleTechRecords: Array<VehicleTechRecordModel> }>()
+    : props<GlobalError>();
+
+  return createAction(type, actionCreator);
+}

--- a/src/app/store/technical-records/effects/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.spec.ts
@@ -9,7 +9,7 @@ import { TechnicalRecordService } from '@services/technical-record/technical-rec
 import { initialAppState } from '@store/.';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { getByPartialVIN, getByPartialVINFailure, getByPartialVINSuccess, getByVIN, getByVINFailure, getByVINSuccess } from '../actions/technical-record-service.actions';
+import { getByPartialVin, getByPartialVinFailure, getByPartialVinSuccess, getByVin, getByVinFailure, getByVinSuccess, getByVrm, getByVrmFailure, getByVrmSuccess } from '../actions/technical-record-service.actions';
 import { TechnicalRecordServiceEffects } from './technical-record-service.effects';
 
 describe('TechnicalRecordServiceEffects', () => {
@@ -40,14 +40,14 @@ describe('TechnicalRecordServiceEffects', () => {
         const technicalRecord = mockVehicleTechnicalRecordList();
 
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVIN });
+        actions$ = hot('-a--', { a: getByVin });
 
         // mock service call
-        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--a|', { a: technicalRecord }));
+        jest.spyOn(technicalRecordService, 'getByVin').mockReturnValue(cold('--a|', { a: technicalRecord }));
 
         // expect effect to return success action
         expectObservable(effects.getTechnicalRecord$).toBe('---b', {
-          b: getByVINSuccess({ vehicleTechRecords: technicalRecord })
+          b: getByVinSuccess({ vehicleTechRecords: technicalRecord })
         });
       });
     });
@@ -56,16 +56,16 @@ describe('TechnicalRecordServiceEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vin = { vin: 'vin' };
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVIN(vin) });
+        actions$ = hot('-a--', { a: getByVin(vin) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({
           status: 500,
           statusText: 'Internal server error'
         });
-        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--#|', {}, expectedError));
+        jest.spyOn(technicalRecordService, 'getByVin').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVINFailure({ error: 'There was a problem getting the Tech Record by vin', anchorLink: 'search-term' }) });
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVinFailure({ error: 'There was a problem getting the Tech Record by vin', anchorLink: 'search-term' }) });
       });
     });
 
@@ -73,16 +73,16 @@ describe('TechnicalRecordServiceEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vin = { vin: 'vin' };
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVIN(vin) });
+        actions$ = hot('-a--', { a: getByVin(vin) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({
           status: 404,
           statusText: 'Vehicle not found'
         });
-        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--#|', {}, expectedError));
+        jest.spyOn(technicalRecordService, 'getByVin').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVINFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVinFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
       });
     });
 
@@ -90,13 +90,13 @@ describe('TechnicalRecordServiceEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vin = { vin: 'vin' };
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVIN(vin) });
+        actions$ = hot('-a--', { a: getByVin(vin) });
 
         // mock service call
         const expectedError = 'string';
-        jest.spyOn(technicalRecordService, 'getByVIN').mockReturnValue(cold('--#|', {}, expectedError));
+        jest.spyOn(technicalRecordService, 'getByVin').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVINFailure({ error: 'string', anchorLink: 'search-term' }) });
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVinFailure({ error: 'string', anchorLink: 'search-term' }) });
       });
     });
   });
@@ -107,14 +107,14 @@ describe('TechnicalRecordServiceEffects', () => {
         const technicalRecord = mockVehicleTechnicalRecordList();
 
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByPartialVIN });
+        actions$ = hot('-a--', { a: getByPartialVin });
 
         // mock service call
-        jest.spyOn(technicalRecordService, 'getByPartialVIN').mockReturnValue(cold('--a|', { a: technicalRecord }));
+        jest.spyOn(technicalRecordService, 'getByPartialVin').mockReturnValue(cold('--a|', { a: technicalRecord }));
 
         // expect effect to return success action
         expectObservable(effects.getTechnicalRecord$).toBe('---b', {
-          b: getByPartialVINSuccess({ vehicleTechRecords: technicalRecord })
+          b: getByPartialVinSuccess({ vehicleTechRecords: technicalRecord })
         });
       });
     });
@@ -123,16 +123,16 @@ describe('TechnicalRecordServiceEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vin = { partialVin: 'vin' };
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByPartialVIN(vin) });
+        actions$ = hot('-a--', { a: getByPartialVin(vin) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({
           status: 500,
           statusText: 'Internal server error'
         });
-        jest.spyOn(technicalRecordService, 'getByPartialVIN').mockReturnValue(cold('--#|', {}, expectedError));
+        jest.spyOn(technicalRecordService, 'getByPartialVin').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByPartialVINFailure({ error: 'There was a problem getting the Tech Record by partialVin', anchorLink: 'search-term' }) });
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByPartialVinFailure({ error: 'There was a problem getting the Tech Record by partialVin', anchorLink: 'search-term' }) });
       });
     });
 
@@ -140,16 +140,16 @@ describe('TechnicalRecordServiceEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vin = { partialVin: 'vin' };
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByPartialVIN(vin) });
+        actions$ = hot('-a--', { a: getByPartialVin(vin) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({
           status: 404,
           statusText: 'Vehicle not found'
         });
-        jest.spyOn(technicalRecordService, 'getByPartialVIN').mockReturnValue(cold('--#|', {}, expectedError));
+        jest.spyOn(technicalRecordService, 'getByPartialVin').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByPartialVINFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByPartialVinFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
       });
     });
 
@@ -157,13 +157,80 @@ describe('TechnicalRecordServiceEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vin = { partialVin: 'vin' };
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByPartialVIN(vin) });
+        actions$ = hot('-a--', { a: getByPartialVin(vin) });
 
         // mock service call
         const expectedError = 'string';
-        jest.spyOn(technicalRecordService, 'getByPartialVIN').mockReturnValue(cold('--#|', {}, expectedError));
+        jest.spyOn(technicalRecordService, 'getByPartialVin').mockReturnValue(cold('--#|', {}, expectedError));
 
-        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByPartialVINFailure({ error: 'string', anchorLink: 'search-term' }) });
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByPartialVinFailure({ error: 'string', anchorLink: 'search-term' }) });
+      });
+    });
+  });
+
+  describe('getByVrm$', () => {
+    it('should return a technical record on successfull API call', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const technicalRecord = mockVehicleTechnicalRecordList();
+
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVrm });
+
+        // mock service call
+        jest.spyOn(technicalRecordService, 'getByVrm').mockReturnValue(cold('--a|', { a: technicalRecord }));
+
+        // expect effect to return success action
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', {
+          b: getByVrmSuccess({ vehicleTechRecords: technicalRecord })
+        });
+      });
+    });
+
+    it('should return generic error message if not not found', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vrm = { vrm: 'vrm' };
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVrm(vrm) });
+
+        // mock service call
+        const expectedError = new HttpErrorResponse({
+          status: 500,
+          statusText: 'Internal server error'
+        });
+        jest.spyOn(technicalRecordService, 'getByVrm').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVrmFailure({ error: 'There was a problem getting the Tech Record by vrm', anchorLink: 'search-term' }) });
+      });
+    });
+
+    it('should return not found error message if not found', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vrm = { vrm: 'vrm' };
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVrm(vrm) });
+
+        // mock service call
+        const expectedError = new HttpErrorResponse({
+          status: 404,
+          statusText: 'Vehicle not found'
+        });
+        jest.spyOn(technicalRecordService, 'getByVrm').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVrmFailure({ error: 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number', anchorLink: 'search-term' }) });
+      });
+    });
+
+    it('should return error message if error is a string', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        const vrm = { vrm: 'vrm' };
+        // mock action to trigger effect
+        actions$ = hot('-a--', { a: getByVrm(vrm) });
+
+        // mock service call
+        const expectedError = 'string';
+        jest.spyOn(technicalRecordService, 'getByVrm').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.getTechnicalRecord$).toBe('---b', { b: getByVrmFailure({ error: 'string', anchorLink: 'search-term' }) });
       });
     });
   });

--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -3,45 +3,49 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
-import { getByPartialVIN, getByPartialVINFailure, getByPartialVINSuccess, getByVIN, getByVINFailure, getByVINSuccess } from '../actions/technical-record-service.actions';
-
-function getErrorMessage(error: any, search: string): string {
-  let message = error;
-  if (typeof error === 'object') {
-    if (error.status === 404) {
-      message = 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number';
-    } else {
-      message = `There was a problem getting the Tech Record by ${search}`;
-    }
-  }
-  return message
-}
+import { getByPartialVin, getByPartialVinFailure, getByPartialVinSuccess, getByVin, getByVinFailure, getByVinSuccess, getByVrm, getByVrmFailure, getByVrmSuccess } from '../actions/technical-record-service.actions';
 
 @Injectable()
 export class TechnicalRecordServiceEffects {
+  constructor(private actions$: Actions, private technicalRecordService: TechnicalRecordService) {}
+
   getTechnicalRecord$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(getByVIN, getByPartialVIN),
+      ofType(getByVin, getByPartialVin, getByVrm),
       mergeMap((action) => {
+        const anchorLink = 'search-term';
+
         switch (action.type) {
-          case (getByVIN.type):
-            return this.technicalRecordService.getByVIN(action.vin).pipe(
-              map((vehicleTechRecords) => getByVINSuccess({ vehicleTechRecords })),
-              catchError((error) => {
-                return of(getByVINFailure({ error: getErrorMessage(error, 'vin'), anchorLink: 'search-term' }));
-              })
-            )
-          case (getByPartialVIN.type): 
-            return this.technicalRecordService.getByPartialVIN(action.partialVin).pipe(
-              map(vehicleTechRecords => getByPartialVINSuccess({ vehicleTechRecords })),
-              catchError((error) => {
-                return of(getByPartialVINFailure({ error: getErrorMessage(error, 'partialVin'), anchorLink: 'search-term'}))
-              })
-            )
+          case getByVin.type:
+            return this.technicalRecordService.getByVin(action.vin)
+              .pipe(
+                map(vehicleTechRecords => getByVinSuccess({ vehicleTechRecords })),
+                catchError(error => of(getByVinFailure({ error: this.getErrorMessage(error, 'vin'), anchorLink })))
+              );
+          case getByPartialVin.type:
+            return this.technicalRecordService.getByPartialVin(action.partialVin)
+              .pipe(
+                map(vehicleTechRecords => getByPartialVinSuccess({ vehicleTechRecords })),
+                catchError(error => of(getByPartialVinFailure({ error: this.getErrorMessage(error, 'partialVin'), anchorLink })))
+              );
+          case getByVrm.type:
+            return this.technicalRecordService.getByVrm(action.vrm)
+              .pipe(
+                map(vehicleTechRecords => getByVrmSuccess({ vehicleTechRecords })),
+                catchError(error => of(getByVrmFailure({ error: this.getErrorMessage(error, 'vrm'), anchorLink })))
+              );
         }
       })
     )
   );
 
-  constructor(private actions$: Actions, private technicalRecordService: TechnicalRecordService) {}
+  getErrorMessage(error: any, search: string): string {
+    if (typeof error !== 'object') {
+      return error;
+    }
+
+    return error.status === 404
+      ? 'Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number'
+      : `There was a problem getting the Tech Record by ${search}`;
+  }
 }

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -1,6 +1,6 @@
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { mockVehicleTechnicalRecordList } from '../../../../mocks/mock-vehicle-technical-record.mock';
-import { getByPartialVIN, getByPartialVINFailure, getByPartialVINSuccess, getByVIN, getByVINFailure, getByVINSuccess } from '../actions/technical-record-service.actions';
+import { getByPartialVin, getByPartialVinFailure, getByPartialVinSuccess, getByVin, getByVinFailure, getByVinSuccess, getByVrm, getByVrmFailure, getByVrmSuccess } from '../actions/technical-record-service.actions';
 import { initialState, TechnicalRecordServiceState, vehicleTechRecordReducer } from './technical-record-service.reducer';
 
 describe('Vehicle Technical Record Reducer', () => {
@@ -21,7 +21,7 @@ describe('Vehicle Technical Record Reducer', () => {
         ...initialState,
         loading: true
       };
-      const action = getByPartialVIN({ partialVin: 'somevin' });
+      const action = getByPartialVin({ partialVin: 'somevin' });
       const state = vehicleTechRecordReducer(initialState, action);
 
       expect(state).toEqual(newState);
@@ -36,7 +36,7 @@ describe('Vehicle Technical Record Reducer', () => {
         ...initialState,
         vehicleTechRecords: records
       };
-      const action = getByPartialVINSuccess({ vehicleTechRecords: [...records] });
+      const action = getByPartialVinSuccess({ vehicleTechRecords: [...records] });
       const state = vehicleTechRecordReducer(initialState, action);
 
       expect(state).toEqual(newState);
@@ -44,11 +44,11 @@ describe('Vehicle Technical Record Reducer', () => {
     });
   })
 
-  describe('getByVINFailure', () => {
+  describe('getByPartialVINFailure', () => {
     it('should set error state', () => {
       const error = 'fetching vehicle tech records failed';
       const newState = { ...initialState, error };
-      const action = getByPartialVINFailure({ error });
+      const action = getByPartialVinFailure({ error });
       const state = vehicleTechRecordReducer(initialState, action);
 
       expect(state).toEqual(newState);
@@ -62,7 +62,7 @@ describe('Vehicle Technical Record Reducer', () => {
         ...initialState,
         loading: true
       };
-      const action = getByVIN({ vin: 'somevin' });
+      const action = getByVin({ vin: 'somevin' });
       const state = vehicleTechRecordReducer(initialState, action);
 
       expect(state).toEqual(newState);
@@ -77,7 +77,7 @@ describe('Vehicle Technical Record Reducer', () => {
         ...initialState,
         vehicleTechRecords: records
       };
-      const action = getByVINSuccess({ vehicleTechRecords: [...records] });
+      const action = getByVinSuccess({ vehicleTechRecords: [...records] });
       const state = vehicleTechRecordReducer(initialState, action);
 
       expect(state).toEqual(newState);
@@ -89,7 +89,45 @@ describe('Vehicle Technical Record Reducer', () => {
     it('should set error state', () => {
       const error = 'fetching vehicle tech records failed';
       const newState = { ...initialState, error };
-      const action = getByVINFailure({ error });
+      const action = getByVinFailure({ error });
+      const state = vehicleTechRecordReducer(initialState, action);
+
+      expect(state).toEqual(newState);
+      expect(state).not.toBe(newState);
+    });
+  });
+
+  describe('getByVrm', () => {
+    it('should set all vehicle technical records', () => {
+      const newState: TechnicalRecordServiceState = { ...initialState, loading: true };
+      const action = getByVrm({ vrm: 'someVrm' });
+      const state = vehicleTechRecordReducer(initialState, action);
+
+      expect(state).toEqual(newState);
+      expect(state).not.toBe(newState);
+    });
+  });
+
+  describe('getByVrmSuccess', () => {
+    it('should set all vehicle technical records', () => {
+      const records = mockVehicleTechnicalRecordList(VehicleTypes.PSV, 5);
+      const newState: TechnicalRecordServiceState = {
+        ...initialState,
+        vehicleTechRecords: records
+      };
+      const action = getByVrmSuccess({ vehicleTechRecords: [...records] });
+      const state = vehicleTechRecordReducer(initialState, action);
+
+      expect(state).toEqual(newState);
+      expect(state).not.toBe(newState);
+    });
+  });
+
+  describe('getByVrmFailure', () => {
+    it('should set error state', () => {
+      const error = 'fetching vehicle tech records failed';
+      const newState = { ...initialState, error };
+      const action = getByVrmFailure({ error });
       const state = vehicleTechRecordReducer(initialState, action);
 
       expect(state).toEqual(newState);

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -1,6 +1,6 @@
 import { createFeatureSelector, createReducer, on } from '@ngrx/store';
 import { VehicleTechRecordModel } from 'src/app/models/vehicle-tech-record.model';
-import { getByPartialVIN, getByPartialVINFailure, getByPartialVINSuccess, getByVIN, getByVINFailure, getByVINSuccess } from '../actions/technical-record-service.actions';
+import { getByPartialVin, getByPartialVinFailure, getByPartialVinSuccess, getByVin, getByVinFailure, getByVinSuccess, getByVrm, getByVrmFailure, getByVrmSuccess } from '../actions/technical-record-service.actions';
 
 export const STORE_FEATURE_TECHNICAL_RECORDS_KEY = 'TechnicalRecords';
 
@@ -18,9 +18,28 @@ export const getVehicleTechRecordState = createFeatureSelector<TechnicalRecordSe
 
 export const vehicleTechRecordReducer = createReducer(
   initialState,
-  on(getByVIN, (state) => ({ ...state, vehicleTechRecords: [], loading: true })),
-  on(getByVINSuccess, (state, { vehicleTechRecords }) => ({ ...state, vehicleTechRecords, loading: false })),
-  on(getByVINFailure, (state, { error }) => ({ ...state, vehicleTechRecords: [], error, loading: false })),
-  on(getByPartialVIN, (state) => ({ ...state, vehicleTechRecords: [], loading: true })),
-  on(getByPartialVINSuccess, (state, { vehicleTechRecords }) => ({ ...state, vehicleTechRecords, loading: false })),
-  on(getByPartialVINFailure, (state, { error }) => ({ ...state, vehicleTechRecords: [], error, loading: false })),);
+
+  on(getByVin, defaultArgs),
+  on(getByVinSuccess, successArgs),
+  on(getByVinFailure, failureArgs),
+
+  on(getByPartialVin, defaultArgs),
+  on(getByPartialVinSuccess, successArgs),
+  on(getByPartialVinFailure, failureArgs),
+
+  on(getByVrm, defaultArgs),
+  on(getByVrmSuccess, successArgs),
+  on(getByVrmFailure, failureArgs)
+);
+
+function defaultArgs(state: TechnicalRecordServiceState) {
+  return { ...state, vehicleTechRecords: [], loading: true };
+}
+
+function successArgs(state: TechnicalRecordServiceState, data: { vehicleTechRecords: Array<VehicleTechRecordModel> }) {
+  return { ...state, vehicleTechRecords: data.vehicleTechRecords, loading: false };
+}
+
+function failureArgs(state: TechnicalRecordServiceState, data: { error: any }) {
+  return { ...state, vehicleTechRecords: [], error: data.error, loading: false };
+}

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -8,7 +8,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { initialAppState } from '@store/.';
 import { selectRouteNestedParams } from '@store/router/selectors/router.selectors';
-import { getByVINSuccess } from '@store/technical-records';
+import { getByVinSuccess } from '@store/technical-records';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mockTestResult, mockTestResultList } from '../../../../mocks/mock-test-result';
@@ -108,7 +108,7 @@ describe('TestResultsEffects', () => {
         const testResults = mockTestResultList();
         const vehicleTechRecords = [{ systemNumber: 'systemSumber' }] as VehicleTechRecordModel[];
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVINSuccess({ vehicleTechRecords }) });
+        actions$ = hot('-a--', { a: getByVinSuccess({ vehicleTechRecords }) });
 
         // mock service call
         jest.spyOn(testResultsService, 'fetchTestResultbySystemId').mockReturnValue(cold('--a|', { a: testResults }));
@@ -124,7 +124,7 @@ describe('TestResultsEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vehicleTechRecords = [{ systemNumber: 'systemSumber' }] as VehicleTechRecordModel[];
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVINSuccess({ vehicleTechRecords }) });
+        actions$ = hot('-a--', { a: getByVinSuccess({ vehicleTechRecords }) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({
@@ -141,7 +141,7 @@ describe('TestResultsEffects', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const vehicleTechRecords = [{ systemNumber: 'systemSumber' }] as VehicleTechRecordModel[];
         // mock action to trigger effect
-        actions$ = hot('-a--', { a: getByVINSuccess({ vehicleTechRecords }) });
+        actions$ = hot('-a--', { a: getByVinSuccess({ vehicleTechRecords }) });
 
         // mock service call
         const expectedError = new HttpErrorResponse({

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -4,7 +4,7 @@ import { select, Store } from '@ngrx/store';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { State } from '@store/.';
 import { selectRouteNestedParams } from '@store/router/selectors/router.selectors';
-import { getByVINSuccess } from '@store/technical-records';
+import { getByVinSuccess } from '@store/technical-records';
 import { catchError, map, mergeMap, of } from 'rxjs';
 import { fetchSelectedTestResult, fetchSelectedTestResultFailed, fetchSelectedTestResultSuccess, fetchTestResultsBySystemId, fetchTestResultsBySystemIdFailed, fetchTestResultsBySystemIdSuccess } from '../actions/test-records.actions';
 
@@ -24,7 +24,7 @@ export class TestResultsEffects {
 
   fetchTestResultsBySystemNumberAfterSearchByVinSucces$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(getByVINSuccess),
+      ofType(getByVinSuccess),
       mergeMap((action) =>
         this.testRecordsService.fetchTestResultbySystemId(action.vehicleTechRecords[0].systemNumber).pipe(
           map((vehicleTestRecords) => fetchTestResultsBySystemIdSuccess({ payload: vehicleTestRecords })),


### PR DESCRIPTION
## Searching for a Tech Record with a primary VRM

Enables search for tech records using the VRM.
Cleans up some of the code related to general search.
[CB2-2892](https://dvsa.atlassian.net/browse/CB2-2892)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
