### PR TITLE
fix(cb2-4814): error with date time

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/seatbelt/seatbelt-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/seatbelt/seatbelt-section.template.ts
@@ -41,7 +41,7 @@ export const SeatbeltSection: FormNode = {
               label: 'Most recent installation check',
               type: FormNodeTypes.CONTROL,
               viewType: FormNodeViewTypes.DATE,
-              editType: FormNodeEditTypes.DATE,
+              editType: FormNodeEditTypes.DATETIME,
               value: null,
               validators: [{ name: ValidatorNames.RequiredIfEquals, args: { sibling: 'seatbeltInstallationCheckDate', value: true } }]
             }


### PR DESCRIPTION
## Contingency test
There is an issue when checking the carried out during test field in the seatbelt section, where "most recent installation check date" is not being updated if the record does not having an "original" date populated as the control doesn't know what value to use for time 
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-4814)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
