### PR TITLE
fix(*): fix routing to do with new historic path

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
@@ -194,6 +194,7 @@ describe('EditTechRecordButtonComponent', () => {
   const expectedResult = {
     vehicleTechRecords: [{
       systemNumber: '1',
+      vin: '1',
       techRecord: [{ createdAt: expectedDate } as TechRecordModel]
     } as VehicleTechRecordModel]
   };
@@ -206,6 +207,6 @@ describe('EditTechRecordButtonComponent', () => {
     tick();
 
     expect(navigateByUrlSpy).toHaveBeenCalledTimes(1);
-    expect(navigateByUrlSpy).toHaveBeenCalledWith('/tech-records/1/historic/' + expectedDate.getTime());
+    expect(navigateByUrlSpy).toHaveBeenCalledWith('/tech-records/1/1/historic/' + expectedDate.getTime());
   }));
 });

--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -27,7 +27,7 @@ export class EditTechRecordButtonComponent implements OnInit {
       .pipe(ofType(updateTechRecordsSuccess, createProvisionalTechRecordSuccess), take(1))
       .subscribe(action =>
         this.router.navigateByUrl(
-          `/tech-records/${action.vehicleTechRecords[0].systemNumber}/historic/${this.getLatestRecordTimestamp(action.vehicleTechRecords[0])}`
+          `/tech-records/${action.vehicleTechRecords[0].systemNumber}/${action.vehicleTechRecords[0].vin}/historic/${this.getLatestRecordTimestamp(action.vehicleTechRecords[0])}`
         )
       );
   }

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
@@ -21,7 +21,7 @@
         <ng-container *ngIf="techRecord.createdAt !== currentRecord?.createdAt">
           <a
             id="view-test-{{ vehicleTechRecord.vin }}"
-            href="/tech-records/{{ vehicleTechRecord.systemNumber }}/historic/{{ convertToUnix(techRecord.createdAt) }}"
+            href="/tech-records/{{ vehicleTechRecord.systemNumber }}/{{ vehicleTechRecord.vin }}/historic/{{ convertToUnix(techRecord.createdAt) }}"
           >
             View
           </a>


### PR DESCRIPTION
Changes so we route to correct path after:
- Submitting an edit on a tech record
- Clicking to view a historic tech record

