### PR TITLE
feat(cb2-4068): reason for creation can now be edited

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/required/required-hidden-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/required/required-hidden-section.template.ts
@@ -94,8 +94,10 @@ export const RequiredSection: FormNode = {
     },
     {
       name: 'reasonForCreation',
+      label: 'Reason for creation',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.TEXTAREA,
       validators: [{ name: ValidatorNames.MaxLength, args: 500 }, { name: ValidatorNames.Required }]
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/required/required-hidden-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/required/required-hidden-section.template.ts
@@ -1,4 +1,5 @@
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
+import { ValidatorNames } from '@forms/models/validators.enum';
 
 export const RequiredSection: FormNode = {
   name: 'requiredSection',
@@ -94,8 +95,8 @@ export const RequiredSection: FormNode = {
     {
       name: 'reasonForCreation',
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.HIDDEN,
-      viewType: FormNodeViewTypes.HIDDEN
+      viewType: FormNodeViewTypes.HIDDEN,
+      validators: [{ name: ValidatorNames.MaxLength, args: 500 }, { name: ValidatorNames.Required }]
     },
     {
       name: 'createdByName',


### PR DESCRIPTION
Allows the reason for creation field to be edited, does not add in a popup as that hasn't been confirmed by service design.
[CB2-4068](https://dvsa.atlassian.net/browse/CB2-4068)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
