### PR TITLE
fix(cb2-6224): fix accordion icons and toggling functionality

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -1,17 +1,17 @@
 <section>
   <app-accordion-control>
     <ng-container *ngFor="let section of sectionTemplates" [ngSwitch]="section.name">
-      <app-accordion *ngIf="section.name !== 'reasonForCreationSection' || isEditable" [id]="section.name" [title]="section.label">
+      <app-accordion [id]="section.name" [title]="section.label">
         <app-dimensions
           *ngSwitchCase="'dimensionsSection'"
           [vehicleTechRecord]="vehicleTechRecordCalculated"
-          [isEditing]="isEditable"
+          [isEditing]="isEditing"
           (formChange)="handleFormState($event)"
         ></app-dimensions>
 
         <app-weights
           *ngSwitchCase="'weightsSection'"
-          [isEditing]="isEditable"
+          [isEditing]="isEditing"
           [template]="section"
           [data]="vehicleTechRecordCalculated"
           (formChange)="handleFormState($event)"
@@ -19,7 +19,7 @@
 
         <app-dynamic-form-group
           *ngSwitchDefault
-          [edit]="isEditable"
+          [edit]="isEditing"
           [template]="section"
           [data]="vehicleTechRecordCalculated"
           (formChange)="handleFormState($event)"

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -26,7 +26,6 @@
 
         <app-dynamic-form-group
           *ngSwitchDefault
