### PR TITLE
fix(*): mock-api and error message fix

### DIFF
--- a/mock-api/mock-api-server.ts
+++ b/mock-api/mock-api-server.ts
@@ -9,8 +9,8 @@ const middlewares = jsonServer.defaults();
 server.use(middlewares);
 
 // Add custom routes before JSON Server router
-server.get('/vehicles/:vin/*', (req, res) => {
-  switch (req.params.vin) {
+server.get('/vehicles/:systemNumber/*', (req, res) => {
+  switch (req.params.systemNumber) {
     case 'delayok':
       console.log('Delaying request');
       setTimeout(() => {
@@ -63,7 +63,7 @@ server.get('/vehicles/:vin/*', (req, res) => {
     default:
       res.status(404);
       res.statusMessage = 'NotFound';
-      res.jsonp('Error no test records found');
+      res.jsonp('Error no tech records found');
       break;
   }
 });

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -111,13 +111,29 @@ describe('TestResultsEffects', () => {
         actions$ = hot('-a--', { a: fetchTestResultsBySystemNumber });
 
         const expectedError = new HttpErrorResponse({
+          status: 500,
+          statusText: 'server not available'
+        });
+        jest.spyOn(testResultsService, 'fetchTestResultbySystemNumber').mockReturnValue(cold('--#|', {}, expectedError));
+
+        expectObservable(effects.fetchTestResultsBySystemNumber$).toBe('---b', {
+          b: fetchTestResultsBySystemNumberFailed({ error: 'Http failure response for (unknown url): 500 server not available' })
+        });
+      });
+    });
+
+    it('should return fetchTestResultsBySystemNumberFailed action on API error', () => {
+      testScheduler.run(({ hot, cold, expectObservable }) => {
+        actions$ = hot('-a--', { a: fetchTestResultsBySystemNumber });
+
+        const expectedError = new HttpErrorResponse({
           status: 404,
           statusText: 'Not found'
         });
         jest.spyOn(testResultsService, 'fetchTestResultbySystemNumber').mockReturnValue(cold('--#|', {}, expectedError));
 
         expectObservable(effects.fetchTestResultsBySystemNumber$).toBe('---b', {
-          b: fetchTestResultsBySystemNumberFailed({ error: 'Http failure response for (unknown url): 404 Not found' })
+          b: fetchTestResultsBySystemNumberSuccess({ payload: [] as TestResultModel[] })
         });
       });
     });

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
+import { TestResultModel } from '@models/test-result.model';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { select, Store } from '@ngrx/store';
 import { RouterService } from '@services/router/router.service';
@@ -28,7 +29,13 @@ export class TestResultsEffects {
       mergeMap(({ systemNumber }) =>
         this.testRecordsService.fetchTestResultbySystemNumber(systemNumber).pipe(
           map(testResults => fetchTestResultsBySystemNumberSuccess({ payload: testResults })),
-          catchError(e => of(fetchTestResultsBySystemNumberFailed({ error: e.message })))
+          catchError(e => {
+            switch (e.status) {
+              case 404:
+                return of(fetchTestResultsBySystemNumberSuccess({ payload: [] as TestResultModel[] }));
+            }
+            return of(fetchTestResultsBySystemNumberFailed({ error: e.message }));
+          })
         )
       )
     )

--- a/src/mocks/hgv-record.mock.ts
+++ b/src/mocks/hgv-record.mock.ts
@@ -13,7 +13,7 @@ import { createMock } from 'ts-auto-mock';
 
 export const createMockHgv = (systemNumber: number): VehicleTechRecordModel =>
   createMock<VehicleTechRecordModel>({
-    systemNumber: `HGV${String(systemNumber + 1).padStart(4, '0')}`,
+    systemNumber: `HGV`,
     vin: `XMGDE03FS0H0${12344 + systemNumber + 1}`,
     vrms: [
       {

--- a/src/mocks/psv-record.mock.ts
+++ b/src/mocks/psv-record.mock.ts
@@ -17,7 +17,7 @@ import { createMock } from 'ts-auto-mock';
 
 export const createMockPsv = (systemNumber: number): VehicleTechRecordModel =>
   createMock<VehicleTechRecordModel>({
-    systemNumber: `SYS${String(systemNumber + 1).padStart(4, '0')}`,
+    systemNumber: `PSV`,
     vin: `XMGDE02FS0H0${12344 + systemNumber + 1}`,
     vrms: [
       {

--- a/src/mocks/trl-record.mock.ts
+++ b/src/mocks/trl-record.mock.ts
@@ -1,67 +1,76 @@
-import { VehicleTechRecordModel, StatusCodes, VehicleTypes, VehicleConfigurations, FrameDescriptions, EuVehicleCategories, approvalType, PlateReasonForIssue } from '../app/models/vehicle-tech-record.model';
-import { createMock } from "ts-auto-mock";
+import {
+  VehicleTechRecordModel,
+  StatusCodes,
+  VehicleTypes,
+  VehicleConfigurations,
+  FrameDescriptions,
+  EuVehicleCategories,
+  approvalType,
+  PlateReasonForIssue
+} from '../app/models/vehicle-tech-record.model';
+import { createMock } from 'ts-auto-mock';
 
 export const createMockTrl = (systemNumber: number): VehicleTechRecordModel =>
-    createMock<VehicleTechRecordModel>({
-        systemNumber: `TRL${String(systemNumber + 1).padStart(4, '0')}`,
-        vin: `XMGDE04FS0H0${12344 + systemNumber + 1}`,
-        vrms: [
-            {
-                vrm: `KP${String(systemNumber + 1).padStart(2, '0')} ABC`,
-                isPrimary: true
-            },
-            {
-                vrm: '609859Z',
-                isPrimary: false
-            }
-        ],
-        techRecord: [
-            currentTechRecord
-        ]
-    });
+  createMock<VehicleTechRecordModel>({
+    systemNumber: `TRL`,
+    vin: `XMGDE04FS0H0${12344 + systemNumber + 1}`,
+    vrms: [
+      {
+        vrm: `KP${String(systemNumber + 1).padStart(2, '0')} ABC`,
+        isPrimary: true
+      },
+      {
+        vrm: '609859Z',
+        isPrimary: false
+      }
+    ],
+    techRecord: [currentTechRecord]
+  });
 
 const currentTechRecord = {
-    createdAt: new Date(),
-    createdByName: 'Nathan',
-    statusCode: StatusCodes.CURRENT,
-    vehicleType: VehicleTypes.TRL,
-    regnDate: '1234',
-    firstUseDate: '1234',
-    manufactureYear: 2022,
-    noOfAxles: 2,
-    brakes: {
-        dtpNumber: '1234'
+  createdAt: new Date(),
+  createdByName: 'Nathan',
+  statusCode: StatusCodes.CURRENT,
+  vehicleType: VehicleTypes.TRL,
+  regnDate: '1234',
+  firstUseDate: '1234',
+  manufactureYear: 2022,
+  noOfAxles: 2,
+  brakes: {
+    dtpNumber: '1234'
+  },
+  axles: [
+    {
+      parkingBrakeMrk: false
     },
-    axles: [
-        {
-            parkingBrakeMrk: false
-        },
-        {
-            parkingBrakeMrk: true
-        }
-    ],
-    suspensionType: '1',
-    roadFriendly: true,
-    drawbarCouplingFitted: true,
-    vehicleClass: {
-        description: 'Description'
-    },
-    vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-    couplingType: '1',
-    maxLoadOnCoupling: 1234,
-    frameDescription: FrameDescriptions.FRAME_SECTION,
-    euVehicleCategory: EuVehicleCategories.M1,
-    departmentalVehicleMarker: true,
-    reasonForCreation: 'Brake Failure',
-    approvalType: approvalType.ECSSTA,
-    approvalTypeNumber: 'approval123',
-    ntaNumber: 'nta789',
-    variantNumber: 'variant123456',
-    variantVersionNumber: 'variantversion123456',
-    plates: [{
-        plateSerialNumber: "12345",
-        plateIssueDate: new Date(),
-        plateReasonForIssue: PlateReasonForIssue.REPLACEMENT,
-        plateIssuer: "person"
-    }]
-}
+    {
+      parkingBrakeMrk: true
+    }
+  ],
+  suspensionType: '1',
+  roadFriendly: true,
+  drawbarCouplingFitted: true,
+  vehicleClass: {
+    description: 'Description'
+  },
+  vehicleConfiguration: VehicleConfigurations.ARTICULATED,
+  couplingType: '1',
+  maxLoadOnCoupling: 1234,
+  frameDescription: FrameDescriptions.FRAME_SECTION,
+  euVehicleCategory: EuVehicleCategories.M1,
+  departmentalVehicleMarker: true,
+  reasonForCreation: 'Brake Failure',
+  approvalType: approvalType.ECSSTA,
+  approvalTypeNumber: 'approval123',
+  ntaNumber: 'nta789',
+  variantNumber: 'variant123456',
+  variantVersionNumber: 'variantversion123456',
+  plates: [
+    {
+      plateSerialNumber: '12345',
+      plateIssueDate: new Date(),
+      plateReasonForIssue: PlateReasonForIssue.REPLACEMENT,
+      plateIssuer: 'person'
+    }
+  ]
+};


### PR DESCRIPTION
## Fixing mock-api and the error message on tech record with no test records

_Changing the routing on tech record to `systemNumber` from `vin` broke the mock-api_
_We also don't want to show an error message on tech record view when the vehicle has no test results, fixing that issue as well_

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
