### PR TITLE
fix(*): fix input bar width service design

### DIFF
--- a/src/app/forms/components/text-input/text-input.component.ts
+++ b/src/app/forms/components/text-input/text-input.component.ts
@@ -16,5 +16,8 @@ import { BaseControlComponent } from '../base-control/base-control.component';
 export class TextInputComponent extends BaseControlComponent {
   @Input() isEditing = true;
   @Input() numeric = false;
-  style = 'govuk-input' + (this.width ? (` govuk-input--width-` + this.width) : '');
+
+  get style(): string {
+    return ('govuk-input ' + (this.width ? ('govuk-input--width-' + this.width.toString()) : ''));
+  }
 }

--- a/src/app/forms/templates/general/applicant-details.template.ts
+++ b/src/app/forms/templates/general/applicant-details.template.ts
@@ -1,4 +1,4 @@
-import { FormNode, FormNodeTypes, FormNodeViewTypes } from '../../services/dynamic-form.types';
+import { FormNode, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '../../services/dynamic-form.types';
 import { ValidatorNames } from '@forms/models/validators.enum';
 
 
@@ -15,7 +15,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'name',
                     label: 'Name or company',
                     value: '',
-                    width: 30,
+                    width: FormNodeWidth.XXL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 150 }]
                 },
@@ -23,7 +23,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'address1',
                     label: 'Address line 1',
                     value: '',
-                    width: 30,
+                    width: FormNodeWidth.XXL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
@@ -31,7 +31,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'address2',
                     label: 'Address line 2',
                     value: '',
-                    width: 30,
+                    width: FormNodeWidth.XXL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
@@ -39,7 +39,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'postTown',
                     label: 'Town or City',
                     value: '',
-                    width: 20,
+                    width: FormNodeWidth.XL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
@@ -47,7 +47,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'address3',
                     label: 'County',
                     value: '',
-                    width: 20,
+                    width: FormNodeWidth.XL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 60 }]
                 },
@@ -55,7 +55,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'postCode',
                     label: 'Postcode',
                     value: '',
-                    width: 10,
+                    width: FormNodeWidth.L,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 12 }]
                 },
@@ -63,7 +63,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'telephoneNumber',
                     label: 'Telephone number',
                     value: '',
-                    width: 20,
+                    width: FormNodeWidth.XL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 25 }]
                 },
@@ -71,7 +71,7 @@ export const ApplicantDetails: FormNode = {
                     name: 'emailAddress',
                     label: 'Email address',
                     value: '',
-                    width: 20,
+                    width: FormNodeWidth.XL,
                     type: FormNodeTypes.CONTROL,
                     validators: [{ name: ValidatorNames.MaxLength, args: 255 }]
                 },


### PR DESCRIPTION
Quick fix for variable input box width which was not able to compute the `width` property during rendering HTML and so the style was defaulting to `govuk-input` even when width was provided in the template. Changed style to a getter which has resolved the issue.
