### PR TITLE
bug(*): fixes a typo in the test result summary view

### DIFF
--- a/src/app/features/test-records/amend/views/test-result-summary/test-result-summary.component.html
+++ b/src/app/features/test-records/amend/views/test-result-summary/test-result-summary.component.html
@@ -62,7 +62,7 @@
           </dd>
         </div>
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">EU vehicle ategory</dt>
+          <dt class="govuk-summary-list__key">EU vehicle category</dt>
           <dd id="test-testTypeId" class="govuk-summary-list__value">
             {{ testResult?.euVehicleCategory | defaultNullOrEmpty }}
           </dd>


### PR DESCRIPTION
Fixes a one-letter typo spotted in the EU vehicle category question title