### PR TITLE
chore(*): add service design to last applicant

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -18,7 +18,7 @@ import { NotesTemplate } from '@forms/templates/general/notes.template';
 import { DocumentsTemplate } from '@forms/templates/general/documents.template';
 import { PlatesTemplate } from '@forms/templates/general/plates.template';
 import { TrlAuthIntoServiceTemplate } from '@forms/templates/trl/trl-auth-into-service.template';
-import { TrlManufacturerTemplate } from '@forms/templates/trl/trl-manufacturer.template';
+import { ManufacturerTemplate } from '@forms/templates/general/manufacturer.template';
 import { PsvDdaTemplate } from '@forms/templates/psv/psv-dda.template';
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
 import { reasonForCreationSection } from '@forms/templates/general/resonForCreation.template';
@@ -159,7 +159,7 @@ export class TechRecordSummaryComponent implements OnInit {
       /* 14 */ getDimensionsMinMaxSection('Coupling center to rear trailer', 'couplingCenterToRearTrlMin', 'couplingCenterToRearTrlMax'),
       /* 15 */ PlatesTemplate,
       /* 16 */ TrlAuthIntoServiceTemplate,
-      /* 17 */ TrlManufacturerTemplate
+      /* 17 */ ManufacturerTemplate
     ];
   }
 }

--- a/src/app/forms/templates/general/applicant-details.template.ts
+++ b/src/app/forms/templates/general/applicant-details.template.ts
@@ -13,57 +13,65 @@ export const ApplicantDetails: FormNode = {
             children: [
                 {
                     name: 'name',
-                    label: 'Name (optional)',
+                    label: 'Name or company',
                     value: '',
+                    width: 30,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 150 }]
                 },
                 {
                     name: 'address1',
-                    label: 'Building and street (optional) (box 1 of 2)',
+                    label: 'Address line 1',
                     value: '',
+                    width: 30,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
                 {
                     name: 'address2',
-                    label: 'Building and street (optional) (box 2 of 2)',
+                    label: 'Address line 2',
                     value: '',
+                    width: 30,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
                 {
                     name: 'postTown',
-                    label: 'Town or city (optional)',
+                    label: 'Town or City',
                     value: '',
+                    width: 20,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
                 {
                     name: 'address3',
-                    label: 'County (optional)',
+                    label: 'County',
                     value: '',
+                    width: 20,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
                 {
                     name: 'postCode',
-                    label: 'Postcode (optional)',
+                    label: 'Postcode',
                     value: '',
+                    width: 10,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 12 }]
                 },
                 {
                     name: 'telephoneNumber',
-                    label: 'Telephone number (optional)',
+                    label: 'Telephone number',
                     value: '',
+                    width: 20,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 25 }]
                 },
                 {
                     name: 'emailAddress',
-                    label: 'Email address (optional)',
+                    label: 'Email address',
                     value: '',
+                    width: 20,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 255 }]
                 },

--- a/src/app/forms/templates/general/manufacturer.template.ts
+++ b/src/app/forms/templates/general/manufacturer.template.ts
@@ -1,7 +1,7 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes } from '../../services/dynamic-form.types';
 
-export const TrlManufacturerTemplate: FormNode = {
+export const ManufacturerTemplate: FormNode = {
   name: 'manufacturerSection',
   label: 'Manufacturer',
   type: FormNodeTypes.GROUP,


### PR DESCRIPTION
Changes:
- Renames manufacturer form 
- Adds service design (different width input boxes) to the last applicant details section [CB2-5687](https://dvsa.atlassian.net/browse/CB2-5687)
![image](https://user-images.githubusercontent.com/92087051/194089908-3b1f2514-5d10-43b8-b6ae-b73bc8aa5781.png)


## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
