### PR TITLE
feat(cb2-5846): set reason for creation to empty string

### DIFF
--- a/src/app/features/test-records/amend/views/test-record/test-record.component.ts
+++ b/src/app/features/test-records/amend/views/test-record/test-record.component.ts
@@ -51,6 +51,7 @@ export class TestRecordComponent implements OnInit, OnDestroy {
         take(1)
       )
       .subscribe(testResult => {
+        testResult!.reasonForCreation = '';
         this.testRecordsService.editingTestResult(testResult!);
       });
 


### PR DESCRIPTION
## Modify behaviour of Reason for Creation field

_Currently the Reason for Creation field on a Test Record Amendment is populated by the value entered during the most recent amendment. This behavior needs to change to enable the user to add a new value against each amendment_
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-5846)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
