### PR TITLE
fix(cb2-4799): test amendment not displaying

### DIFF
--- a/src/app/resolvers/test-result/test-result.resolver.spec.ts
+++ b/src/app/resolvers/test-result/test-result.resolver.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, RouterStateSnapshot } from '@angular/router';
+import { RouterStateSnapshot } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TestResultModel } from '@models/test-result.model';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -9,15 +8,12 @@ import { initialAppState, State } from '@store/.';
 import { fetchSelectedTestResult, fetchSelectedTestResultFailed, fetchSelectedTestResultSuccess, selectedTestResultState } from '@store/test-records';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { createMock } from 'ts-auto-mock';
 import { TestResultResolver } from './test-result.resolver';
 
 describe('TestResultResolver', () => {
   let resolver: TestResultResolver;
   let actions$ = new Observable<Action>();
   let testScheduler: TestScheduler;
-  let route: ActivatedRoute;
-  let state: RouterStateSnapshot;
   let mockSnapshot: any = jest.fn;
   let store: MockStore<State>;
 
@@ -31,10 +27,7 @@ describe('TestResultResolver', () => {
         { provide: RouterStateSnapshot, useValue: mockSnapshot }
       ]
     });
-
     resolver = TestBed.inject(TestResultResolver);
-    route = TestBed.inject(ActivatedRoute);
-    state = TestBed.inject(RouterStateSnapshot);
     store = TestBed.inject(MockStore);
   });
 
@@ -48,28 +41,13 @@ describe('TestResultResolver', () => {
     expect(resolver).toBeTruthy();
   });
 
-  describe('when selected test result is already in state', () => {
-    it(`should resolve to true without calling dispatching 'fetchSelectedTestResult'`, () => {
-      const dispatchSpy = jest.spyOn(store, 'dispatch');
-      const testResult = createMock<TestResultModel>({ testResultId: 'testResultId' });
-      store.overrideSelector(selectedTestResultState, testResult);
-      testScheduler.run(({ hot, expectObservable }) => {
-        expectObservable(resolver.resolve(route.snapshot, state)).toBe('(a|)', {
-          a: true
-        });
-      });
-
-      expect(dispatchSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when selected test result is not in state', () => {
+  describe('fetch test result', () => {
     it(`should dispatch 'fetchSelectedTestResult' action and resolve to true when 'fetchSelectedTestResultSuccess' action is emitted`, () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       store.overrideSelector(selectedTestResultState, undefined);
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a-', { a: fetchSelectedTestResultSuccess });
-        expectObservable(resolver.resolve(route.snapshot, state)).toBe('-(b|)', {
+        expectObservable(resolver.resolve()).toBe('-(b|)', {
           b: true
         });
       });
@@ -82,7 +60,7 @@ describe('TestResultResolver', () => {
       store.overrideSelector(selectedTestResultState, undefined);
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a-', { a: fetchSelectedTestResultFailed });
-        expectObservable(resolver.resolve(route.snapshot, state)).toBe('-(b|)', {
+        expectObservable(resolver.resolve()).toBe('-(b|)', {
           b: false
         });
       });

--- a/src/app/resolvers/test-result/test-result.resolver.ts
+++ b/src/app/resolvers/test-result/test-result.resolver.ts
@@ -17,7 +17,7 @@ export class TestResultResolver implements Resolve<boolean> {
     return this.action$.pipe(
       ofType(fetchSelectedTestResultSuccess, fetchSelectedTestResultFailed),
       take(1),
-      map(action => (action.type === fetchSelectedTestResultSuccess.type ? true : false))
+      map(action => action.type === fetchSelectedTestResultSuccess.type)
     );
   }
 }

--- a/src/app/resolvers/test-result/test-result.resolver.ts
+++ b/src/app/resolvers/test-result/test-result.resolver.ts
@@ -12,31 +12,12 @@ import { concatMap, map, mergeMap, Observable, of, take, tap } from 'rxjs';
 export class TestResultResolver implements Resolve<boolean> {
   constructor(private store: Store<State>, private action$: Actions) {}
 
-  /**
-   * Fetch test result if it is not already in the store and resolve to true if it is or fetch was successful.
-   * @param route
-   * @param state
-   * @returns true to resolve the route or false to block navigation
-   */
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    return this.store.pipe(
-      select(selectedTestResultState),
+  resolve(): Observable<boolean> {
+    this.store.dispatch(fetchSelectedTestResult());
+    return this.action$.pipe(
+      ofType(fetchSelectedTestResultSuccess, fetchSelectedTestResultFailed),
       take(1),
-      concatMap((testResult) => of(!testResult ? true : false)),
-      tap((dispatch) => {
-        if (dispatch) {
-          this.store.dispatch(fetchSelectedTestResult());
-        }
-      }),
-      mergeMap((dispatch) => {
-        return dispatch
-          ? this.action$.pipe(
-              ofType(fetchSelectedTestResultSuccess, fetchSelectedTestResultFailed),
-              take(1),
-              map((action) => (action.type === fetchSelectedTestResultSuccess.type ? true : false))
-            )
-          : of(true);
-      })
+      map(action => (action.type === fetchSelectedTestResultSuccess.type ? true : false))
     );
   }
 }


### PR DESCRIPTION
## Ticket title

_Test amendment history is not displaying when navigating from tech record view. The resolver checking if the test record exists in store is redundant and means vtm does not make a second request to the api for test history when navigating from tech view_
[CB2-4799](https://dvsa.atlassian.net/browse/CB2-4799)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
