### PR TITLE
feat(cb2-5728): auto focus date segments

### DIFF
--- a/src/app/forms/components/date/date.component.html
+++ b/src/app/forms/components/date/date.component.html
@@ -14,7 +14,7 @@
             [includeTime]="includeTime"
             class="govuk-input govuk-date-input__input govuk-input--width-2"
             [ngClass]="{ 'govuk-input--error': elementHasErrors(0) && (dayEl.dirty || dayEl.touched) }"
-            attr.id="{{ name }}-day"
+            id="{{ name }}-day"
             name="{{ name }}-day"
             type="number"
             inputmode="numeric"

--- a/src/app/forms/components/date/date.component.html
+++ b/src/app/forms/components/date/date.component.html
@@ -10,9 +10,11 @@
           <input
             #dayEl="ngModel"
             appNumberOnly
+            appFocusNext
+            [includeTime]="includeTime"
             class="govuk-input govuk-date-input__input govuk-input--width-2"
             [ngClass]="{ 'govuk-input--error': elementHasErrors(0) && (dayEl.dirty || dayEl.touched) }"
-            id="{{ name }}-day"
+            attr.id="{{ name }}-day"
             name="{{ name }}-day"
             type="number"
             inputmode="numeric"
@@ -31,6 +33,8 @@
           <input
             #monthEl="ngModel"
             appNumberOnly
+            appFocusNext
+            [includeTime]="includeTime"
             class="govuk-input govuk-date-input__input govuk-input--width-2"
             [ngClass]="{ 'govuk-input--error': (monthEl.dirty || monthEl.touched) && elementHasErrors(1) }"
             id="{{ name }}-month"
@@ -52,6 +56,8 @@
           <input
             #yearEl="ngModel"
             appNumberOnly
+            appFocusNext
+            [includeTime]="includeTime"
             class="govuk-input govuk-date-input__input govuk-input--width-4"
             [ngClass]="{ 'govuk-input--error': (yearEl.dirty || yearEl.touched) && (elementHasErrors(2) || yearEl.invalid) }"
             id="{{ name }}-year"
@@ -75,8 +81,12 @@
             <input
               #hourEl="ngModel"
               appNumberOnly
+              appFocusNext
+              [includeTime]="includeTime"
               class="govuk-input govuk-date-input__input govuk-input--width-2"
-              [ngClass]="{ 'govuk-input--error': (yearEl.dirty || yearEl.touched) && (undefined === hour || null === hour || hourEl.invalid) }"
+              [ngClass]="{
+                'govuk-input--error': (yearEl.dirty || yearEl.touched) && value && (undefined === hour || null === hour || hourEl.invalid)
+              }"
               id="{{ name }}-hour"
               name="{{ name }}-hour"
               type="number"
@@ -100,7 +110,7 @@
               appNumberOnly
               class="govuk-input govuk-date-input__input govuk-input--width-2"
               [ngClass]="{
-                'govuk-input--error': (yearEl.dirty || yearEl.touched) && (undefined === minute || null === minute || minuteEl.invalid)
+                'govuk-input--error': (yearEl.dirty || yearEl.touched) && value && (undefined === minute || null === minute || minuteEl.invalid)
               }"
               id="{{ name }}-minute"
               name="{{ name }}-minute"

--- a/src/app/forms/components/date/date.component.ts
+++ b/src/app/forms/components/date/date.component.ts
@@ -1,6 +1,5 @@
 import { AfterContentInit, ChangeDetectorRef, Component, ElementRef, Injector, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { AbstractControlDirective, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { ValidatorNames } from '@forms/models/validators.enum';
 import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
 import validateDate from 'validate-govuk-date';
 import { DateValidators } from '../../validators/date/date.validators';

--- a/src/app/forms/components/date/focus-next.directive.spec.ts
+++ b/src/app/forms/components/date/focus-next.directive.spec.ts
@@ -1,0 +1,91 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FocusNextDirective } from './focus-next.directive';
+
+@Component({
+  selector: 'app-test',
+  template: `
+    <div>
+      <input appFocusNext [includeTime]="includeTime" type="number" id="test-day" />
+      <input appFocusNext [includeTime]="includeTime" type="number" id="test-month" />
+      <input appFocusNext [includeTime]="includeTime" type="number" id="test-year" />
+      <input appFocusNext [includeTime]="includeTime" type="number" id="test-hour" />
+      <input appFocusNext [includeTime]="includeTime" type="number" id="test-minute" />
+    </div>
+  `
+})
+class TestComponent {
+  includeTime = false;
+}
+
+describe('FocusNextDirective', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, FocusNextDirective]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    de = fixture.debugElement;
+  });
+
+  it('should create an instance', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('should tab from day to month after two numbers', () => {
+    const day: HTMLInputElement = fixture.debugElement.query(By.css('#test-day')).nativeElement;
+    const month: HTMLInputElement = fixture.debugElement.query(By.css('#test-month')).nativeElement;
+    day.value = '01';
+    day.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    const focusedElement = de.query(By.css(':focus')).nativeElement;
+    expect(month).toBe(focusedElement);
+  });
+
+  it('should tab from month to year after two numbers', () => {
+    const month: HTMLInputElement = fixture.debugElement.query(By.css('#test-month')).nativeElement;
+    const year: HTMLInputElement = fixture.debugElement.query(By.css('#test-year')).nativeElement;
+    month.value = '01';
+    month.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    const focusedElement = de.query(By.css(':focus')).nativeElement;
+    expect(year).toBe(focusedElement);
+  });
+
+  it('should tab from hour to minute after two numbers', () => {
+    const hour: HTMLInputElement = fixture.debugElement.query(By.css('#test-hour')).nativeElement;
+    const minute: HTMLInputElement = fixture.debugElement.query(By.css('#test-minute')).nativeElement;
+    hour.value = '01';
+    hour.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    const focusedElement = de.query(By.css(':focus')).nativeElement;
+    expect(minute).toBe(focusedElement);
+  });
+
+  it('should tab from year to hour after four numbers if includeTime is true', () => {
+    const year: HTMLInputElement = fixture.debugElement.query(By.css('#test-year')).nativeElement;
+    const hour: HTMLInputElement = fixture.debugElement.query(By.css('#test-hour')).nativeElement;
+
+    year.focus();
+    year.value = '2000';
+    year.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    let focusedElement = de.query(By.css(':focus')).nativeElement;
+    expect(year).toBe(focusedElement);
+
+    component.includeTime = true;
+    fixture.detectChanges();
+    year.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    focusedElement = de.query(By.css(':focus')).nativeElement;
+    expect(hour).toBe(focusedElement);
+  });
+});

