### PR TITLE
feat(cb2-5811): group 9 templates

### DIFF
--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -11,10 +11,8 @@ import { SeatbeltSection } from './section-templates/seatbelt/seatbelt-section.t
 import { ContingencyTestSectionGroup1 } from './section-templates/test/contingency-test-section-group1.template';
 import { TestSection } from './section-templates/test/test-section.template';
 import { ContingencyVehicleSectionDefaultPsvHgv } from './section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template';
-import { VehicleSectionDefaultPsvHgv } from './section-templates/vehicle/default-psv-hgv-vehicle-section.template';
 import { ContingencyVisitSection } from './section-templates/visit/contingency-visit-section.template';
 import { VisitSection } from './section-templates/visit/visit-section.template';
-import { VehicleSectionDefaultTrl } from './section-templates/vehicle/default-trl-vehicle-section.template';
 import { ContingencyVehicleSectionDefaultTrl } from './section-templates/vehicle/contingency-default-trl-vehicle-section.template';
 import { ContingencyTestSectionGroup9And10 } from './section-templates/test/contingency-test-section-group9And10.template';
 import { ContingencyTestSectionGroup12and14 } from './section-templates/test/contingency-test-section-group12and14.template';
@@ -35,7 +33,7 @@ const groups1and2Template: Record<string, FormNode> = {
 export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Record<string, FormNode>>> = {
   psv: {
     default: {
-      vehicle: VehicleSectionDefaultPsvHgv,
+      vehicle: ContingencyVehicleSectionDefaultPsvHgv,
       test: TestSection,
       seatbelts: SeatbeltSection,
       emissions: EmissionsSection,
@@ -50,13 +48,23 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
   },
   hgv: {
     default: {
-      vehicle: VehicleSectionDefaultPsvHgv,
+      vehicle: ContingencyVehicleSectionDefaultPsvHgv,
       test: TestSection,
       visit: VisitSection,
       notes: NotesSection,
       defects: DefectsTpl,
       customDefects: CustomDefectsSection,
       required: CreateRequiredSectionHgvTrl
+    },
+    testTypesGroup9And10: {
+      required: CreateRequiredSectionHgvTrl,
+      vehicle: ContingencyVehicleSectionDefaultPsvHgv,
+      test: ContingencyTestSectionGroup9And10,
+      visit: ContingencyVisitSection,
+      notes: NotesSection,
+      defects: DefectsTpl,
+      customDefects: CustomDefectsSection,
+      reasonForCreation: reasonForCreationSection
     },
     testTypesGroup12And14: {
       required: CreateRequiredSectionHgvTrl,
@@ -71,7 +79,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
   },
   trl: {
     default: {
-      vehicle: VehicleSectionDefaultTrl,
+      vehicle: ContingencyVehicleSectionDefaultTrl,
       test: TestSection,
       visit: VisitSection,
       notes: NotesSection,

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template.ts
@@ -63,24 +63,6 @@ export const ContingencyVehicleSectionDefaultPsvHgv: FormNode = {
       validators: [{ name: ValidatorNames.Required }],
       viewType: FormNodeViewTypes.HIDDEN,
       editType: FormNodeEditTypes.RADIO
-    },
-    {
-      name: 'preparerName',
-      label: 'Preparer Name',
-      value: '',
-      type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.HIDDEN,
-      editType: FormNodeEditTypes.HIDDEN,
-      disabled: true
-    },
-    {
-      name: 'preparerId',
-      label: 'Preparer ID',
-      value: '',
-      type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.HIDDEN,
-      editType: FormNodeEditTypes.HIDDEN,
-      disabled: true
     }
   ]
 };

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -468,6 +468,7 @@ describe('TestResultsEffects', () => {
           b: templateSectionsChanged({
             sectionTemplates: Object.values(contingencyTestTemplates.psv['testTypesGroup1']),
             sectionsValue: {
+              contingencyTestNumber: undefined,
               countryOfRegistration: '',
               createdById: undefined,
               createdByName: undefined,
@@ -481,11 +482,10 @@ describe('TestResultsEffects', () => {
               numberOfWheelsDriven: undefined,
               odometerReading: 0,
               odometerReadingUnits: OdometerReadingUnits.KILOMETRES,
-              preparerId: '',
-              preparerName: '',
               reasonForCancellation: undefined,
               reasonForCreation: undefined,
               regnDate: undefined,
+              source: undefined,
               shouldEmailCertificate: undefined,
               systemNumber: '',
               testEndTimestamp: '',
@@ -522,6 +522,7 @@ describe('TestResultsEffects', () => {
               testerEmailAddress: '',
               testerName: '',
               testerStaffId: undefined,
+              typeOfTest: undefined,
               vehicleClass: null,
               vehicleConfiguration: undefined,
               vehicleSize: undefined,


### PR DESCRIPTION
## Contingency Testing - Create HGV/TRL Contingency Test for Prohibition Clearance, First Test, Annual Test (Group 9)

Adding in support for a HGV of group 9 as well as removing the preparer from PSV and HGV forms.

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-5811)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
