### PR TITLE
fix(cb2-6234): clicking cancel confirmation to not take out of edit mode

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -51,12 +51,12 @@ export class EditTechRecordButtonComponent implements OnInit {
   cancelAmend() {
     if (!this.isDirty || confirm('Your changes will not be saved. Are you sure?')) {
       this.toggleEditMode();
+      this.router.navigate([]);
+      this.errorService.clearErrors();
+      this.store.dispatch(updateEditingTechRecordCancel());
     }
-
-    this.errorService.clearErrors();
-    this.store.dispatch(updateEditingTechRecordCancel());
-    this.router.navigate([]);
   }
+
 
   clickScrollToTop(): void {
     this.viewportScroller.scrollToPosition([0, 0]);


### PR DESCRIPTION
## Click on cancel on warning message should keep tech record in editable mode with new values

Previously when canceling an amendment of a tech record, you were prompted with a popup if you were sure you wanted to cancel. If you then clicked that you didn't want to cancel the amendment, your changes would be lost and the non-edit view would be presented to the user.

The expected behavior of staying in the edit view is now retained if you choose to not want to cancel the amendment when prompted.

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6234)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
