### PR TITLE
fix(*): fix constant dispatching of actions

### DIFF
--- a/src/app/forms/validators/custom-async-validators.spec.ts
+++ b/src/app/forms/validators/custom-async-validators.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormGroup, ValidationErrors } from '@angular/forms';
 import { CustomFormControl, FormNodeTypes } from '@forms/services/dynamic-form.types';
 import { mockTestResult } from '@mocks/mock-test-result';
@@ -91,7 +91,7 @@ describe('updateTestStationDetails', () => {
         provideMockStore({
           initialState: {
             ...initialAppState,
-            testStations: { ...initialTestStationsState, ids: ['1'], entities: { ['1']: { testStationName: 'foo', testStationPNumber: '1234' } } }
+            testStations: { ...initialTestStationsState, ids: ['1'], entities: { ['1']: { testStationName: 'foo', testStationPNumber: '1234', testStationType: 'bar' } } }
           }
         })
       ]
@@ -100,21 +100,16 @@ describe('updateTestStationDetails', () => {
     store = TestBed.inject(MockStore);
 
     form = new FormGroup({
-      testStationName: new CustomFormControl({ name: 'testStationName', type: FormNodeTypes.CONTROL, children: [] }, null)
+      testStationName: new CustomFormControl({ name: 'testStationName', type: FormNodeTypes.CONTROL, children: [] }, null),
+      testStationType: new CustomFormControl({ name: 'testStationType', type: FormNodeTypes.CONTROL, children: [] }, null),
+      testStationPNumber: new CustomFormControl({ name: 'testStationPNumber', type: FormNodeTypes.CONTROL, children: [] }, null),
     });
   });
-  it('should dispatch the action to update the test stations details', async () => {
-    form.controls['testStationName'].patchValue('foo');
-    const dispatchSpy = jest.spyOn(store, 'dispatch');
-    expect(form.controls['testStationName']).toBeTruthy;
-    await firstValueFrom(CustomAsyncValidators.updateTestStationDetails(store)(form.controls['testStationName']) as Observable<null>);
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchSpy).toHaveBeenCalledWith({
-      payload: {
-        testStationName: 'foo',
-        testStationPNumber: '1234'
-      },
-      type: '[test-stations] update the test station'
-    });
+  it('should update the test stations details', async () => {
+    form.controls['testStationPNumber'].patchValue('1234');
+    expect(form.controls['testStationPNumber']).toBeTruthy();
+    await firstValueFrom(CustomAsyncValidators.updateTestStationDetails(store)(form.controls['testStationPNumber']) as Observable<null>);
+    expect(form.controls['testStationType'].value).toBe('bar')
+    expect(form.controls['testStationName'].value).toBe('foo')
   });
 });

--- a/src/app/store/test-records/reducers/test-records.reducer.spec.ts
+++ b/src/app/store/test-records/reducers/test-records.reducer.spec.ts
@@ -1,7 +1,6 @@
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { TestStation } from '@models/test-stations/test-station.model';
 import { Action } from '@ngrx/store';
-import { updateTestStation } from '@store/test-stations';
 import { mockTestResultList } from '../../../../mocks/mock-test-result';
 import {
   fetchSelectedTestResult,
@@ -371,17 +370,4 @@ describe('Test Results Reducer', () => {
     });
   });
 
-  describe('update the test station details', () => {
-    it('should update the test station details', () => {
-      const testStation = {
-        testStationName: 'foo',
-        testStationType: 'atf',
-        testStationPNumber: '7890'
-      } as TestStation;
-      const action = updateTestStation({ payload: testStation });
-      const newState = testResultsReducer({ ...initialTestResultsState, editingTestResult: { testStationName: 'bar' } as TestResultModel }, action);
-      expect(newState.editingTestResult?.testStationName).toBe('foo');
-      expect(newState.editingTestResult?.testStationType).toBe('atf');
-    });
-  });
 });

--- a/src/app/store/test-records/reducers/test-records.reducer.ts
+++ b/src/app/store/test-records/reducers/test-records.reducer.ts
@@ -4,7 +4,6 @@ import { TestResultModel } from '@models/test-results/test-result.model';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
 import { createEntityAdapter, EntityAdapter, EntityState } from '@ngrx/entity';
 import { createFeatureSelector, createReducer, on } from '@ngrx/store';
-import { updateTestStation } from '@store/test-stations';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 import {
@@ -66,19 +65,7 @@ export const testResultsReducer = createReducer(
     ...state,
     editingTestResult: merge({}, action.testResult)
   })),
-  on(updateResultOfTest, state => ({ ...state, editingTestResult: calculateTestResult(state.editingTestResult) })),
-  on(updateTestStation, (state, action) => {
-    return !state.editingTestResult
-      ? { ...state }
-      : {
-          ...state,
-          editingTestResult: {
-            ...state.editingTestResult,
-            testStationName: action.payload.testStationName,
-            testStationType: action.payload.testStationType
-          }
-        };
-  })
+  on(updateResultOfTest, state => ({ ...state, editingTestResult: calculateTestResult(state.editingTestResult) }))
 );
 
 export const testResultsFeatureState = createFeatureSelector<TestResultsState>(STORE_FEATURE_TEST_RESULTS_KEY);

--- a/src/app/store/test-stations/actions/test-stations.actions.spec.ts
+++ b/src/app/store/test-stations/actions/test-stations.actions.spec.ts
@@ -5,7 +5,6 @@ import {
   fetchTestStationsFailed,
   fetchTestStationsSuccess,
   fetchTestStationSuccess,
-  updateTestStation
 } from './test-stations.actions';
 
 describe('Test Stations Actions', () => {
@@ -16,6 +15,5 @@ describe('Test Stations Actions', () => {
     expect(fetchTestStation.type).toBe('[API/test-stations] Fetch Test Station by ID');
     expect(fetchTestStationSuccess.type).toBe('[API/test-stations] Fetch Test Station by ID Success');
     expect(fetchTestStationFailed.type).toBe('[API/test-stations] Fetch Test Station by ID Failed');
-    expect(updateTestStation.type).toBe('[test-stations] update the test station');
   });
 });

--- a/src/app/store/test-stations/actions/test-stations.actions.ts
+++ b/src/app/store/test-stations/actions/test-stations.actions.ts
@@ -16,4 +16,3 @@ function getTitle(isPlural: boolean = false, suffix: string = ''): string {
   return '[API/test-stations] Fetch Test Station' + plural + suffix;
 }
 
-export const updateTestStation = createAction('[test-stations] update the test station', props<{ payload: TestStation }>());


### PR DESCRIPTION
Following the service design PR https://github.com/dvsa/cvs-app-vtm/pull/462, there is an issue when navigating from test amend page back to the test view page by clicking the breadcrumbs. Actions are constantly being dispatched and eventually the page will crash and run out of memory.

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