-          class="govuk-summary-list"
           [data]="vehicleTechRecordCalculated"
           [template]="section"
           [edit]="isEditing"

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -44,7 +44,7 @@ describe('TechRecordSummaryComponent', () => {
 
   describe( 'TechRecordSummaryComponent View', () => {
     it('should show PSV record found', () => {
-      component.isEditable = false
+      component.isEditing = false
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       fixture.detectChanges();
 
@@ -52,7 +52,7 @@ describe('TechRecordSummaryComponent', () => {
     });
 
     it('should show PSV record found without dimensions', () => {
-      component.isEditable = false
+      component.isEditing = false
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       component.vehicleTechRecord!.dimensions = undefined;
       fixture.detectChanges();
@@ -61,7 +61,7 @@ describe('TechRecordSummaryComponent', () => {
     });
 
     it('should show HGV record found', () => {
-      component.isEditable = false
+      component.isEditing = false
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
       fixture.detectChanges();
 
@@ -69,7 +69,7 @@ describe('TechRecordSummaryComponent', () => {
     });
 
     it('should show HGV record found without dimensions', () => {
-      component.isEditable = false
+      component.isEditing = false
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
       component.vehicleTechRecord!.dimensions = undefined;
       fixture.detectChanges();
@@ -78,7 +78,7 @@ describe('TechRecordSummaryComponent', () => {
     });
 
     it('should show TRL record found', () => {
-      component.isEditable = false
+      component.isEditing = false
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
       fixture.detectChanges();
 
@@ -86,7 +86,7 @@ describe('TechRecordSummaryComponent', () => {
     });
 
     it('should show TRL record found without dimensions', () => {
-      component.isEditable = false
+      component.isEditing = false
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
       component.vehicleTechRecord!.dimensions = undefined;
       fixture.detectChanges();
@@ -97,7 +97,7 @@ describe('TechRecordSummaryComponent', () => {
 
   describe( 'TechRecordSummaryComponent Amend', () => {
     it('should make reason for change null in editMode', () => {
-      component.isEditable = true;
+      component.isEditing = true;
       component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       fixture.detectChanges();
 

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -46,13 +46,14 @@ export class TechRecordSummaryComponent implements OnInit {
 
   @Input() vehicleTechRecord!: TechRecordModel;
 
-  private _isEditable: boolean = false;
-  get isEditable(): boolean {
-    return this._isEditable;
+  private _isEditing: boolean = false;
+  get isEditing(): boolean {
+    return this._isEditing;
   }
   @Input()
-  set isEditable(value: boolean) {
-    this._isEditable = value;
+  set isEditing(value: boolean) {
+    this._isEditing = value;
+    this.toggleReasonForCreation();
     this.calculateVehicleModel();
   }
 
@@ -65,26 +66,31 @@ export class TechRecordSummaryComponent implements OnInit {
   constructor(private store: Store<TechnicalRecordServiceState>) {}
 
   ngOnInit(): void {
-    this.initializeVehicleTemplates();
+    this.sectionTemplates = this.vehicleTemplates;
     this.calculateVehicleModel();
   }
 
-  initializeVehicleTemplates(): void {
+  get vehicleTemplates(): Array<FormNode> {
     switch (this.vehicleTechRecord.vehicleType) {
-      case 'psv':
-        this.sectionTemplates = this.getPsvTemplates();
-        break;
-      case 'hgv':
-        this.sectionTemplates = this.getHgvTemplates();
-        break;
-      case 'trl':
-        this.sectionTemplates = this.getTrlTemplates();
-        break;
+      case VehicleTypes.PSV:
+        return this.getPsvTemplates();
+      case VehicleTypes.HGV:
+        return this.getHgvTemplates();
+      case VehicleTypes.TRL:
+        return this.getTrlTemplates();
+    }
+  }
+
+  toggleReasonForCreation(): void {
+    if (this.isEditing) {
+      this.sectionTemplates.unshift(reasonForCreationSection);
+    } else {
+      this.sectionTemplates.shift()
     }
   }
 
   calculateVehicleModel(): void {
-    this.vehicleTechRecordCalculated = this.isEditable ? { ...cloneDeep(this.vehicleTechRecord), reasonForCreation: '' } : this.vehicleTechRecord;
+    this.vehicleTechRecordCalculated = this.isEditing ? { ...cloneDeep(this.vehicleTechRecord), reasonForCreation: '' } : this.vehicleTechRecord;
 
     this.store.dispatch(updateEditingTechRecord({ techRecord: this.vehicleTechRecordCalculated }));
   }
@@ -101,7 +107,7 @@ export class TechRecordSummaryComponent implements OnInit {
 
   getPsvTemplates(): Array<FormNode> {
     return [
-      /*  1 */ reasonForCreationSection,
+      /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ PsvNotes,
       /*  3 */ PsvTechRecord,
       /*  4 */ getTypeApprovalSection(VehicleTypes.PSV),
@@ -119,7 +125,7 @@ export class TechRecordSummaryComponent implements OnInit {
 
   getHgvTemplates(): Array<FormNode> {
     return [
-      /*  1 */ reasonForCreationSection,
+      /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ NotesTemplate,
       /*  3 */ HgvTechRecord,
       /*  4 */ getTypeApprovalSection(VehicleTypes.HGV),
@@ -141,7 +147,7 @@ export class TechRecordSummaryComponent implements OnInit {
 
   getTrlTemplates(): Array<FormNode> {
     return [
-      /*  1 */ reasonForCreationSection,
+      /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ NotesTemplate,
       /*  3 */ TrlTechRecordTemplate,
       /*  4 */ getTypeApprovalSection(VehicleTypes.TRL),

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -52,7 +52,7 @@
     ></app-edit-tech-record-button>
     <app-tech-record-summary
       *ngIf="currentTechRecord$ | async as currentTechRecord"
-      [isEditable]="isEditable"
+      [isEditing]="isEditable"
       [vehicleTechRecord]="currentTechRecord"
       (formChange)="handleFormState()"
     ></app-tech-record-summary>

--- a/src/app/features/test-records/components/base-test-record/base-test-record.component.html
+++ b/src/app/features/test-records/components/base-test-record/base-test-record.component.html
@@ -15,7 +15,7 @@
 <ng-container *ngIf="sectionTemplates$ | async as sectionTemplates">
   <app-accordion-control>
     <ng-container *ngFor="let template of sectionTemplates; let i = index" [ngSwitch]="template.name">
-      <app-accordion *ngSwitchCase="'defects'" [id]="template.name" [title]="template.label" [expanded]="expandSections">
+      <app-accordion *ngSwitchCase="'defects'" [id]="template.name" [title]="template.label">
         <app-defects
           class="section"
           [id]="template.name"
@@ -28,7 +28,7 @@
       </app-accordion>
 
       <ng-container *ngSwitchCase="'vehicleSection'">
-        <app-accordion *ngIf="isEditing" [id]="template.name" [title]="template.label" [expanded]="expandSections">
+        <app-accordion *ngIf="isEditing" [id]="template.name" [title]="template.label">
           <app-dynamic-form-group
             class="section"
             [id]="template.name"
@@ -53,7 +53,7 @@
 
       <ng-container *ngSwitchDefault>
         <!-- skip `reasonForCreationSection` because its handled further down -->
-        <app-accordion *ngIf="'reasonForCreationSection' !== template.name" [id]="template.name" [title]="template.label" [expanded]="expandSections">
+        <app-accordion *ngIf="'reasonForCreationSection' !== template.name" [id]="template.name" [title]="template.label">
           <app-dynamic-form-group
             class="section"
             [id]="template.name"
@@ -65,12 +65,7 @@
         </app-accordion>
 
         <!-- We only show this section if in editing state -->
-        <app-accordion
-          *ngIf="'reasonForCreationSection' === template.name && isEditing"
-          [id]="template.name"
-          [title]="template.label"
-          [expanded]="expandSections"
-        >
+        <app-accordion *ngIf="'reasonForCreationSection' === template.name && isEditing" [id]="template.name" [title]="template.label">
           <app-dynamic-form-group
             class="section"
             [id]="template.name"

--- a/src/app/shared/components/accordion-control/accordion-control.component.html
+++ b/src/app/shared/components/accordion-control/accordion-control.component.html
@@ -1,10 +1,7 @@
 <div class="govuk-accordion__controls">
-  <button type="button" class="govuk-accordion__show-all" [attr.aria-expanded]="expanded" (click)="expanded ? close() : open()">
-    <span
-      class="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"
-      [ngClass]="expanded ? 'govuk-accordion-nav__chevron--down' : 'govuk-accordion-nav__chevron'"
-    ></span
-    ><span class="govuk-accordion__show-all-text">{{ expanded ? 'Hide' : 'Show' }} all sections</span>
+  <button type="button" class="govuk-accordion__show-all" [attr.aria-expanded]="isExpanded" (click)="toggle()">
+    <span [class]="iconStyle"></span>
+    <span class="govuk-accordion__show-all-text">{{ isExpanded ? 'Hide' : 'Show' }} all sections</span>
   </button>
 </div>
 <ng-content></ng-content>

--- a/src/app/shared/components/accordion-control/accordion-control.component.spec.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.spec.ts
@@ -35,11 +35,11 @@ describe('AccordionControlComponent', () => {
   it('should open and close child accordions', () => {
     fixture.whenRenderingDone().then(() => {
       expect(component.accordions?.length).toBe(1);
-      expect(component.accordions[0].expanded).toBeFalsy();
-      component.open();
-      expect(component.accordions[0].expanded).toBeTruthy();
-      component.close();
-      expect(component.accordions[0].expanded).toBeFalsy();
+      expect(component.accordions?.get(0)!.isExpanded).toBeFalsy();
+      component.toggle();
+      expect(component.accordions?.get(0)!.isExpanded).toBeTruthy();
+      component.toggle();
+      expect(component.accordions?.get(0)!.isExpanded).toBeFalsy();
     });
   });
 });

--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChildren, Input, QueryList } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChildren, Input, QueryList } from '@angular/core';
 import { AccordionComponent } from '../accordion/accordion.component';
 
 @Component({
@@ -7,40 +7,33 @@ import { AccordionComponent } from '../accordion/accordion.component';
   styleUrls: ['accordion-control.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AccordionControlComponent implements AfterContentInit {
-  @ContentChildren(AccordionComponent) _accordions?: QueryList<AccordionComponent>;
-
-  @Input() set expanded(expanded: boolean) {
-    this.expanded_ = expanded;
+export class AccordionControlComponent  {
+  private _accordions?: QueryList<AccordionComponent>;
+  get accordions(): QueryList<AccordionComponent> | undefined {
+    return this._accordions;
+  }
+  @ContentChildren(AccordionComponent) set accordions(value: QueryList<AccordionComponent> | undefined) {
+    this._accordions = value;
+    this.toggleAccordions();
   }
 
-  private accordions_: Array<AccordionComponent> = [];
-  private expanded_ = false;
+  @Input() isExpanded = false;
 
   constructor(private cdr: ChangeDetectorRef) {}
 
-  ngAfterContentInit(): void {
-    this._accordions?.forEach(a => this.accordions_.push(a));
+  get iconStyle(): string {
+    return 'govuk-accordion-nav__chevron' +(this.isExpanded ? '' : ' govuk-accordion-nav__chevron--down');
   }
 
-  get accordions() {
-    return this.accordions_;
-  }
-
-  get expanded(): boolean {
-    return this.expanded_;
-  }
-
-  open(): void {
-    this.expanded = true;
-    this.accordions_.forEach(a => {
-      a.open();
-    });
+  toggle(): void {
+    this.isExpanded = !this.isExpanded;
+    this.toggleAccordions();
     this.cdr.markForCheck();
   }
-  close(): void {
-    this.expanded = false;
-    this.accordions_.forEach(a => a.close());
-    this.cdr.markForCheck();
+
+  toggleAccordions(): void {
+    if (this.accordions) {
+      this.accordions.forEach(a => this.isExpanded ? a.open() : a.close());
+    }
   }
 }

--- a/src/app/shared/components/accordion/accordion.component.html
+++ b/src/app/shared/components/accordion/accordion.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-accordion__section" [ngClass]="{ 'govuk-accordion__section--expanded': expanded }">
+<div class="govuk-accordion__section" [ngClass]="{ 'govuk-accordion__section--expanded': isExpanded }">
   <div class="govuk-accordion__section-header">
     <h2 class="govuk-accordion__section-heading">
       <button
@@ -6,20 +6,21 @@
         type="button"
         attr.aria-controls="accordion-details-{{ id }}"
         class="govuk-accordion__section-button"
-        [attr.aria-expanded]="expanded"
-        (click)="toggle()"
+        [attr.aria-expanded]="isExpanded"
+        (click)="isExpanded ? close() : open()"
       >
-        <span class="govuk-accordion__section-heading-text" id="accordion-title-{{ id }}"
-          ><span class="govuk-accordion__section-heading-text-focus">{{ title }}</span></span
-        ><span class="govuk-visually-hidden govuk-accordion__section-heading-divider">, </span
-        ><span class="govuk-accordion__section-toggle" data-nosnippet=""
-          ><span class="govuk-accordion__section-toggle-focus"
-            ><span class="govuk-accordion-nav__chevron govuk-accordion-nav__chevron--down"></span
-            ><span class="govuk-accordion__section-toggle-text"
-              >{{ expanded ? 'Hide' : 'Show' }}<span class="govuk-visually-hidden"> this section</span></span
-            ></span
-          ></span
-        >
+        <span class="govuk-accordion__section-heading-text" id="accordion-title-{{ id }}">
+          <span class="govuk-accordion__section-heading-text-focus">{{ title }}</span>
+        </span>
+        <span class="govuk-visually-hidden govuk-accordion__section-heading-divider">, </span>
+        <span class="govuk-accordion__section-toggle" data-nosnippet="">
+          <span class="govuk-accordion__section-toggle-focus">
+            <span [class]="iconStyle"></span>
+            <span class="govuk-accordion__section-toggle-text">
+              {{ isExpanded ? 'Hide' : 'Show' }}<span class="govuk-visually-hidden"> this section</span>
+            </span>
+          </span>
+        </span>
       </button>
     </h2>
   </div>

--- a/src/app/shared/components/accordion/accordion.component.spec.ts
+++ b/src/app/shared/components/accordion/accordion.component.spec.ts
@@ -38,24 +38,24 @@ describe('AccordionComponent', () => {
     const button: HTMLButtonElement = fixture.debugElement.query(By.css('#accordion-control-test')).nativeElement;
 
     button.click();
-    expect(component.expanded).toBeTruthy();
+    expect(component.isExpanded).toBeTruthy();
 
     button.click();
-    expect(component.expanded).toBeFalsy();
+    expect(component.isExpanded).toBeFalsy();
   });
 
   it('should set expanded value to true', () => {
     const markForCheckSpy = jest.spyOn(component['cdr'], 'markForCheck');
     component.open();
-    expect(component.expanded).toBeTruthy();
+    expect(component.isExpanded).toBeTruthy();
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should set expanded value to false', () => {
     const markForCheckSpy = jest.spyOn(component['cdr'], 'markForCheck');
-    component.expanded = true;
+    component.isExpanded = true;
     component.close();
-    expect(component.expanded).toBeFalsy();
+    expect(component.isExpanded).toBeFalsy();
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/shared/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/accordion/accordion.component.ts
@@ -10,28 +10,21 @@ export class AccordionComponent {
   @Input() title: string | undefined = '';
   @Input() id: string | number = '';
 
-  @Input() set expanded(expanded: boolean) {
-    this.expanded_ = expanded;
-  }
-
-  private expanded_ = false;
+  @Input() isExpanded = false;
 
   constructor(private cdr: ChangeDetectorRef) {}
 
-  get expanded(): boolean {
-    return this.expanded_;
-  }
-
-  toggle() {
-    this.expanded = !this.expanded;
+  get iconStyle(): string {
+    return 'govuk-accordion-nav__chevron' +(this.isExpanded ? '' : ' govuk-accordion-nav__chevron--down');
   }
 
   open(): void {
-    this.expanded = true;
+    this.isExpanded = true;
     this.cdr.markForCheck();
   }
+
   close(): void {
-    this.expanded = false;
+    this.isExpanded = false;
     this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
## Reason for creation text box not expanded when click on Show all sections in edit tech record mode

- Fix the accordion icons which were not toggling correctly.
- Handle the edge case where the accordion control would ignore new accordions added after the `ngAfterContentInit()`.
- Simplify and refactor the accordion and accordion control components.

[CB2-6224](https://dvsa.atlassian.net/browse/CB2-6224)