### PR TITLE
fix(cb2-5732): fix the test type selector method

### DIFF
--- a/src/app/services/test-types/test-types.service.ts
+++ b/src/app/services/test-types/test-types.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable, Optional } from '@angular/core';
-import { BASE_PATH, Configuration, TestType, TestTypeCategory, TestTypesService as TestTypesApiService, TestTypesTaxonomy } from '@api/test-types';
-import { select, Store } from '@ngrx/store';
+import { BASE_PATH, Configuration, TestTypesService as TestTypesApiService, TestTypesTaxonomy } from '@api/test-types';
+import { Store } from '@ngrx/store';
 import { State } from '@store/.';
 import { testTypeIdChanged } from '@store/test-records';
 import { fetchTestTypes } from '@store/test-types/actions/test-types.actions';
@@ -21,25 +21,15 @@ export class TestTypesService extends TestTypesApiService {
     super(httpClient, basePath, configuration);
   }
 
+  get selectAllTestTypes$(): Observable<TestTypesTaxonomy> {
+    return this.store.select(selectTestTypesByVehicleType);
+  }
+
   fetchTestTypes(): void {
     this.store.dispatch(fetchTestTypes());
   }
 
-  get selectAllTestTypes$(): Observable<TestTypesTaxonomy> {
-    return this.store.pipe(select(selectTestTypesByVehicleType));
-  }
-
   testTypeIdChanged(testTypeId: string): void {
     this.store.dispatch(testTypeIdChanged({ testTypeId }));
-  }
-
-  findTestTypeNameById(id: string, testTypes: Array<TestType | TestTypeCategory>): TestType | undefined {
-    function usingIdMatch(testType: TestType | TestTypeCategory) {
-      return testType.id === id
-        || testType.hasOwnProperty('nextTestTypesOrCategories')
-        && (testType as TestTypeCategory).nextTestTypesOrCategories?.some(usingIdMatch);
-    }
-
-    return testTypes.find(usingIdMatch);
   }
 }

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -35,6 +35,7 @@ import {
   updateTestResultSuccess
 } from '../actions/test-records.actions';
 import { selectedTestResultState, testResultInEdit } from '../selectors/test-records.selectors';
