### PR TITLE
fix(CB2-5613): Enable the Selection of Advisory Defects

### DIFF
--- a/src/app/forms/components/defect-select/defect-select.component.html
+++ b/src/app/forms/components/defect-select/defect-select.component.html
@@ -41,6 +41,10 @@
           {{ deficiency.deficiencyText }}
         </button>
       </li>
+
+      <li class="list__item">
+        <button (click)="handleSelect()">advisory (add an advisory note).</button>
+      </li>
     </ol>
   </div>
 </div>

--- a/src/app/forms/components/defect-select/defect-select.component.ts
+++ b/src/app/forms/components/defect-select/defect-select.component.ts
@@ -12,7 +12,7 @@ import { Subject } from 'rxjs';
 export class DefectSelectComponent implements OnDestroy {
   @Input() defects!: Defect[] | null;
   @Input() isParentEditing = false;
-  @Output() formChange = new EventEmitter<{ defect: Defect, item: Item, deficiency: Deficiency }>();
+  @Output() formChange = new EventEmitter<{ defect: Defect, item: Item, deficiency?: Deficiency }>();
 
   isEditing = false;
   selectedDefect?: Defect;
@@ -47,7 +47,7 @@ export class DefectSelectComponent implements OnDestroy {
     this.selectedDeficiency = undefined;
   }
 
-  handleSelect(selected: Defect | Item | Deficiency, type: Types): void {
+  handleSelect(selected?: Defect | Item | Deficiency, type?: Types): void {
     switch (type) {
       case Types.Defect:
         this.selectedDefect = selected as Defect;
@@ -61,6 +61,10 @@ export class DefectSelectComponent implements OnDestroy {
       case Types.Deficiency:
         this.selectedDeficiency = selected as Deficiency;
         this.formChange.emit({ defect: this.selectedDefect!, item: this.selectedItem!, deficiency: this.selectedDeficiency })
+        this.toggleEditMode();
+        break;
+      default:
+        this.formChange.emit({ defect: this.selectedDefect!, item: this.selectedItem! })
         this.toggleEditMode();
         break;
     }

--- a/src/app/forms/components/defect-select/defect-select.component.ts
+++ b/src/app/forms/components/defect-select/defect-select.component.ts
@@ -1,15 +1,14 @@
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Defect } from '@models/defects/defect.model';
 import { Deficiency } from '@models/defects/deficiency.model';
 import { Item } from '@models/defects/item.model';
-import { Subject } from 'rxjs';
 
 @Component({
   selector: 'app-defect-select[isParentEditing][defects]',
   templateUrl: './defect-select.component.html',
   styleUrls: ['./defect-select.component.scss']
 })
-export class DefectSelectComponent implements OnDestroy {
+export class DefectSelectComponent {
   @Input() defects!: Defect[] | null;
   @Input() isParentEditing = false;
   @Output() formChange = new EventEmitter<{ defect: Defect, item: Item, deficiency?: Deficiency }>();
@@ -19,14 +18,7 @@ export class DefectSelectComponent implements OnDestroy {
   selectedItem?: Item;
   selectedDeficiency?: Deficiency;
 
-  private destroy$ = new Subject<void>();
-
   constructor() { }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 
   get types(): typeof Types {
     return Types;

--- a/src/app/forms/components/defect/defect.component.html
+++ b/src/app/forms/components/defect/defect.component.html
@@ -66,9 +66,9 @@
     <app-text-input formControlName="imDescription" label="IM description"></app-text-input>
     <app-text-input formControlName="itemNumber" label="Item No."></app-text-input>
     <app-text-input formControlName="itemDescription" label="Item description"></app-text-input>
-    <app-text-input formControlName="deficiencyId" label="Deficiency ID"></app-text-input>
-    <app-text-input formControlName="deficiencySubId" label="Deficiency sub ID"></app-text-input>
-    <app-text-input formControlName="deficiencyText" label="Deficiency text"></app-text-input>
+    <app-text-input *ngIf="!isAdvisory" formControlName="deficiencyId" label="Deficiency ID"></app-text-input>
+    <app-text-input *ngIf="!isAdvisory" formControlName="deficiencySubId" label="Deficiency sub ID"></app-text-input>
+    <app-text-input *ngIf="!isAdvisory" formControlName="deficiencyText" label="Deficiency text"></app-text-input>
 
     <ng-container formGroupName="additionalInformation">
       <ng-container formGroupName="location">
@@ -80,10 +80,10 @@
           [options]="item.value"
         ></app-radio-group>
       </ng-container>
-      <app-text-input *ngIf="info?.notes" [name]="'notes-' + index" label="Notes" formControlName="notes"></app-text-input>
+      <app-text-input *ngIf="info?.notes || isAdvisory" [name]="'notes-' + index" label="Notes" formControlName="notes"></app-text-input>
     </ng-container>
 
-    <app-radio-group [name]="'prs-' + index" label="PRS" formControlName="prs" [options]="booleanOptions"></app-radio-group>
+    <app-radio-group *ngIf="!isAdvisory" [name]="'prs-' + index" label="PRS" formControlName="prs" [options]="booleanOptions"></app-radio-group>
 
     <app-radio-group
       *ngIf="isDangerous"

--- a/src/app/forms/components/defect/defect.component.ts
+++ b/src/app/forms/components/defect/defect.component.ts
@@ -16,20 +16,23 @@ import { DefaultNullOrEmpty } from '@shared/pipes/default-null-or-empty/default-
 export class DefectComponent {
   @Input() form!: CustomFormGroup;
   @Input() vehicleType!: VehicleTypes;
-  @Input() isDangerous = false;
+  @Input() category!: string;
   @Input() isEditing = false;
   @Input() index!: number;
 
   @Input() set defect(defect: Defect | undefined) {
     const infoShorthand = defect?.additionalInfo;
 
+    if (!infoShorthand) { return }
+
     this.info = defect?.additionalInfo[this.vehicleType as keyof typeof infoShorthand] as AdditionalInfoSection | undefined;
 
-    if (this.info) {
-      type LocationKey = keyof typeof this.info.location;
+    if (this.info && !this.isAdvisory) {
+      const location = this.info.location;
+      type LocationKey = keyof typeof location;
 
-      Object.keys(this.info.location).forEach(key => {
-        const options = this.info?.location[key as LocationKey];
+      Object.keys(location).forEach(key => {
+        const options = location[key as LocationKey];
         if (options) {
           this.infoDictionary[key] = this.mapOptions(options);
         }
@@ -49,6 +52,14 @@ export class DefectComponent {
   ];
 
   constructor(private pipe: DefaultNullOrEmpty) {}
+
+  get isAdvisory(): Boolean {
+    return this.category === 'advisory';
+  }
+
+  get isDangerous(): Boolean {
+    return this.category === 'dangerous';
+  }
 
   trackByFn = (_index: number, keyValuePair: KeyValue<string, Array<any>>): string => keyValuePair.key;
 

--- a/src/app/forms/components/defects/defects.component.html
+++ b/src/app/forms/components/defects/defects.component.html
@@ -7,7 +7,7 @@
     [form]="getDefectForm(i)"
     [defect]="getDefect(i)"
     [vehicleType]="data.vehicleType!"
-    [isDangerous]="isDangerous(i)"
+    [category]="getDefectCategory(i)"
     [index]="i"
     (removeDefect)="handleRemoveDefect($event)"
   ></app-defect>

--- a/src/app/forms/components/defects/defects.component.ts
+++ b/src/app/forms/components/defects/defects.component.ts
@@ -62,12 +62,12 @@ export class DefectsComponent implements OnInit, OnDestroy {
     return imNumber && this.defects?.find(defect => defect.imNumber === imNumber);
   }
 
-  isDangerous(i: number): boolean {
+  getDefectCategory(i: number): string {
     const defectForm = this.getDefectForm(i);
-    return defectForm.get(['deficiencyCategory'])?.value === 'dangerous';
+    return defectForm.get(['deficiencyCategory'])?.value;
   }
 
-  handleDefectSelection(selection: { defect: Defect; item: Item; deficiency: Deficiency }): void {
+  handleDefectSelection(selection: { defect: Defect; item: Item; deficiency?: Deficiency }): void {
     const testResultDefect: TestResultDefect = {
       imDescription: selection.defect.imDescription,
       imNumber: selection.defect.imNumber,
@@ -75,13 +75,18 @@ export class DefectsComponent implements OnInit, OnDestroy {
       itemDescription: selection.item.itemDescription,
       itemNumber: selection.item.itemNumber,
 
-      deficiencyCategory: selection.deficiency.deficiencyCategory,
-      deficiencyId: selection.deficiency.deficiencyId,
-      deficiencySubId: selection.deficiency.deficiencySubId,
-      deficiencyText: selection.deficiency.deficiencyText,
-      deficiencyRef: selection.deficiency.ref,
-      stdForProhibition: selection.deficiency.stdForProhibition
+      deficiencyCategory: TestResultDefect.DeficiencyCategoryEnum.Advisory,
+      deficiencyRef: `${selection.defect.imNumber}.${selection.item.itemNumber}`
     };
+
+    if (selection.deficiency) {
+      testResultDefect.deficiencyCategory = selection.deficiency.deficiencyCategory;
+      testResultDefect.deficiencyId = selection.deficiency.deficiencyId;
+      testResultDefect.deficiencySubId = selection.deficiency.deficiencySubId;
+      testResultDefect.deficiencyText = selection.deficiency.deficiencyText;
+      testResultDefect.deficiencyRef = selection.deficiency.ref;
+      testResultDefect.stdForProhibition = selection.deficiency.stdForProhibition;
+    }
 
     this.defectsForm.addControl(testResultDefect);
   }

--- a/src/app/forms/templates/general/defect.template.ts
+++ b/src/app/forms/templates/general/defect.template.ts
@@ -63,18 +63,21 @@ export const DefectsTpl: FormNode = {
                     {
                       name: 'deficiencyId',
                       label: 'Deficiency ID',
+                      value: null,
                       type: FormNodeTypes.CONTROL,
                       disabled: true
                     },
                     {
                       name: 'deficiencySubId',
                       label: 'Deficiency sub ID',
+                      value: null,
                       type: FormNodeTypes.CONTROL,
                       disabled: true
                     },
                     {
                       name: 'deficiencyText',
                       label: 'Deficiency text',
+                      value: null,
                       type: FormNodeTypes.CONTROL,
                       disabled: true
                     },
@@ -172,6 +175,7 @@ export const DefectsTpl: FormNode = {
                     {
                       name: 'stdForProhibition',
                       label: 'STD for prohibition',
+                      value: null,
                       type: FormNodeTypes.CONTROL,
                       disabled: true
                     }

--- a/src/app/forms/validators/defects/defect.validators.ts
+++ b/src/app/forms/validators/defects/defect.validators.ts
@@ -8,8 +8,8 @@ export class DefectValidators {
       const prohibitionIssued = grandParent.get('prohibitionIssued') as CustomFormControl;
       const deficiencyCategory = grandParent?.get('deficiencyCategory') as CustomFormControl;
       if (!control.value
-        && deficiencyCategory.value === 'advisory'
-        || (deficiencyCategory.value === 'dangerous*' && prohibitionIssued.value === false)) {
+        && (deficiencyCategory.value === 'advisory'
+        || (deficiencyCategory.value === 'dangerous*' && prohibitionIssued.value === false))) {
         return { validateDefectNotes: true };
       }
     }

--- a/src/app/forms/validators/defects/defect.validators.ts
+++ b/src/app/forms/validators/defects/defect.validators.ts
@@ -7,7 +7,9 @@ export class DefectValidators {
       const grandParent = control.parent.parent;
       const prohibitionIssued = grandParent.get('prohibitionIssued') as CustomFormControl;
       const deficiencyCategory = grandParent?.get('deficiencyCategory') as CustomFormControl;
-      if (deficiencyCategory.value === 'dangerous*' && prohibitionIssued.value === false && !control.value) {
+      if (!control.value
+        && deficiencyCategory.value === 'advisory'
+        || (deficiencyCategory.value === 'dangerous*' && prohibitionIssued.value === false)) {
         return { validateDefectNotes: true };
       }
     }


### PR DESCRIPTION
## Add the Advisory Defects Functionality

- Add an "advisory" option to the end of every defect selection.
- Update the defect fields' visibility based on this election.
- Alter the validation so that "Notes" is a required field on "advisory" defects.

[CB2-5613](https://dvsa.atlassian.net/browse/CB2-5613)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
