### PR TITLE
fix(cb2-4581): Fix dispensations field on the PSV notes

### DIFF
--- a/src/app/forms/templates/psv/psv-notes.template.ts
+++ b/src/app/forms/templates/psv/psv-notes.template.ts
@@ -10,6 +10,12 @@ export const PsvNotes: FormNode = {
       name: 'remarks',
       label: 'Notes',
       type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'dispensations',
+      type: FormNodeTypes.CONTROL,
+      label: 'Dispensations',
+      value: ''
     }
   ]
 };

--- a/src/mocks/psv-record.mock.ts
+++ b/src/mocks/psv-record.mock.ts
@@ -151,6 +151,7 @@ const provisionalTechRecord = {
     microfilmSerialNumber: 'ser123456'
   },
   remarks: 'Some notes about the vehicle',
+  dispensations: 'reason given',
   reasonForCreation: 'Brake Failure',
   modelLiteral: 'Vehicle model',
   chassisMake: 'Chassis make',
@@ -288,6 +289,7 @@ const archivedTechRecord = {
     microfilmSerialNumber: 'ser123456'
   },
   remarks: 'Some notes about the vehicle',
+  dispensations: 'reason given',
   reasonForCreation: 'COIF',
   modelLiteral: 'Vehicle model',
   chassisMake: 'Chassis make',
@@ -411,6 +413,7 @@ const currentTechRecord = {
     microfilmSerialNumber: 'ser123456'
   },
   remarks: 'Some notes about the vehicle',
+  dispensations: 'reason given',
   reasonForCreation: 'COIF',
   modelLiteral: 'Vehicle model',
   chassisMake: 'Chassis make',


### PR DESCRIPTION
## Fix dispensations field on the PSV notes

Had to add in the dispensations field for PSV
[CB2-4581](https://dvsa.atlassian.net/browse/CB2-4581)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Link to the PR added to the repo
- [x] Delete branch after merge
