### PR TITLE
fix(cb2-4566): fix tech record not rendering with an empty array

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -25,7 +25,7 @@ import { getDimensionsMinMaxSection, getDimensionsSection } from '@forms/templat
 import { getBodyTemplate } from '@forms/templates/general/body.template';
 import { NotesTemplate } from '@forms/templates/general/notes.template';
 import { DocumentsTemplate } from '@forms/templates/general/documents.template';
-import { PlatesTemplate } from '@forms/templates/general/plates.template'
+import { PlatesTemplate } from '@forms/templates/general/plates.template';
 import { TrlAuthIntoServiceTemplate } from '@forms/templates/trl/trl-auth-into-service.template';
 import { TrlManufacturerTemplate } from '@forms/templates/trl/trl-manufacturer.template';
 
@@ -66,7 +66,7 @@ export class TechRecordSummaryComponent implements OnInit {
     this.currentBrakeRecord = this.vehicleTechRecord?.brakes;
   }
 
-  constructor() { }
+  constructor() {}
 
   vehicleTemplate(): void {
     switch (this.vehicleTechRecord?.vehicleType) {
@@ -76,7 +76,11 @@ export class TechRecordSummaryComponent implements OnInit {
         this.psvBrakeTemplate = PsvBrakeSection;
         this.brakeTemplateWheelsNotLocked = PsvBrakeSectionWheelsNotLocked;
         this.brakeTemplateWheelsHalfLocked = PsvBrakeSectionWheelsHalfLocked;
-        this.dimensionsTemplate = getDimensionsSection(VehicleTypes.PSV, this.vehicleTechRecord.noOfAxles, this.vehicleTechRecord?.dimensions?.axleSpacing);
+        this.dimensionsTemplate = getDimensionsSection(
+          VehicleTypes.PSV,
+          this.vehicleTechRecord.noOfAxles,
+          this.vehicleTechRecord?.dimensions?.axleSpacing
+        );
         this.applicantDetailsTemplate = PsvApplicantDetails;
         this.documentsTemplate = DocumentsTemplate;
         this.notesTemplate = PsvNotes;
@@ -90,14 +94,22 @@ export class TechRecordSummaryComponent implements OnInit {
       case 'hgv': {
         this.vehicleSummaryTemplate = HgvTechRecord;
         this.approvalTypeTemplate = getTypeApprovalSection();
-        this.bodyTemplate = getBodyTemplate()
+        this.bodyTemplate = getBodyTemplate();
         this.grossVehicleWeightTemplate = HgvGrossVehicleWeight;
         this.trainWeightTemplate = HgvGrossTrainWeight;
         this.maxTrainWeightTemplate = HgvMaxTrainWeight;
         this.axleWeightsTemplate = HgvAxleWeights;
         this.tyresTemplate = getTyresSection();
-        this.dimensionsTemplate = getDimensionsSection(VehicleTypes.HGV, this.vehicleTechRecord.noOfAxles, this.vehicleTechRecord?.dimensions?.axleSpacing);
-        this.firstMinMaxTemplate = getDimensionsMinMaxSection('Front of vehicle to 5th wheel coupling', 'frontAxleTo5thWheelCouplingMin', 'frontAxleTo5thWheelCouplingMax');
+        this.dimensionsTemplate = getDimensionsSection(
+          VehicleTypes.HGV,
+          this.vehicleTechRecord.noOfAxles,
+          this.vehicleTechRecord?.dimensions?.axleSpacing
+        );
+        this.firstMinMaxTemplate = getDimensionsMinMaxSection(
+          'Front of vehicle to 5th wheel coupling',
+          'frontAxleTo5thWheelCouplingMin',
+          'frontAxleTo5thWheelCouplingMax'
+        );
         this.secondMinMaxTemplate = getDimensionsMinMaxSection('Front axle to 5th wheel', 'frontAxleTo5thWheelMin', 'frontAxleTo5thWheelMax');
         this.notesTemplate = NotesTemplate;
         this.documentsTemplate = DocumentsTemplate;
@@ -107,14 +119,26 @@ export class TechRecordSummaryComponent implements OnInit {
       case 'trl': {
         this.vehicleSummaryTemplate = TrlTechRecordTemplate;
         this.approvalTypeTemplate = getTypeApprovalSection();
-        this.bodyTemplate = getBodyTemplate()
+        this.bodyTemplate = getBodyTemplate();
         this.axleWeightsTemplate = TrlAxleWeightsTemplate;
         this.grossVehicleWeightTemplate = TrlGrossVehicleWeightTemplate;
         this.tyresTemplate = getTyresSection();
         this.brakesTemplate = BrakesTemplate;
-        this.dimensionsTemplate = getDimensionsSection(VehicleTypes.TRL, this.vehicleTechRecord.noOfAxles, this.vehicleTechRecord?.dimensions?.axleSpacing);
-        this.firstMinMaxTemplate = getDimensionsMinMaxSection('Coupling center to rear axle', 'couplingCenterToRearAxleMin', 'couplingCenterToRearAxleMax');
-        this.secondMinMaxTemplate = getDimensionsMinMaxSection('Coupling center to rear trailer', 'couplingCenterToRearTrlMin', 'couplingCenterToRearTrlMax');
+        this.dimensionsTemplate = getDimensionsSection(
+          VehicleTypes.TRL,
+          this.vehicleTechRecord.noOfAxles,
+          this.vehicleTechRecord?.dimensions?.axleSpacing
+        );
+        this.firstMinMaxTemplate = getDimensionsMinMaxSection(
+          'Coupling center to rear axle',
+          'couplingCenterToRearAxleMin',
+          'couplingCenterToRearAxleMax'
+        );
+        this.secondMinMaxTemplate = getDimensionsMinMaxSection(
+          'Coupling center to rear trailer',
+          'couplingCenterToRearTrlMin',
+          'couplingCenterToRearTrlMax'
+        );
         this.notesTemplate = NotesTemplate;
         this.documentsTemplate = DocumentsTemplate;
         this.platesTemplate = PlatesTemplate;

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.spec.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.spec.ts
@@ -114,8 +114,21 @@ describe('DynamicFormGroupComponent', () => {
       ]
     };
 
+    const data = {
+      levelOneControl: 'some string',
+      levelOneGroup: {
+        levelTwoControl: 'some string',
+        levelTwoArray: [
+          {
+            levelTwoArrayControlOne: 'some string',
+            levelTwoArrayControlTwo: 'some string'
+          }
+        ]
+      }
+    };
+
     it('should generate the correct number of detail summary elements', inject([DynamicFormService], (dfs: DynamicFormService) => {
-      component.form = dfs.createForm(template);
+      component.form = dfs.createForm(template, data);
 
       fixture.detectChanges();
 
@@ -128,7 +141,7 @@ describe('DynamicFormGroupComponent', () => {
 
     it('should generate the correct number of input elements', inject([DynamicFormService], (dfs: DynamicFormService) => {
       component.edit = true;
-      component.form = dfs.createForm(template);
+      component.form = dfs.createForm(template, data);
 
       fixture.detectChanges();
 

--- a/src/app/forms/services/dynamic-form.service.spec.ts
+++ b/src/app/forms/services/dynamic-form.service.spec.ts
@@ -88,11 +88,11 @@ describe('DynamicFormService', () => {
         type: FormNodeTypes.GROUP,
         children: [
           <FormNode>{
-            name: 'nestedArray',
+            name: 'vins',
             type: FormNodeTypes.ARRAY,
             children: [
               <FormNode>{
-                name: 'vin',
+                name: '0',
                 label: 'Vechile Identification Number',
                 type: FormNodeTypes.CONTROL,
                 viewType: FormNodeViewTypes.STRING
@@ -102,10 +102,14 @@ describe('DynamicFormService', () => {
         ]
       };
 
-      const outputGroup = service.createForm(node);
-      const formArray = outputGroup.get('nestedArray');
+      const data = {
+        vins: ['123', '456']
+      };
+
+      const outputGroup = service.createForm(node, data);
+      const formArray = outputGroup.get('vins');
       expect(formArray instanceof FormArray).toBeTruthy();
-      expect((formArray as FormArray).controls.length).toBe(1);
+      expect((formArray as FormArray).controls.length).toBe(2);
     });
 
     it('should return a formGroup with a nested FormArray with data given ', () => {

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -62,13 +62,13 @@ export class DynamicFormService {
 
   createControls(child: FormNode, d: any) {
     const controls: any[] = [];
-    if (d.length && d.length > 0) {
+    if (Array.isArray(d)) {
       d.forEach(() => {
         if (FormNodeTypes.CONTROL !== child.type) {
           // Note: There's a quirk here when dealing with arrays where if
           // `d` is a array then `child.name` should be a correct index so
           // make sure the template has the correct name to the node.
-          controls.push(this.createForm(child, d[child.name]));
+          controls.push(this.createForm(child, d[Number(child.name)]));
         } else {
           controls.push(new CustomFormControl({ ...child }, { value: child.value, disabled: !!child.disabled }));
         }

--- a/src/app/forms/services/dynamic-form.types.spec.ts
+++ b/src/app/forms/services/dynamic-form.types.spec.ts
@@ -29,11 +29,7 @@ describe('Custom Classes', () => {
             {
               name: 'levelTwoArray',
               type: FormNodeTypes.ARRAY,
-              children: [
-                { name: 'levelTwoArrayControlOne', type: FormNodeTypes.CONTROL, value: '1' },
-                { name: 'sectionLabel', type: FormNodeTypes.SECTION, label: 'Section Label' },
-                { name: 'levelTwoArrayControlTwo', type: FormNodeTypes.CONTROL, value: '2' }
-              ]
+              children: [{ name: '0', type: FormNodeTypes.CONTROL, value: '1' }]
             }
           ]
         }
@@ -49,7 +45,7 @@ describe('Custom Classes', () => {
     it('should return a json object where properties are only FormNodeTypes GROUP | ARRAY | CONTROL', inject(
       [DynamicFormService],
       (dfs: DynamicFormService) => {
-        const form = dfs.createForm(template);
+        const form = dfs.createForm(template, expected);
         expect(form.getCleanValue(form)).toEqual(expected);
       }
     ));

--- a/src/app/forms/templates/general/plates.template.ts
+++ b/src/app/forms/templates/general/plates.template.ts
@@ -1,44 +1,46 @@
 import { FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
 
 export const PlatesTemplate: FormNode = {
-    name: '',
-    label: 'Plates',
-    viewType: FormNodeViewTypes.SUBHEADING,
-    type: FormNodeTypes.GROUP,
-    children: [{
-        name: 'plates',
-        type: FormNodeTypes.ARRAY,
-        children: [
+  name: 'platesSection',
+  label: 'Plates',
+  viewType: FormNodeViewTypes.SUBHEADING,
+  type: FormNodeTypes.GROUP,
+  children: [
+    {
+      name: 'plates',
+      type: FormNodeTypes.ARRAY,
+      children: [
+        {
+          name: '0',
+          type: FormNodeTypes.GROUP,
+          children: [
             {
-                name: 'plates',
-                type: FormNodeTypes.GROUP,
-                children: [
-                    {
-                        name: 'plateSerialNumber',
-                        label: 'Plate serial number',
-                        value: '',
-                        type: FormNodeTypes.CONTROL,
-                    },
-                    {
-                        name: 'plateIssueDate',
-                        label: 'Plate issue date',
-                        value: '',
-                        type: FormNodeTypes.CONTROL,
-                    },
-                    {
-                        name: 'plateReasonForIssue',
-                        label: 'Plate reason for issue',
-                        value: '',
-                        type: FormNodeTypes.CONTROL,
-                    },
-                    {
-                        name: 'plateIssuer',
-                        label: 'Plate issuer',
-                        value: '',
-                        type: FormNodeTypes.CONTROL,
-                    }
-                ]
+              name: 'plateSerialNumber',
+              label: 'Plate serial number',
+              value: '',
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'plateIssueDate',
+              label: 'Plate issue date',
+              value: '',
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'plateReasonForIssue',
+              label: 'Plate reason for issue',
+              value: '',
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'plateIssuer',
+              label: 'Plate issuer',
+              value: '',
+              type: FormNodeTypes.CONTROL
             }
-        ]
-    }]
+          ]
+        }
+      ]
+    }
+  ]
 };

--- a/src/mocks/hgv-record.mock.ts
+++ b/src/mocks/hgv-record.mock.ts
@@ -1,104 +1,114 @@
-import { VehicleTechRecordModel, StatusCodes, VehicleTypes, FuelTypes, VehicleConfigurations, EuVehicleCategories, approvalType, PlateReasonForIssue, BodyTypeDescription } from '../app/models/vehicle-tech-record.model';
-import { createMock } from "ts-auto-mock";
+import {
+  VehicleTechRecordModel,
+  StatusCodes,
+  VehicleTypes,
+  FuelTypes,
+  VehicleConfigurations,
+  EuVehicleCategories,
+  approvalType,
+  PlateReasonForIssue,
+  BodyTypeDescription
+} from '../app/models/vehicle-tech-record.model';
+import { createMock } from 'ts-auto-mock';
 
 export const createMockHgv = (systemNumber: number): VehicleTechRecordModel =>
-    createMock<VehicleTechRecordModel>({
-        systemNumber: `HGV${String(systemNumber + 1).padStart(4, '0')}`,
-        vin: `XMGDE03FS0H0${12344 + systemNumber + 1}`,
-        vrms: [
-            {
-                vrm: `KP${String(systemNumber + 1).padStart(2, '0')} ABC`,
-                isPrimary: true
-            },
-            {
-                vrm: '609859Z',
-                isPrimary: false
-            }
-        ],
-        techRecord: [
-            currentTechRecord
-        ]
-    });
+  createMock<VehicleTechRecordModel>({
+    systemNumber: `HGV${String(systemNumber + 1).padStart(4, '0')}`,
+    vin: `XMGDE03FS0H0${12344 + systemNumber + 1}`,
+    vrms: [
+      {
+        vrm: `KP${String(systemNumber + 1).padStart(2, '0')} ABC`,
+        isPrimary: true
+      },
+      {
+        vrm: '609859Z',
+        isPrimary: false
+      }
+    ],
+    techRecord: [currentTechRecord]
+  });
 
 const currentTechRecord = {
-    createdAt: new Date(),
-    createdByName: 'Nathan',
-    statusCode: StatusCodes.CURRENT,
-    vehicleType: VehicleTypes.HGV,
-    regnDate: '1234',
-    manufactureYear: 2022,
-    noOfAxles: 2,
-    axles: [
-        {
-            axleNumber: 12,
-            parkingBrakeMrk: false,
-        },
-        {
-            parkingBrakeMrk: true
-        }
-    ],
-    brakes: {
-        dtpNumber: '1234'
+  createdAt: new Date(),
+  createdByName: 'Nathan',
+  statusCode: StatusCodes.CURRENT,
+  vehicleType: VehicleTypes.HGV,
+  regnDate: '1234',
+  manufactureYear: 2022,
+  noOfAxles: 2,
+  axles: [
+    {
+      axleNumber: 12,
+      parkingBrakeMrk: false
     },
-    speedLimiterMrk: true,
-    tachoExemptMrk: true,
-    euroStandard: '123',
-    roadFriendly: true,
-    fuelPropulsionSystem: FuelTypes.HYBRID,
-    drawbarCouplingFitted: true,
-    vehicleClass: {
-        description: 'Description'
+    {
+      parkingBrakeMrk: true
+    }
+  ],
+  brakes: {
+    dtpNumber: '1234'
+  },
+  speedLimiterMrk: true,
+  tachoExemptMrk: true,
+  euroStandard: '123',
+  roadFriendly: true,
+  fuelPropulsionSystem: FuelTypes.HYBRID,
+  drawbarCouplingFitted: true,
+  vehicleClass: {
+    description: 'Description'
+  },
+  vehicleConfiguration: VehicleConfigurations.ARTICULATED,
+  offRoad: true,
+  euVehicleCategory: EuVehicleCategories.M1,
+  emissionsLimit: 1234,
+  departmentalVehicleMarker: true,
+  reasonForCreation: 'Brake Failure',
+  approvalType: approvalType.ECSSTA,
+  approvalTypeNumber: 'approval123',
+  ntaNumber: 'nta789',
+  variantNumber: 'variant123456',
+  variantVersionNumber: 'variantversion123456',
+  dimensions: {
+    length: 1,
+    width: 2,
+    height: 6,
+    axleSpacing: [
+      {
+        axles: '1-2',
+        value: 4
+      }
+    ]
+  },
+  frontAxleToRearAxle: 3,
+  frontAxleTo5thWheelCouplingMin: 5,
+  frontAxleTo5thWheelCouplingMax: 6,
+  frontAxleTo5thWheelMin: 7,
+  frontAxleTo5thWheelMax: 8,
+  plates: [
+    {
+      plateSerialNumber: '12345',
+      plateIssueDate: new Date(),
+      plateReasonForIssue: PlateReasonForIssue.REPLACEMENT,
+      plateIssuer: 'person'
     },
-    vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-    offRoad: true,
-    euVehicleCategory: EuVehicleCategories.M1,
-    emissionsLimit: 1234,
-    departmentalVehicleMarker: true,
-    reasonForCreation: 'Brake Failure',
-    approvalType: approvalType.ECSSTA,
-    approvalTypeNumber: 'approval123',
-    ntaNumber: 'nta789',
-    variantNumber: 'variant123456',
-    variantVersionNumber: 'variantversion123456',
-    dimensions: {
-        length: 1,
-        width: 2,
-        height: 6,
-        axleSpacing: [{
-            axles: '1-2',
-            value: 4
-        }]
-    },
-    frontAxleToRearAxle: 3,
-    frontAxleTo5thWheelCouplingMin: 5,
-    frontAxleTo5thWheelCouplingMax: 6,
-    frontAxleTo5thWheelMin: 7,
-    frontAxleTo5thWheelMax: 8,
-    plates: [
-        {
-            plateSerialNumber: "12345",
-            plateIssueDate: new Date(),
-            plateReasonForIssue: PlateReasonForIssue.REPLACEMENT,
-            plateIssuer: "person"
-        },
-        {
-            plateSerialNumber: "54321",
-            plateIssueDate: new Date(),
-            plateReasonForIssue: PlateReasonForIssue.REPLACEMENT,
-            plateIssuer: "person 2"
-        }
-    ],
-    make: "1234",
-    model: "1234",
-    bodyType: {
-        description: BodyTypeDescription.OTHER,
-    },
-    functionCode: "1",
-    conversionRefNo: "1234",
-    grossGbWeight: 2,
-    grossEecWeight: 4,
-    grossDesignWeight: 3,
-    trainGbWeight: 3,
-    trainEecWeight: 3,
-    trainDesignWeight: 7,
-}
+    {
+      plateSerialNumber: '54321',
+      plateIssueDate: new Date(),
+      plateReasonForIssue: PlateReasonForIssue.REPLACEMENT,
+      plateIssuer: 'person 2'
+    }
+  ],
+  make: '1234',
+  model: '1234',
+  bodyType: {
+    description: BodyTypeDescription.OTHER
+  },
+  functionCode: '1',
+  conversionRefNo: '1234',
+  grossGbWeight: 2,
+  grossEecWeight: 4,
+  grossDesignWeight: 3,
+  trainGbWeight: 3,
+  trainEecWeight: 3,
+  trainDesignWeight: 7
+};


### PR DESCRIPTION
## Fix tech record not rendering with an empty array

When a section that requires an array to be provided was given a null, the form broke and would not load. This fix aims to correct that. Currently it just renders the title and no more information, but in future work this will be changed.

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