+import { selectTestType } from '@store/test-types/selectors/test-types.selectors';
 
 @Injectable()
 export class TestResultsEffects {
@@ -162,31 +163,36 @@ export class TestResultsEffects {
     this.actions$.pipe(
       ofType(contingencyTestTypeSelected),
       mergeMap(action =>
-        of(action).pipe(withLatestFrom(this.store.pipe(select(testResultInEdit)), this.testTypeService.selectAllTestTypes$), take(1))
+        of(action).pipe(
+          withLatestFrom(
+            this.store.select(testResultInEdit),
+            this.store.select(selectTestType(action.testType))
+          ),
+          take(1)
+        )
       ),
-      concatMap(([action, editingTestResult, testTypesTaxonomy]) => {
-        const { testType } = action;
+      concatMap(([action, editingTestResult, testTypeTaxonomy]) => {
+        const id = action.testType;
 
         const { vehicleType } = editingTestResult!;
         if (!vehicleType || !contingencyTestTemplates.hasOwnProperty(vehicleType)) {
           return of(templateSectionsChanged({ sectionTemplates: [], sectionsValue: undefined }));
         }
 
-        const testTypeGroup = TestRecordsService.getTestTypeGroup(testType);
+        const testTypeGroup = TestRecordsService.getTestTypeGroup(id);
         const vehicleTpl = contingencyTestTemplates[vehicleType as VehicleTypes];
 
         const tpl = testTypeGroup && vehicleTpl.hasOwnProperty(testTypeGroup) ? vehicleTpl[testTypeGroup] : vehicleTpl['default'];
 
-        const mergedForms = {};
+        const mergedForms = {} as TestResultModel;
         Object.values(tpl).forEach(node => {
           const form = this.dfs.createForm(node, editingTestResult);
           merge(mergedForms, form.getCleanValue(form));
         });
 
-        const testTypeTaxonomy = this.testTypeService.findTestTypeNameById(testType, testTypesTaxonomy);
-        (mergedForms as TestResultModel).testTypes[0].testTypeId = testType;
-        (mergedForms as TestResultModel).testTypes[0].name = testTypeTaxonomy?.name ?? '';
-        (mergedForms as TestResultModel).testTypes[0].testTypeName = testTypeTaxonomy?.testTypeName ?? '';
+        mergedForms.testTypes[0].testTypeId = id;
+        mergedForms.testTypes[0].name = testTypeTaxonomy?.name ?? '';
+        mergedForms.testTypes[0].testTypeName = testTypeTaxonomy?.testTypeName ?? '';
 
         return of(templateSectionsChanged({ sectionTemplates: Object.values(tpl), sectionsValue: mergedForms as TestResultModel }));
       })

--- a/src/app/store/test-types/selectors/test-types.selectors.spec.ts
+++ b/src/app/store/test-types/selectors/test-types.selectors.spec.ts
@@ -1,6 +1,6 @@
-import { TestTypesTaxonomy } from '@api/test-types';
+import { TestTypeCategory, TestTypesTaxonomy } from '@api/test-types';
 import { TestResultModel } from '@models/test-results/test-result.model';
-import { selectTestTypesByVehicleType, sortedTestTypes } from './test-types.selectors';
+import { selectTestType, selectTestTypesByVehicleType, sortedTestTypes } from './test-types.selectors';
 
 describe('selectors', () => {
   describe('selectTestTypesByVehicleType', () => {
@@ -286,5 +286,26 @@ describe('selectors', () => {
       const sorted = sortedTestTypes.projector(unsortedData);
       expect(sorted).toEqual(expectedTestTypes);
     });
+  });
+
+  describe('selectTestType', () => {
+    it('return the right test type', () => {
+      const exampleTestTypes: TestTypesTaxonomy = [
+        { id: '8' },
+        { id: '7', sortId: '1' },
+        {
+          id: '5',
+          sortId: '3',
+          nextTestTypesOrCategories: [
+            { id: '40', sortId: '1' },
+            { id: '39', sortId: '2' }
+          ]
+        },
+        { id: '1', sortId: '4' }
+      ] as TestTypesTaxonomy;
+
+      const selector = selectTestType('39').projector(exampleTestTypes);
+      expect(selector).toEqual((exampleTestTypes[2] as TestTypeCategory).nextTestTypesOrCategories?.pop());
+    })
   });
 });

--- a/src/app/store/test-types/selectors/test-types.selectors.ts
+++ b/src/app/store/test-types/selectors/test-types.selectors.ts
@@ -1,8 +1,9 @@
+import { TestType } from '@api/test-types';
 import { TestTypeCategory } from '@api/test-types/model/testTypeCategory';
 import { TestTypesTaxonomy } from '@api/test-types/model/testTypesTaxonomy';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { createSelector } from '@ngrx/store';
-import { selectedTestResultState, toEditOrNotToEdit } from '@store/test-records';
+import { toEditOrNotToEdit } from '@store/test-records';
 import { testTypesAdapter, testTypesFeatureState } from '../reducers/test-types.reducer';
 
 const { selectIds, selectEntities, selectAll, selectTotal } = testTypesAdapter.getSelectors();
@@ -54,6 +55,16 @@ export const sortedTestTypes = createSelector(selectTestTypesByVehicleType, test
   };
 
   return sortTestTypes(testTypes);
+});
+
+export const selectTestType = (id: string) => createSelector(selectTestTypesByVehicleType, (testTypes): TestType | undefined => {
+  function usingIdMatch(testType: TestType | TestTypeCategory) {
+    return testType.id === id
+      || (testType.hasOwnProperty('nextTestTypesOrCategories')
+      && (testType as TestTypeCategory).nextTestTypesOrCategories?.some(usingIdMatch));
+  }
+
+  return testTypes.find(usingIdMatch);
 });
 
 function filterTestTypes(testTypes: TestTypesTaxonomy, testResult: TestResultModel): TestTypesTaxonomy {

--- a/src/app/store/test-types/selectors/test-types.selectors.ts
+++ b/src/app/store/test-types/selectors/test-types.selectors.ts
@@ -58,13 +58,27 @@ export const sortedTestTypes = createSelector(selectTestTypesByVehicleType, test
 });
 
 export const selectTestType = (id: string) => createSelector(selectTestTypesByVehicleType, (testTypes): TestType | undefined => {
-  function usingIdMatch(testType: TestType | TestTypeCategory) {
-    return testType.id === id
-      || (testType.hasOwnProperty('nextTestTypesOrCategories')
-      && (testType as TestTypeCategory).nextTestTypesOrCategories?.some(usingIdMatch));
+  function findUsingId(id: string, testTypes: TestTypesTaxonomy | undefined): TestType | undefined {
+    if (!testTypes) {
+      return undefined;
+    }
+
+    for (const testType of testTypes) {
+      if (testType.id === id) {
+        return testType;
+      }
+
+      const found = findUsingId(id, (testType as TestTypeCategory).nextTestTypesOrCategories)
+
+      if (found) {
+        return found;
+      }
+    }
+
+    return undefined;
   }
 
-  return testTypes.find(usingIdMatch);
+  return findUsingId(id, testTypes);
 });
 
 function filterTestTypes(testTypes: TestTypesTaxonomy, testResult: TestResultModel): TestTypesTaxonomy {


### PR DESCRIPTION
## Contingency Testing - Create PSV Retest & Prohibition Clearance Tests (Without Certification)

The test type selector method in our test types service is supposed to search the taxonomy tree recursively and return the right one given an ID. But this was bugged and led to the test results summary not displaying the names for certain selections.

This PR fixes that.

[CB2-5732](https://dvsa.atlassian.net/browse/CB2-5732)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
