### PR TITLE
feat(CB2-4202): Make the Defect Fields Dynamic

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -108,6 +108,7 @@
   },
   "defaultProject": "cvs-app-vtm",
   "cli": {
+    "analytics": false,
     "defaultCollection": "@angular-eslint/schematics"
   }
 }

--- a/src/app/features/test-records/views/test-record/test-record.component.html
+++ b/src/app/features/test-records/views/test-record/test-record.component.html
@@ -13,7 +13,7 @@
   <app-base-test-record
     [isEditing]="(isEditing$ | async) || false"
     [testResult]="testResult"
-    [defectsData]="defects$ | async"
+    [defectsData]="getDefects$(testResult.vehicleType) | async"
     [sectionTemplates]="(sectionTemplates$ | async) || []"
     (newTestResult)="handleNewTestResult($event)"
   ></app-base-test-record>

--- a/src/app/features/test-records/views/test-record/test-record.component.ts
+++ b/src/app/features/test-records/views/test-record/test-record.component.ts
@@ -9,11 +9,12 @@ import { masterTpl } from '@forms/templates/test-records/master.template';
 import { Defect } from '@models/defects/defect.model';
 import { Roles } from '@models/roles.enum';
 import { TestResultModel } from '@models/test-results/test-result.model';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { RouterService } from '@services/router/router.service';
 import { TestRecordsService } from '@services/test-records/test-records.service';
-import { defects, DefectsState, fetchDefects } from '@store/defects';
+import { DefectsState, fetchDefects, filteredDefects } from '@store/defects';
 import { updateTestResultSuccess } from '@store/test-records';
 import cloneDeep from 'lodash.clonedeep';
 import { firstValueFrom, map, Observable, of, skipWhile, Subject, switchMap, take, takeUntil, takeWhile } from 'rxjs';
@@ -72,8 +73,8 @@ export class TestRecordComponent implements OnInit, OnDestroy {
     return Roles;
   }
 
-  get defects$(): Observable<Defect[]> {
-    return this.defectsStore.select(defects);
+  getDefects$(type: VehicleTypes): Observable<Defect[]> {
+    return this.defectsStore.select(filteredDefects(type));
   }
 
   handleEdit(): void {

--- a/src/app/forms/components/defect/defect.component.html
+++ b/src/app/forms/components/defect/defect.component.html
@@ -72,35 +72,25 @@
 
     <ng-container formGroupName="additionalInformation">
       <ng-container formGroupName="location">
-        <app-text-input formControlName="vertical" label="Vertical"></app-text-input>
-        <app-text-input formControlName="horizontal" label="Horizontal"></app-text-input>
-        <app-text-input formControlName="lateral" label="Lateral"></app-text-input>
-        <app-text-input formControlName="longitudinal" label="Longitudinal"></app-text-input>
-        <app-text-input formControlName="rowNumber" label="Row number"></app-text-input>
-        <app-text-input formControlName="seatNumber" label="Seat number"></app-text-input>
-        <app-text-input formControlName="axleNumber" label="Axle number"></app-text-input>
+        <app-radio-group
+          *ngFor="let item of infoDictionary | keyvalue; trackBy: trackByFn"
+          [name]="item.key + index"
+          [label]="pascalCase(item.key)"
+          [formControlName]="item.key"
+          [options]="item.value"
+        ></app-radio-group>
       </ng-container>
-      <app-text-input formControlName="notes" label="Notes"></app-text-input>
+      <app-text-input *ngIf="info?.notes" [name]="'notes-' + index" label="Notes" formControlName="notes"></app-text-input>
     </ng-container>
 
-    <app-radio-group
-      [name]="'prs-' + index"
-      formControlName="prs"
-      label="PRS"
-      [options]="[
-        { value: true, label: 'Yes' },
-        { value: false, label: 'No' }
-      ]"
-    ></app-radio-group>
+    <app-radio-group [name]="'prs-' + index" label="PRS" formControlName="prs" [options]="booleanOptions"></app-radio-group>
 
     <app-radio-group
+      *ngIf="isDangerous"
       [name]="'prohibitionIssued-' + index"
-      formControlName="prohibitionIssued"
       label="Prohibition issued"
-      [options]="[
-        { value: true, label: 'Yes' },
-        { value: false, label: 'No' }
-      ]"
+      formControlName="prohibitionIssued"
+      [options]="booleanOptions"
     ></app-radio-group>
   </ng-container>
 </ng-template>

