### PR TITLE
feat(cb2-4274): Add the Documents Section to HGV and TRL

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -11,7 +11,6 @@ import { PsvAxleWeights } from '@forms/templates/psv/psv-axle-weights.template';
 import { PsvBrakeSectionWheelsHalfLocked } from '@forms/templates/psv/psv-brake-wheels-half-locked.template';
 import { PsvBrakeSectionWheelsNotLocked } from '@forms/templates/psv/psv-brake-wheels-not-locked.template';
 import { PsvBrakeSection } from '@forms/templates/psv/psv-brake.template';
-import { PsvDocuments } from '@forms/templates/psv/psv-document.template';
 import { PsvGrossVehicleWeight } from '@forms/templates/psv/psv-gross-vehicle-weights.template';
 import { PsvNotes } from '@forms/templates/psv/psv-notes.template';
 import { PsvTechRecord } from '@forms/templates/psv/psv-tech-record.template';
@@ -24,6 +23,7 @@ import { getTyresSection } from '@forms/templates/general/tyres.template';
 import { getTypeApprovalSection } from '@forms/templates/general/approval-type.template';
 import { getDimensionsMinMaxSection, getDimensionsSection } from '@forms/templates/general/dimensions.template';
 import { getBodyTemplate } from '@forms/templates/general/body.template';
+import { DocumentsTemplate } from '@forms/templates/general/documents.template';
 
 @Component({
   selector: 'app-tech-record-summary',
@@ -71,7 +71,7 @@ export class TechRecordSummaryComponent implements OnInit {
         this.brakeTemplateWheelsHalfLocked = PsvBrakeSectionWheelsHalfLocked;
         this.dimensionsTemplate = getDimensionsSection(VehicleTypes.PSV, this.vehicleTechRecord.noOfAxles, this.vehicleTechRecord?.dimensions?.axleSpacing);
         this.applicantDetailsTemplate = PsvApplicantDetails;
-        this.documentsTemplate = PsvDocuments;
+        this.documentsTemplate = DocumentsTemplate;
         this.notesTemplate = PsvNotes;
         this.bodyTemplate = getBodyTemplate(true);
         this.tyresTemplate = getTyresSection(true);
@@ -92,6 +92,7 @@ export class TechRecordSummaryComponent implements OnInit {
         this.dimensionsTemplate = getDimensionsSection(VehicleTypes.HGV, this.vehicleTechRecord.noOfAxles, this.vehicleTechRecord?.dimensions?.axleSpacing);
         this.firstMinMaxTemplate = getDimensionsMinMaxSection('Front of vehicle to 5th wheel coupling', 'frontAxleTo5thWheelCouplingMin', 'frontAxleTo5thWheelCouplingMax');
         this.secondMinMaxTemplate = getDimensionsMinMaxSection('Front axle to 5th wheel', 'frontAxleTo5thWheelMin', 'frontAxleTo5thWheelMax');
+        this.documentsTemplate = DocumentsTemplate;
         break;
       }
       case 'trl': {
@@ -105,6 +106,7 @@ export class TechRecordSummaryComponent implements OnInit {
         this.dimensionsTemplate = getDimensionsSection(VehicleTypes.TRL, this.vehicleTechRecord.noOfAxles, this.vehicleTechRecord?.dimensions?.axleSpacing);
         this.firstMinMaxTemplate = getDimensionsMinMaxSection('Coupling center to rear axle', 'couplingCenterToRearAxleMin', 'couplingCenterToRearAxleMax');
         this.secondMinMaxTemplate = getDimensionsMinMaxSection('Coupling center to rear trailer', 'couplingCenterToRearTrlMin', 'couplingCenterToRearTrlMax');
+        this.documentsTemplate = DocumentsTemplate;
         break;
       }
       default: {

--- a/src/app/forms/templates/general/documents.template.ts
+++ b/src/app/forms/templates/general/documents.template.ts
@@ -1,6 +1,6 @@
 import { FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
 
-export const PsvDocuments: FormNode = {
+export const DocumentsTemplate: FormNode = {
   name: 'documentsSection',
   label: 'Documents',
   type: FormNodeTypes.GROUP,
@@ -8,7 +8,6 @@ export const PsvDocuments: FormNode = {
   children: [
     {
       name: 'microfilm',
-      label: 'Documents',
       type: FormNodeTypes.GROUP,
       children: [
         {
@@ -23,7 +22,7 @@ export const PsvDocuments: FormNode = {
         },
         {
           name: 'microfilmSerialNumber',
-          label: 'Microfilm Serial Number',
+          label: 'Microfilm serial number',
           type: FormNodeTypes.CONTROL
         }
       ]


### PR DESCRIPTION
## View Documents Section for HGV and trailer Tech Record

Centralize the `documents` template.
Use it for HGV and TRL record types.

[CB2-4274](https://dvsa.atlassian.net/browse/CB2-4274)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
