### PR TITLE
fix(cb2-5623): made changes to templates to allow validation to pass

### DIFF
--- a/src/app/forms/templates/test-records/master.template.ts
+++ b/src/app/forms/templates/test-records/master.template.ts
@@ -61,7 +61,7 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       reasonForCreation: reasonForCreationSection,
       required: RequiredSection
     },
-    testTypesGroup3and4and8: {
+    testTypesGroup3And4And8: {
       vehicle: VehicleSectionDefaultPsvHgv,
       test: TestSectionGroup3And4And8,
       emissions: EmissionsSection,
@@ -92,7 +92,7 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       customDefects: CustomDefectsSection,
       required: RequiredSectionHGVTRL
     },
-    testTypesGroup3and4and8: {
+    testTypesGroup3And4And8: {
       vehicle: VehicleSectionDefaultPsvHgv,
       test: TestSectionGroup3And4And8,
       emissions: EmissionsSection,
@@ -118,7 +118,8 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       notes: NotesSection,
       defects: DefectsTpl,
       reasonForCreation: reasonForCreationSection,
-      required: RequiredSectionHGVTRL
+      required: RequiredSectionHGVTRL,
+      customDefects: CustomDefectsSection
     },
     testTypesGroup7:{
       vehicle: VehicleSectionDefaultPsvHgv,
@@ -146,8 +147,19 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       notes: NotesSection,
       defects: DefectsTpl,
       reasonForCreation: reasonForCreationSection,
-      required: RequiredSectionHGVTRL
+      required: RequiredSectionHGVTRL,
+      CustomDefectsSection: CustomDefectsSection
     },
+    testTypesGroup15And16: {
+      vehicle: VehicleSectionDefaultPsvHgv,
+      test: TestSectionGroup15And16,
+      emissions: EmissionsSection,
+      visit: VisitSection,
+      notes: NotesSection,
+      customDefects: CustomDefectsSection,
+      reasonForCreation: reasonForCreationSection,
+      required: RequiredSection
+    }
     
   },
   trl: {
@@ -159,7 +171,7 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       customDefects: CustomDefectsSection,
       required: RequiredSectionHGVTRL
     },
-    testTypesGroup3and4and8: {
+    testTypesGroup3And4And8: {
       vehicle: VehicleSectionDefaultTrl,
       test: TestSectionGroup3And4And8,
       emissions: EmissionsSection,
@@ -185,7 +197,8 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       notes: NotesSection,
       defects: DefectsTpl,
       reasonForCreation: reasonForCreationSection,
-      required: RequiredSectionHGVTRL
+      required: RequiredSectionHGVTRL,
+      customDefects: CustomDefectsSection
     },
     testTypesGroup7:{
       vehicle: VehicleSectionDefaultTrl,
@@ -214,7 +227,8 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       notes: NotesSection,
       defects: DefectsTpl,
       reasonForCreation: reasonForCreationSection,
-      required: RequiredSectionHGVTRL
+      required: RequiredSectionHGVTRL,
+      CustomDefectsSection: CustomDefectsSection
     },
   }
 };


### PR DESCRIPTION
Fixes the templates to allow validation to pass for records for certain test types
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-5623)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