--- a/src/app/forms/components/defect/defect.component.spec.ts
+++ b/src/app/forms/components/defect/defect.component.spec.ts
@@ -25,7 +25,7 @@ describe('DefectComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe(DefectComponent.prototype.mapLocationText.name, () => {
+  describe("mapLocationText", () => {
     it.each([
       ['', createMock<DefectAdditionalInformationLocation>()],
       ['', createMock<DefectAdditionalInformationLocation>({ axleNumber: undefined })],

--- a/src/app/forms/components/defect/defect.component.ts
+++ b/src/app/forms/components/defect/defect.component.ts
@@ -65,10 +65,10 @@ export class DefectComponent {
    * @param location - DefectAdditionalInformationLocation object
    * @returns string
    */
-  mapLocationText = (location: DefectAdditionalInformationLocation): string => location
-    ? Object.entries(location)
+  mapLocationText = (location: DefectAdditionalInformationLocation): string => !location
+    ? '-'
+    : Object.entries(location)
       .filter(([, value]) => (typeof value === 'number' && isNaN(value) === false) || value)
       .map(([key, value]) => `${key}: ${value}`)
-      .join(' / ')
-    : '-';
+      .join(' / ');
 }

--- a/src/app/forms/components/defect/defect.component.ts
+++ b/src/app/forms/components/defect/defect.component.ts
@@ -1,24 +1,62 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { CustomFormGroup } from '@forms/services/dynamic-form.types';
+import { KeyValue } from '@angular/common';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CustomFormGroup, FormNodeOption } from '@forms/services/dynamic-form.types';
+import { AdditionalInfoSection } from '@models/defects/additional-information.model';
+import { Defect } from '@models/defects/defect.model';
 import { DefectAdditionalInformationLocation } from '@models/test-results/defectAdditionalInformationLocation';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { DefaultNullOrEmpty } from '@shared/pipes/default-null-or-empty/default-null-or-empty.pipe';
 
 @Component({
-  selector: 'app-defect[form][index]',
+  selector: 'app-defect[form][index][defect][vehicleType]',
   templateUrl: './defect.component.html',
-  providers: [DefaultNullOrEmpty]
+  providers: [DefaultNullOrEmpty],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DefectComponent {
   @Input() form!: CustomFormGroup;
+  @Input() vehicleType!: VehicleTypes;
+  @Input() isDangerous = false;
   @Input() isEditing = false;
   @Input() index!: number;
+
+  @Input() set defect(defect: Defect | undefined) {
+    const infoShorthand = defect?.additionalInfo;
+
+    this.info = defect?.additionalInfo[this.vehicleType as keyof typeof infoShorthand] as AdditionalInfoSection | undefined;
+
+    if (this.info) {
+      type LocationKey = keyof typeof this.info.location;
+
+      Object.keys(this.info.location).forEach(key => {
+        const options = this.info?.location[key as LocationKey];
+        if (options) {
+          this.infoDictionary[key] = this.mapOptions(options);
+        }
+      });
+    }
+  }
+
   @Output() removeDefect = new EventEmitter<number>();
+
+  info?: AdditionalInfoSection;
+
+  infoDictionary: Record<string, Array<FormNodeOption<any>>> = {};
+
+  booleanOptions: FormNodeOption<string | number | boolean>[] = [
+    { value: true, label: 'Yes' },
+    { value: false, label: 'No' }
+  ];
 
   constructor(private pipe: DefaultNullOrEmpty) {}
 
-  combined(...params: string[]): string {
-    return params.map(p => this.pipe.transform(p)).join(' / ');
-  }
+  trackByFn = (_index: number, keyValuePair: KeyValue<string, Array<any>>): string => keyValuePair.key;
+
+  mapOptions = (options: Array<any>): Array<FormNodeOption<any>> => options.map(option => ({ value: option, label: this.pascalCase(String(option)) }));
+
+  pascalCase = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).replace(/([A-Z])/g, ' $1');
+
+  combined = (...params: string[]): string => params.map(p => this.pipe.transform(p)).join(' / ');
 
   /**
    * takes the location object where all properties are optional and returns a string with all the properties that have values separated with ` / `.
@@ -27,12 +65,10 @@ export class DefectComponent {
    * @param location - DefectAdditionalInformationLocation object
    * @returns string
    */
-  mapLocationText(location: DefectAdditionalInformationLocation): string {
-    return !location
-      ? '-'
-      : Object.entries(location)
-          .filter(([, value]) => (typeof value === 'number' && isNaN(value) === false) || value)
-          .map(([key, value]) => `${key}: ${value}`)
-          .join(' / ');
-  }
+  mapLocationText = (location: DefectAdditionalInformationLocation): string => location
+    ? Object.entries(location)
+      .filter(([, value]) => (typeof value === 'number' && isNaN(value) === false) || value)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(' / ')
+    : '-';
 }

--- a/src/app/forms/components/defects/defects.component.html
+++ b/src/app/forms/components/defects/defects.component.html
@@ -5,6 +5,9 @@
     *ngFor="let defect of defectsForm?.controls; let i = index; trackBy: trackByFn"
     [isEditing]="isEditing"
     [form]="getDefectForm(i)"
+    [defect]="getDefect(i)"
+    [vehicleType]="data.vehicleType!"
+    [isDangerous]="isDangerous(i)"
     [index]="i"
     (removeDefect)="handleRemoveDefect($event)"
   ></app-defect>

--- a/src/app/forms/components/defects/defects.component.ts
+++ b/src/app/forms/components/defects/defects.component.ts
@@ -5,6 +5,7 @@ import { Defect } from '@models/defects/defect.model';
 import { Deficiency } from '@models/defects/deficiency.model';
 import { Item } from '@models/defects/item.model';
 import { TestResultDefect } from '@models/test-results/test-result-defect.model';
+import { TestResultModel } from '@models/test-results/test-result.model';
 import { ResultOfTestService } from '@services/result-of-test/result-of-test.service';
 import { debounceTime, Subscription } from 'rxjs';
 
@@ -16,41 +17,54 @@ export class DefectsComponent implements OnInit, OnDestroy {
   @Input() isEditing = false;
   @Input() defects!: Defect[] | null;
   @Input() template!: FormNode;
-  @Input() data: any = {};
+  @Input() data: Partial<TestResultModel> = {};
 
   @Output() formChange = new EventEmitter();
+
   form!: CustomFormGroup;
 
-  private formSubscription = new Subscription();
+  private _formSubscription = new Subscription();
+  private _defectsForm?: CustomFormArray;
 
   constructor(private dfs: DynamicFormService, private resultService: ResultOfTestService) {}
 
   ngOnInit(): void {
     this.form = this.dfs.createForm(this.template, this.data) as CustomFormGroup;
-    this.formSubscription = this.form.cleanValueChanges.pipe(debounceTime(400)).subscribe(event => {
+    this._formSubscription = this.form.cleanValueChanges.pipe(debounceTime(400)).subscribe(event => {
       this.formChange.emit(event);
       this.resultService.updateResultOfTest();
     });
   }
 
   ngOnDestroy(): void {
-    this.formSubscription.unsubscribe();
+    this._formSubscription.unsubscribe();
   }
 
-  get defectsForm() {
-    return this.form?.get(['testTypes', '0', 'defects']) as CustomFormArray;
+  get defectsForm(): CustomFormArray {
+    if (!this._defectsForm) {
+      this._defectsForm = this.form?.get(['testTypes', '0', 'defects']) as CustomFormArray
+    }
+    return this._defectsForm;
   }
 
-  getDefectForm(i: number) {
-    return this.defectsForm?.controls[i] as CustomFormGroup;
-  }
-
-  trackByFn(index: number): number {
-    return index;
-  }
-
-  get defectCount() {
+  get defectCount(): number {
     return this.defectsForm?.controls.length;
+  }
+
+  trackByFn = (index: number): number => index;
+
+  getDefectForm = (i: number): CustomFormGroup => this.defectsForm?.controls[i] as CustomFormGroup;
+
+  getDefect(i: number): Defect | undefined {
+    const defectForm = this.getDefectForm(i);
+    const imNumber = defectForm.get(['imNumber'])?.value;
+
+    return imNumber && this.defects?.find(defect => defect.imNumber === imNumber);
+  }
+
+  isDangerous(i: number): boolean {
+    const defectForm = this.getDefectForm(i);
+    return defectForm.get(['deficiencyCategory'])?.value === 'dangerous';
   }
 
   handleDefectSelection(selection: { defect: Defect; item: Item; deficiency: Deficiency }): void {

--- a/src/app/forms/components/radio-group/radio-group.component.html
+++ b/src/app/forms/components/radio-group/radio-group.component.html
@@ -6,7 +6,7 @@
     </legend>
     <app-field-error-message [error]="error" [name]="name"></app-field-error-message>
     <div class="govuk-radios" data-module="govuk-radios">
-      <div *ngFor="let option of options" class="govuk-radios__item">
+      <div *ngFor="let option of options; trackBy: trackByFn" class="govuk-radios__item">
         <input
           class="govuk-radios__input"
           [id]="name + '-' + option.value + '-radio'"

--- a/src/app/forms/components/radio-group/radio-group.component.ts
+++ b/src/app/forms/components/radio-group/radio-group.component.ts
@@ -16,4 +16,6 @@ import { BaseControlComponent } from '../base-control/base-control.component';
 })
 export class RadioGroupComponent extends BaseControlComponent {
   @Input() options: FormNodeOption<string | number | boolean>[] = [];
+
+  trackByFn = (index: number): number => index;
 }

--- a/src/app/forms/templates/general/defect.template.ts
+++ b/src/app/forms/templates/general/defect.template.ts
@@ -91,36 +91,43 @@ export const DefectsTpl: FormNode = {
                             {
                               name: 'vertical',
                               label: 'Vertical',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             },
                             {
                               name: 'horizontal',
                               label: 'Horizontal',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             },
                             {
                               name: 'lateral',
                               label: 'Lateral',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             },
                             {
                               name: 'longitudinal',
                               label: 'Longitudinal',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             },
                             {
                               name: 'rowNumber',
                               label: 'Row number',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             },
                             {
                               name: 'seatNumber',
                               label: 'Seat number',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             },
                             {
                               name: 'axleNumber',
                               label: 'Axle number',
+                              value: null,
                               type: FormNodeTypes.CONTROL
                             }
                           ]
@@ -128,6 +135,7 @@ export const DefectsTpl: FormNode = {
                         {
                           name: 'notes',
                           label: 'Notes',
+                          value: null,
                           type: FormNodeTypes.CONTROL,
                           validators: [{ name: ValidatorNames.ValidateDefectNotes }]
                         }

--- a/src/app/models/defects/location.model.ts
+++ b/src/app/models/defects/location.model.ts
@@ -1,10 +1,10 @@
 export interface Location {
-  axleNumber: number[];
-  horizontal: Location.Horizontal[];
-  lateral: Location.Lateral[];
+  axleNumber?: number[];
+  horizontal?: Location.Horizontal[];
+  lateral?: Location.Lateral[];
   longitudinal?: Location.Longitudinal[];
-  rowNumber?: number;
-  seatNumber?: number;
+  rowNumber?: number[];
+  seatNumber?: number[];
   vertical?: Location.Vertical[];
 }
 

--- a/src/app/store/defects/selectors/defects.selectors.ts
+++ b/src/app/store/defects/selectors/defects.selectors.ts
@@ -1,9 +1,31 @@
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { createSelector } from '@ngrx/store';
+import cloneDeep from 'lodash.clonedeep';
 import { defectsAdapter, defectsFeatureState } from '../reducers/defects.reducer';
 
 const { selectAll } = defectsAdapter.getSelectors();
 
 export const defects = createSelector(defectsFeatureState, state => selectAll(state));
+
+export const filteredDefects = (type: VehicleTypes) => createSelector(defects, defects => {
+  return cloneDeep(defects)
+    .filter(defect => defect.forVehicleType.includes(type))
+    .map(defect => ({
+      ...defect,
+      items: defect.items
+        .filter(item => item.forVehicleType.includes(type))
+        .map(item => ({
+          ...item,
+          deficiencies: item.deficiencies.filter(deficiency => deficiency.forVehicleType.includes(type))
+        }))
+    }));
+});
+
+export const psvDefects = filteredDefects(VehicleTypes.PSV);
+
+export const hgvDefects = filteredDefects(VehicleTypes.HGV);
+
+export const trlDefects = filteredDefects(VehicleTypes.TRL);
 
 export const defect = (id: string) => createSelector(defectsFeatureState, state => state.entities[id]);
 


### PR DESCRIPTION
## Add a Defect (with Taxonomy)

- Add additional selectors for defects that enable filtering based on vehicle type
- Correct the Additional Info location model
- Add `null`s to the defect template to prevent the auto-population bug
- Extend the `defects` component adding the ability to retrieve more info about individual defects to be passed onto the `defect` component and filter results based on the current vehicle type
- Greatly overhaul the `defect` component to:
  - Dynamically display all optional fields based on the selected defect
  - Replace the static HTML for the optional fields with a loop of a custom dictionary
  - Display the "Prohibition Issued" field only when a defect is "Dangerous"

[CB2-4229](https://dvsa.atlassian.net/browse/CB2-4229)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
