### PR TITLE
fix(cb2-4380): add prohibition field to test types 6 and 11

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
@@ -125,6 +125,17 @@ export const TestSectionGroup6And11: FormNode = {
               disabled: true,
               label: 'End time',
               viewType: FormNodeViewTypes.TIME
+            },
+            {
+              name: 'prohibitionIssued',
+              type: FormNodeTypes.CONTROL,
+              label: 'Prohibition issued',
+              editType: FormNodeEditTypes.RADIO,
+              options: [
+                { value: true, label: 'Yes' },
+                { value: false, label: 'No' }
+              ],
+              validators: [{ name: ValidatorNames.Required }]
             }
           ]
         }


### PR DESCRIPTION
## Amend a TRL test record for test types in groups 11 & 13

It turns out that the prohibition field is required for group 11, but forbidden for group 13.
This PR corrects that.
2nd worst ticket I have worked on thus far...

[CB2-4380](https://dvsa.atlassian.net/browse/CB2-4380)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
