### PR TITLE
chore(*): improve performance

### DIFF
--- a/src/app/forms/components/defects/defects.component.spec.ts
+++ b/src/app/forms/components/defects/defects.component.spec.ts
@@ -15,7 +15,6 @@ import { DefectSelectComponent } from '../defect-select/defect-select.component'
 import { DefectComponent } from '../defect/defect.component';
 import { DefectsComponent } from './defects.component';
 import { ButtonComponent } from '@shared/components/button/button.component';
-import exp from 'constants';
 
 describe('DefectsComponent', () => {
   let component: DefectsComponent;
@@ -85,7 +84,7 @@ describe('DefectsComponent', () => {
   });
 
   describe('update the result of the test', () => {
-    it('should dispatch the action to udpate the result of the test on form change', () => {
+    it('should dispatch the action to udpate the result of the test on form change', fakeAsync(() => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const template = DefectsTpl;
       const data = mockTestResult();
@@ -96,9 +95,10 @@ describe('DefectsComponent', () => {
       expect(component.defectsForm.length).toBe(1);
 
       component.handleRemoveDefect(0);
+      tick(500);
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       fixture.detectChanges();
       expect(component.defectsForm.length).toBe(0);
-    });
+    }));
   });
 });

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.spec.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideMockStore } from '@ngrx/store/testing';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
@@ -151,5 +151,31 @@ describe('DynamicFormGroupComponent', () => {
 
       expect(inputList.length).toBe(4);
     }));
+  });
+
+  describe('value changes', () => {
+    const template = <FormNode>{
+      name: 'myForm',
+      type: FormNodeTypes.GROUP,
+      children: [{ name: 'levelOneControl', type: FormNodeTypes.CONTROL, label: 'Level one control', value: 'some string' }]
+    };
+
+    const data = {
+      levelOneControl: 'some string'
+    };
+    it('should output an event when the value of the control changes', fakeAsync(
+      inject([DynamicFormService], (dfs: DynamicFormService) => {
+        component.edit = true;
+        component.form = dfs.createForm(template, data);
+
+        fixture.detectChanges();
+
+        const control = component.form.get('levelOneControl');
+        control?.patchValue('foo');
+        const emitter = jest.spyOn(component.formChange, 'emit');
+        tick(500);
+        expect(emitter).toHaveBeenCalledTimes(1);
+      })
+    ));
   });
 });

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Subject, takeUntil, debounceTime, tap, distinctUntilChanged, map } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { DynamicFormService } from '../../services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
 

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject, takeUntil, debounceTime, tap, distinctUntilChanged, map } from 'rxjs';
 import { DynamicFormService } from '../../services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
 
@@ -28,7 +28,7 @@ export class DynamicFormGroupComponent implements OnChanges, OnInit, OnDestroy {
       this.form = this.dfs.createForm(template.currentValue, this.data);
     }
     if (data.currentValue && data.currentValue !== data.previousValue) {
-      this.form.patchValue(data.currentValue);
+      this.form.patchValue(data.currentValue, { emitEvent: false });
     }
   }
 

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/forms';
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { map, Observable } from 'rxjs';
+import { map, Observable, debounceTime } from 'rxjs';
 import { DynamicFormService } from './dynamic-form.service';
 import { SpecialRefData } from './multi-options.service';
 
@@ -136,7 +136,10 @@ export class CustomFormGroup extends FormGroup implements CustomGroup, BaseForm 
   getCleanValue = cleanValue.bind(this);
 
   get cleanValueChanges() {
-    return this.valueChanges.pipe(map(() => this.getCleanValue(this)));
+    return this.valueChanges.pipe(
+      debounceTime(500),
+      map(() => this.getCleanValue(this))
+    );
   }
 }
 
@@ -162,7 +165,10 @@ export class CustomFormArray extends FormArray implements CustomArray, BaseForm 
   getCleanValue = cleanValue.bind(this);
 
   get cleanValueChanges() {
-    return this.valueChanges.pipe(map(() => this.getCleanValue(this)));
+    return this.valueChanges.pipe(
+      debounceTime(500),
+      map(() => this.getCleanValue(this))
+    );
   }
 
   addControl(data?: any): void {


### PR DESCRIPTION
VTM is currently dispatching 16-17 actions on every keystroke to update state with the latest changes from the form, causing a noticeable drop in speed and efficiency. In order to fix this issue, this PR:

- Ensures the number of actions being dispatched is at maximum one per keystroke
- Adds a debounce time to only dispatch the action if the form has not been updated in the last 500ms

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
