### PR TITLE
fix(cb2-6229): only toggle edit mode when form is valid

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -6,7 +6,6 @@ import { ofType, Actions } from '@ngrx/effects';
 import { take } from 'rxjs';
 import { Router } from '@angular/router';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { ViewportScroller } from '@angular/common';
 
 @Component({
@@ -23,11 +22,8 @@ export class EditTechRecordButtonComponent implements OnInit {
   @Output() editableStateChange = new EventEmitter<boolean>();
   @Output() submitCheckFormValidity = new EventEmitter();
 
-  errors: GlobalError[];
 
-  constructor(private actions$: Actions, private errorService: GlobalErrorService, private router: Router, private store: Store, private viewportScroller: ViewportScroller) {
-    this.errors = []
-  }
+  constructor(private actions$: Actions, private errorService: GlobalErrorService, private router: Router, private store: Store, private viewportScroller: ViewportScroller) {}
 
   ngOnInit() {
     this.actions$
@@ -37,7 +33,6 @@ export class EditTechRecordButtonComponent implements OnInit {
           `/tech-records/${action.vehicleTechRecords[0].systemNumber}/${action.vehicleTechRecords[0].vin}/historic/${this.getLatestRecordTimestamp(action.vehicleTechRecords[0])}`
         )
       );
-    this.errorService.errors$.subscribe((error) => this.errors = error)
   }
 
   get isArchived(): boolean {
@@ -70,9 +65,5 @@ export class EditTechRecordButtonComponent implements OnInit {
   submitTechRecord() {
     this.submitCheckFormValidity.emit();
     this.clickScrollToTop()
-
-    if (!this.errors) {
-      this.toggleEditMode();
-    }
   }
 }


### PR DESCRIPTION
When a user clicked submit when a form was invalid, the user was switched to the non-edit mode and all changes were lost. 

Now when a form is invalid and the user clicks submit, the user remains on the edit screen and they are scrolled to the top of the page to highlight the errors as per service design

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6229)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
