### PR TITLE
fix(cb2-6192): navigate on cancelling amendment of tech record

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -52,6 +52,7 @@ export class EditTechRecordButtonComponent implements OnInit {
 
     this.errorService.clearErrors();
     this.store.dispatch(updateEditingTechRecordCancel());
+    this.router.navigate([]);
   }
 
   submitTechRecord() {


### PR DESCRIPTION
When a value in the tech record is amended that is originally `undefined` and the amendment is cancelled, the non-edit view shows the amendments and not the original `undefined` state.

This is an issue with the way dynamic forms are updated/patched using the tech record received from the API and the values that are amended. The complexity of changing the functionality of the dynamic form component has been mitigated by forcing a navigation to the same URL path causing the component to be reloaded - recreating the form with the original tech record found in state.

[Link to ticket number](https://dvsa.atlassian.net/browse/CB2-6192)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
