### PR TITLE
fix(cb2-4969): brought additional comments for abandoning into line

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group12And14.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group12And14.template.ts
@@ -91,8 +91,16 @@ export const TestSectionGroup12And14: FormNode = {
               name: 'additionalCommentsForAbandon',
               type: FormNodeTypes.CONTROL,
               value: '',
+              required: true,
               label: 'Additional details for abandoning',
-              disabled: true
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+              ]
             },
             {
               name: 'testTypeStartTimestamp',

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group3And4And8.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group3And4And8.template.ts
@@ -91,8 +91,16 @@ export const TestSectionGroup3And4And8: FormNode = {
               name: 'additionalCommentsForAbandon',
               type: FormNodeTypes.CONTROL,
               value: '',
+              required: true,
               label: 'Additional details for abandoning',
-              disabled: true
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+              ]
             },
             {
               name: 'testTypeStartTimestamp',

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group5And13.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group5And13.template.ts
@@ -99,8 +99,16 @@ export const TestSectionGroup5And13: FormNode = {
               name: 'additionalCommentsForAbandon',
               type: FormNodeTypes.CONTROL,
               value: '',
+              required: true,
               label: 'Additional details for abandoning',
-              disabled: true
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+              ]
             },
             {
               name: 'testTypeStartTimestamp',

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
@@ -99,8 +99,16 @@ export const TestSectionGroup6And11: FormNode = {
               name: 'additionalCommentsForAbandon',
               type: FormNodeTypes.CONTROL,
               value: '',
+              required: true,
               label: 'Additional details for abandoning',
-              disabled: true
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+              ]
             },
             {
               name: 'testTypeStartTimestamp',

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group7.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group7.template.ts
@@ -107,8 +107,16 @@ export const TestSectionGroup7: FormNode = {
               name: 'additionalCommentsForAbandon',
               type: FormNodeTypes.CONTROL,
               value: '',
+              required: true,
               label: 'Additional details for abandoning',
-              disabled: true
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+              ]
             },
             {
               name: 'testTypeStartTimestamp',

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group9And10.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group9And10.template.ts
@@ -108,8 +108,16 @@ export const TestSectionGroup9And10: FormNode = {
               name: 'additionalCommentsForAbandon',
               type: FormNodeTypes.CONTROL,
               value: '',
+              required: true,
               label: 'Additional details for abandoning',
-              disabled: true
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+              ]
             },
             {
               name: 'testAnniversaryDate',


### PR DESCRIPTION
Additional comments were not set to required when hidden in all templates, this has been fixed.

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-4969)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
