### PR TITLE
fix(cb2-4380): restructure the prohibition fields for groups 11 and 13

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group5And13.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group5And13.template.ts
@@ -125,6 +125,17 @@ export const TestSectionGroup5And13: FormNode = {
               disabled: true,
               label: 'End time',
               viewType: FormNodeViewTypes.TIME
+            },
+            {
+              name: 'prohibitionIssued',
+              type: FormNodeTypes.CONTROL,
+              label: 'Prohibition issued',
+              editType: FormNodeEditTypes.RADIO,
+              options: [
+                { value: true, label: 'Yes' },
+                { value: false, label: 'No' }
+              ],
+              validators: [{ name: ValidatorNames.Required }]
             }
           ]
         }

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
@@ -125,17 +125,6 @@ export const TestSectionGroup6And11: FormNode = {
               disabled: true,
               label: 'End time',
               viewType: FormNodeViewTypes.TIME
-            },
-            {
-              name: 'prohibitionIssued',
-              type: FormNodeTypes.CONTROL,
-              label: 'Prohibition issued',
-              editType: FormNodeEditTypes.RADIO,
-              options: [
-                { value: true, label: 'Yes' },
-                { value: false, label: 'No' }
-              ],
-              validators: [{ name: ValidatorNames.Required }]
             }
           ]
         }


### PR DESCRIPTION
## Amend a TRL test record for test types in groups 11 & 13

This is hopefully the final change to the prohibition fields right for every group mentioned in the ticket.

There was a lot of tinkering here because testing this has been a nightmare with the API endpoints not always responding.

[CB2-4380](https://dvsa.atlassian.net/browse/CB2-4380)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
