### PR TITLE
feat(cb2-5779): added specialist test group 1

### DIFF
--- a/src/app/forms/templates/test-records/master.template.ts
+++ b/src/app/forms/templates/test-records/master.template.ts
@@ -21,6 +21,8 @@ import { TestSection } from './section-templates/test/test-section.template';
 import { VehicleSectionDefaultPsvHgv } from './section-templates/vehicle/default-psv-hgv-vehicle-section.template';
 import { VehicleSectionDefaultTrl } from './section-templates/vehicle/default-trl-vehicle-section.template';
 import { VisitSection } from './section-templates/visit/visit-section.template';
+import { SpecialistTestSectionGroup1 } from './section-templates/test/specialist-test-section-group1.template';
+import { RequiredSpecialistSection } from './section-templates/required/required-hidden-specialist-section.template';
 //Keys of root object must a a valid vehicle type.
 //Keys of child object must be a valid test type id.
 //Child object must ALWAYS have a 'default' key.
@@ -78,6 +80,15 @@ export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormN
       customDefects: CustomDefectsSection,
       reasonForCreation: reasonForCreationSection,
       required: RequiredSection
+    },
+    testTypesSpecialistGroup1: {
+      vehicle: VehicleSectionDefaultPsvHgv,
+      test: SpecialistTestSectionGroup1,
+      visit: VisitSection,
+      notes: NotesSection,
+      customDefects: CustomDefectsSection,
+      reasonForCreation: reasonForCreationSection,
+      required: RequiredSpecialistSection
     }
   },
   hgv: {

--- a/src/app/forms/templates/test-records/section-templates/required/required-hidden-specialist-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/required/required-hidden-specialist-section.template.ts
@@ -1,0 +1,232 @@
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
+
+export const RequiredSpecialistSection: FormNode = {
+  name: 'requiredSection',
+  type: FormNodeTypes.GROUP,
+  children: [
+    {
+      name: 'testResultId',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'vehicleType',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'contingencyTestNumber',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'typeOfTest',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'source',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'testStatus',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'systemNumber',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'testerStaffId',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'testEndTimestamp',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'vehicleClass',
+      type: FormNodeTypes.GROUP,
+      editType: FormNodeEditTypes.HIDDEN,
+
+      viewType: FormNodeViewTypes.HIDDEN,
+      children: [
+        {
+          name: 'code',
+          type: FormNodeTypes.CONTROL,
+          editType: FormNodeEditTypes.HIDDEN,
+          viewType: FormNodeViewTypes.HIDDEN
+        },
+        {
+          name: 'description',
+          type: FormNodeTypes.CONTROL,
+          editType: FormNodeEditTypes.HIDDEN,
+          viewType: FormNodeViewTypes.HIDDEN
+        }
+      ]
+    },
+    {
+      name: 'vehicleType',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'noOfAxles',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'numberOfWheelsDriven',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'regnDate',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'firstUseDate',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'createdByName',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'createdById',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'lastUpdatedAt',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'lastUpdatedByName',
+
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'lastUpdatedById',
+
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'shouldEmailCertificate',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'numberOfSeats',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'vehicleConfiguration',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'vehicleSize',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'reasonForCancellation',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'testTypes',
+      label: 'Test Types',
+      type: FormNodeTypes.ARRAY,
+      children: [
+        {
+          name: '0', // it is important here that the name of the node for an ARRAY type should be an index value
+          type: FormNodeTypes.GROUP,
+          children: [
+            {
+              name: 'testTypeId',
+              label: 'Test Type ID',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            },
+            {
+              name: 'name',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            },
+            {
+              name: 'createdAt',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            },
+            {
+              name: 'lastUpdatedAt',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            },
+            {
+              name: 'certificateLink',
+
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            },
+            {
+              name: 'testTypeClassification',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            },
+            {
+              name: 'deletionFlag',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/src/app/forms/templates/test-records/section-templates/test/specialist-test-section-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/specialist-test-section-group1.template.ts
@@ -1,0 +1,141 @@
+import { ValidatorNames } from '@forms/models/validators.enum';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
+import { TestAbandonmentReasonsPsvData } from '../../test-abandonment-reasons';
+
+export const SpecialistTestSectionGroup1: FormNode = {
+  name: 'testSection',
+  label: 'Test',
+  type: FormNodeTypes.GROUP,
+  children: [
+    {
+      name: 'createdAt',
+      label: 'Created',
+      disabled: true,
+
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.DATE,
+      editType: FormNodeEditTypes.DATE
+    },
+
+    {
+      name: 'testStartTimestamp',
+      label: 'Test Date',
+      value: '',
+      disabled: true,
+
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.DATE,
+      editType: FormNodeEditTypes.DATE
+    },
+    {
+      name: 'testTypes',
+      label: 'Test Types',
+      type: FormNodeTypes.ARRAY,
+      children: [
+        {
+          name: '0', // it is important here that the name of the node for an ARRAY type should be an index value
+          type: FormNodeTypes.GROUP,
+          children: [
+            {
+              name: 'testCode',
+              label: 'Test Code',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'testResult',
+              label: 'Result',
+              editType: FormNodeEditTypes.HIDDEN,
+              viewType: FormNodeViewTypes.HIDDEN,
+              validators: [
+                { name: ValidatorNames.HideIfNotEqual, args: { sibling: 'reasonForAbandoning', value: 'abandoned' } },
+                { name: ValidatorNames.HideIfNotEqual, args: { sibling: 'additionalCommentsForAbandon', value: 'abandoned' } }
+              ],
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'reasonForAbandoning',
+              type: FormNodeTypes.CONTROL,
+              label: 'Reason for abandoning',
+              editType: FormNodeEditTypes.CHECKBOX,
+              delimited: { regex: '\\. (?<!\\..\\. )', separator: '. ' },
+              required: true,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                }
+              ],
+              options: TestAbandonmentReasonsPsvData
+            },
+            {
+              name: 'additionalCommentsForAbandon',
+              type: FormNodeTypes.CONTROL,
+              value: '',
+              required: true,
+              label: 'Additional details for abandoning',
+              editType: FormNodeEditTypes.TEXTAREA,
+              validators: [
+                {
+                  name: ValidatorNames.RequiredIfEquals,
+                  args: { sibling: 'testResult', value: 'abandoned' }
+                },
+                { name: ValidatorNames.MaxLength, args: 500 }
+              ]
+            },
+            {
+              name: 'testTypeName',
+              label: 'Description',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'certificateNumber',
+              label: 'Certificate number',
+              value: '',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.TEXT
+            },
+            {
+              name: 'testNumber',
+              label: 'Test Number',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL
+            },
+            {
+              name: 'testTypeStartTimestamp',
+              type: FormNodeTypes.CONTROL,
+              value: '',
+              disabled: true,
+              label: 'Start time',
+              viewType: FormNodeViewTypes.TIME
+            },
+            {
+              name: 'testTypeEndTimestamp',
+              type: FormNodeTypes.CONTROL,
+              value: '',
+              disabled: true,
+              label: 'End time',
+              viewType: FormNodeViewTypes.TIME
+            },
+            {
+              name: 'prohibitionIssued',
+              type: FormNodeTypes.CONTROL,
+              label: 'Prohibition issued',
+              value: null,
+              editType: FormNodeEditTypes.RADIO,
+              options: [
+                { value: true, label: 'Yes' },
+                { value: false, label: 'No' }
+              ],
+              validators: [{ name: ValidatorNames.Required }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
## Support Specialist Test Types Group 1 (IVA Inspection, DDA Schedule 1, 2 or 3)

_This ticket is to increase this scope to supporting to all test types for amending PSV Specialist Test Types within Group 1 (Test Type IDs 126, 128, 130, 150, 151, 161, 162, 163, 181, 182)_
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-5779)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