--- a/src/app/forms/components/date/focus-next.directive.ts
+++ b/src/app/forms/components/date/focus-next.directive.ts
@@ -9,32 +9,38 @@ export class FocusNextDirective {
   constructor(private el: ElementRef) {}
 
   @HostListener('input', ['$event'])
-  onInput(e: InputEvent) {
+  onInput() {
     const {
       nativeElement: { id, value }
     } = this.el;
     const segments = id.split('-');
-    const currentSegment = segments.splice(-1)[0];
-    const name = segments.join('-');
+    const next = this.getNextElement(segments.splice(-1)[0], value);
 
-    if (value.length === 2) {
-      if ('day' === currentSegment) {
-        this.focus(`${name}-month`);
-        return;
-      } else if ('month' === currentSegment) {
-        this.focus(`${name}-year`);
-        return;
-      } else if ('hour' === currentSegment) {
-        this.focus(`${name}-minute`);
-        return;
-      }
-    } else if (value.length === 4 && this.includeTime && 'year' === currentSegment) {
-      this.focus(`${name}-hour`);
-      return;
+    if (next) {
+      document.getElementById(segments.join('-') + next)?.focus();
     }
   }
 
-  focus(el: string) {
-    document.getElementById(el)?.focus();
+  private getNextElement(currentSegment: string, value: string): string | undefined {
+    let nextEl = undefined;
+
+    if (value.length === 2) {
+      switch (currentSegment) {
+        case 'day':
+          nextEl = '-month';
+          break;
+        case 'month':
+          nextEl = '-year';
+          break;
+        case 'hour':
+          nextEl = '-minute';
+          break;
+        default:
+      }
+    } else if (value.length === 4 && this.includeTime && currentSegment === 'year') {
+      nextEl = '-hour';
+    }
+
+    return nextEl;
   }
 }

--- a/src/app/forms/components/date/focus-next.directive.ts
+++ b/src/app/forms/components/date/focus-next.directive.ts
@@ -1,0 +1,40 @@
+import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+
+@Directive({
+  selector: '[appFocusNext]'
+})
+export class FocusNextDirective {
+  @Input() includeTime = false;
+
+  constructor(private el: ElementRef) {}
+
+  @HostListener('input', ['$event'])
+  onInput(e: InputEvent) {
+    const {
+      nativeElement: { id, value }
+    } = this.el;
+    const segments = id.split('-');
+    const currentSegment = segments.splice(-1)[0];
+    const name = segments.join('-');
+
+    if (value.length === 2) {
+      if ('day' === currentSegment) {
+        this.focus(`${name}-month`);
+        return;
+      } else if ('month' === currentSegment) {
+        this.focus(`${name}-year`);
+        return;
+      } else if ('hour' === currentSegment) {
+        this.focus(`${name}-minute`);
+        return;
+      }
+    } else if (value.length === 4 && this.includeTime && 'year' === currentSegment) {
+      this.focus(`${name}-hour`);
+      return;
+    }
+  }
+
+  focus(el: string) {
+    document.getElementById(el)?.focus();
+  }
+}

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -21,6 +21,7 @@ import { TextInputComponent } from './components/text-input/text-input.component
 import { ViewCombinationComponent } from './components/view-combination/view-combination.component';
 import { ViewListItemComponent } from './components/view-list-item/view-list-item.component';
 import { NumberOnlyDirective } from './directives/app-number-only.directive';
+import { FocusNextDirective } from './components/date/focus-next.directive';
 
 @NgModule({
   declarations: [
@@ -41,7 +42,8 @@ import { NumberOnlyDirective } from './directives/app-number-only.directive';
     SelectComponent,
     DynamicFormFieldComponent,
     FieldErrorMessageComponent,
-    DefectSelectComponent
+    DefectSelectComponent,
+    FocusNextDirective
   ],
   imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
   exports: [


### PR DESCRIPTION
## Date Component Improvement

_Automate the focus event between date segments as the user types numeric values in._
[link to ticket number]()

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
