### PR TITLE
fix(*): improve-performance

### DIFF
--- a/src/app/features/test-records/components/base-test-record/base-test-record.component.ts
+++ b/src/app/features/test-records/components/base-test-record/base-test-record.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, Component, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { DefectsComponent } from '@forms/components/defects/defects.component';
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
 import { FormNode } from '@forms/services/dynamic-form.types';

--- a/src/app/features/test-records/components/base-test-record/base-test-record.component.ts
+++ b/src/app/features/test-records/components/base-test-record/base-test-record.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, Component, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, Component, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { DefectsComponent } from '@forms/components/defects/defects.component';
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
 import { FormNode } from '@forms/services/dynamic-form.types';
@@ -10,7 +10,7 @@ import merge from 'lodash.merge';
   selector: 'app-base-test-record[testResult]',
   templateUrl: './base-test-record.component.html'
 })
-export class BaseTestRecordComponent implements AfterViewChecked {
+export class BaseTestRecordComponent implements AfterViewInit {
   @ViewChildren(DynamicFormGroupComponent) sections?: QueryList<DynamicFormGroupComponent>;
   @ViewChild(DefectsComponent) defects?: DefectsComponent;
 
@@ -21,7 +21,7 @@ export class BaseTestRecordComponent implements AfterViewChecked {
 
   @Output() newTestResult = new EventEmitter<TestResultModel>();
 
-  ngAfterViewChecked(): void {
+  ngAfterViewInit(): void {
     this.handleFormChange({});
   }
 

--- a/src/app/forms/components/defects/defects.component.ts
+++ b/src/app/forms/components/defects/defects.component.ts
@@ -6,7 +6,7 @@ import { Deficiency } from '@models/defects/deficiency.model';
 import { Item } from '@models/defects/item.model';
 import { TestResultDefect } from '@models/test-results/test-result-defect.model';
 import { ResultOfTestService } from '@services/result-of-test/result-of-test.service';
-import { Subscription } from 'rxjs';
+import { debounceTime, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-defects[defects][template]',
@@ -27,7 +27,7 @@ export class DefectsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.form = this.dfs.createForm(this.template, this.data) as CustomFormGroup;
-    this.formSubscription = this.form.cleanValueChanges.subscribe(event => {
+    this.formSubscription = this.form.cleanValueChanges.pipe(debounceTime(400)).subscribe(event => {
       this.formChange.emit(event);
       this.resultService.updateResultOfTest();
     });

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.spec.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.spec.ts
@@ -174,6 +174,7 @@ describe('DynamicFormGroupComponent', () => {
         control?.patchValue('foo');
         const emitter = jest.spyOn(component.formChange, 'emit');
         tick(500);
+        expect(emitter).toHaveBeenCalledWith({ ...data, levelOneControl: 'foo' });
         expect(emitter).toHaveBeenCalledTimes(1);
       })
     ));

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject, takeUntil, tap, debounceTime } from 'rxjs';
 import { DynamicFormService } from '../../services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
 
@@ -33,7 +33,7 @@ export class DynamicFormGroupComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.form.cleanValueChanges.pipe(takeUntil(this.destroy$)).subscribe(e => this.formChange.emit(e));
+    this.form.cleanValueChanges.pipe(debounceTime(400), takeUntil(this.destroy$)).subscribe(e => this.formChange.emit(e));
   }
 
   ngOnDestroy(): void {

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Subject, takeUntil, tap, debounceTime } from 'rxjs';
+import { Subject, takeUntil, debounceTime } from 'rxjs';
 import { DynamicFormService } from '../../services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
 

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -14,7 +14,7 @@ import { ValidatorNames } from '@forms/models/validators.enum';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
 import { Store } from '@ngrx/store';
 import { TestResultsState } from '@store/test-records';
-import { map, Observable, debounceTime } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { DynamicFormService } from './dynamic-form.service';
 import { SpecialRefData } from './multi-options.service';
 
@@ -140,10 +140,7 @@ export class CustomFormGroup extends FormGroup implements CustomGroup, BaseForm 
   getCleanValue = cleanValue.bind(this);
 
   get cleanValueChanges() {
-    return this.valueChanges.pipe(
-      debounceTime(500),
-      map(() => this.getCleanValue(this))
-    );
+    return this.valueChanges.pipe(map(() => this.getCleanValue(this)));
   }
 }
 
@@ -170,10 +167,7 @@ export class CustomFormArray extends FormArray implements CustomArray, BaseForm 
   getCleanValue = cleanValue.bind(this);
 
   get cleanValueChanges() {
-    return this.valueChanges.pipe(
-      debounceTime(500),
-      map(() => this.getCleanValue(this))
-    );
+    return this.valueChanges.pipe(map(() => this.getCleanValue(this)));
   }
 
   addControl(data?: any): void {


### PR DESCRIPTION
https://github.com/dvsa/cvs-app-vtm/pull/454 had some unintended consequences where the subscription was not updating the object in state. Moving the debounce from the interface to the consumers of the observable fixed the issue. Many actions were still being dispatched since the base-test-record component essentially dispatched actions on change with the `afterViewChecked` lifecycle hook

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
