### PR TITLE
feat(cb2-5906): odometer reading validation

### DIFF
--- a/src/app/core/components/spinner/spinner.component.scss
+++ b/src/app/core/components/spinner/spinner.component.scss
@@ -7,17 +7,23 @@
   height: 100%;
   top: 0;
   left: 0;
-  background-color: rgba(255, 255, 255, 0.5);
   z-index: 1002;
   & .spinner-wrapper {
     height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
     & #loader {
       display: flex;
       align-items: center;
       justify-content: center;
+      position: absolute;
+      top: 60px;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background-color: rgba(255, 255, 255);
     }
   }
 

--- a/src/app/forms/models/validators.enum.ts
+++ b/src/app/forms/models/validators.enum.ts
@@ -8,6 +8,8 @@ export enum ValidatorNames {
   HideIfParentSiblingNotEqual = 'hideIfParentSiblingNotEqual',
   MaxLength = 'maxlength',
   MinLength = 'minlength',
+  Max = 'max',
+  Min = 'min',
   Numeric = 'numeric',
   Pattern = 'pattern',
   Required = 'required',

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -29,6 +29,8 @@ export class DynamicFormService {
       CustomValidators.hideIfParentSiblingNotEqual(args.sibling, args.value),
     [ValidatorNames.MaxLength]: (args: number) => Validators.maxLength(args),
     [ValidatorNames.MinLength]: (args: number) => Validators.minLength(args),
+    [ValidatorNames.Max]: (args: number) => Validators.max(args),
+    [ValidatorNames.Min]: (args: number) => Validators.min(args),
     [ValidatorNames.Numeric]: () => CustomValidators.numeric(),
     [ValidatorNames.Pattern]: (args: string) => Validators.pattern(args),
     [ValidatorNames.Required]: () => Validators.required,

--- a/src/app/forms/templates/test-records/section-templates/test/contingency-test-section-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency-test-section-group1.template.ts
@@ -72,7 +72,7 @@ export const ContingencyTestSectionGroup1: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group1.template.ts
@@ -82,7 +82,7 @@ export const TestSectionGroup1: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group12And14.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group12And14.template.ts
@@ -99,7 +99,7 @@ export const TestSectionGroup12And14: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group15And16.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group15And16.template.ts
@@ -85,7 +85,7 @@ export const TestSectionGroup15And16: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group2.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group2.template.ts
@@ -82,7 +82,7 @@ export const TestSectionGroup2: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group3And4And8.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group3And4And8.template.ts
@@ -99,7 +99,7 @@ export const TestSectionGroup3And4And8: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group5And13.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group5And13.template.ts
@@ -107,7 +107,7 @@ export const TestSectionGroup5And13: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group6And11.template.ts
@@ -107,7 +107,7 @@ export const TestSectionGroup6And11: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group7.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group7.template.ts
@@ -115,7 +115,7 @@ export const TestSectionGroup7: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group9And10.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group9And10.template.ts
@@ -12,7 +12,6 @@ export const TestSectionGroup9And10: FormNode = {
       name: 'createdAt',
       label: 'Created',
       disabled: true,
-      
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.DATE,
       editType: FormNodeEditTypes.DATE
@@ -116,7 +115,7 @@ export const TestSectionGroup9And10: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/test/test-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section.template.ts
@@ -91,7 +91,7 @@ export const TestSection: FormNode = {
                   name: ValidatorNames.RequiredIfEquals,
                   args: { sibling: 'testResult', value: 'abandoned' }
                 },
-                { name: ValidatorNames.MaxLength, args: { length: 500 } }
+                { name: ValidatorNames.MaxLength, args: 500 }
               ]
             },
             {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template.ts
@@ -46,7 +46,7 @@ export const ContingencyVehicleSectionDefaultPsvHgv: FormNode = {
       name: 'odometerReading',
       label: 'Odometer Reading',
       value: '',
-      validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Required }],
+      validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Required }, { name: ValidatorNames.Max, args: 9999999 }],
       editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
@@ -58,9 +58,8 @@ export const VehicleSectionDefaultPsvHgv: FormNode = {
       name: 'odometerReading',
       label: 'Odometer Reading',
       value: '',
-      validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Required }],
+      validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Required }, { name: ValidatorNames.Max, args: 9999999 }],
       editType: FormNodeEditTypes.NUMBER,
-
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN
     },

--- a/src/app/forms/utils/error-message-map.ts
+++ b/src/app/forms/utils/error-message-map.ts
@@ -4,7 +4,7 @@ const DEFAULT_LABEL = 'This field';
 export const ErrorMessageMap: Record<string, (...args: any) => string> = {
   invalidDate: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is an invalid date`,
   invalidOption: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is invalid`,
-  invalidTestResult: (err: { message: string}) => err.message,
+  invalidTestResult: (err: { message: string }) => err.message,
   [ValidatorNames.CustomPattern]: (err: { message: string }, label?: string) => `${label || DEFAULT_LABEL} ${err.message}`,
   [ValidatorNames.MaxLength]: (err: { requiredLength: number }, label?: string) =>
     `${label || DEFAULT_LABEL} must be less than ${err.requiredLength} characters`,
@@ -14,6 +14,8 @@ export const ErrorMessageMap: Record<string, (...args: any) => string> = {
   [ValidatorNames.Required]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is required`,
   [ValidatorNames.RequiredIfEquals]: (err: { sibling: string }, label?: string) => `${label || DEFAULT_LABEL} is required with ${err.sibling}`,
   [ValidatorNames.ValidateDefectNotes]: () => 'Notes is required',
+  [ValidatorNames.Max]: (err: { max: number }, label?: string) => `${label || DEFAULT_LABEL} must be less than ${err.max}`,
+  [ValidatorNames.Min]: (err: { min: number }, label?: string) => `${label || DEFAULT_LABEL} must be more than ${err.min}`
 };
 
 function displayArray(array: string[]) {


### PR DESCRIPTION
## Contingency Testing - Odometer Validation

_Ticket to add field-level validation to the Odometer field whilst recording contingency tests_

 - Add max validator to odometer reading to 9999999.
 - Fix maxLength args in templates.
 - Fix spinner styling to correctly hide background content while spinning.

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-5906)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
