### PR TITLE
fix(cb2-6291): fix displaying string booleans

### DIFF
--- a/src/app/forms/templates/trl/trl-brakes.template.ts
+++ b/src/app/forms/templates/trl/trl-brakes.template.ts
@@ -8,7 +8,6 @@ export const TrlBrakes: FormNode = {
   children: [
     {
       name: 'brakes',
-      value: '',
       type: FormNodeTypes.GROUP,
       children: [
         {
@@ -33,7 +32,6 @@ export const TrlBrakes: FormNode = {
         {
           name: '0',
           label: 'Axle',
-          value: '',
           type: FormNodeTypes.GROUP,
           children: [
             {

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -383,7 +383,7 @@ export enum RetarderBrake {
 export interface AxleBrakeProperties {
   brakeActuator: string;
   leverLength: string;
-  springBrakeParking: string;
+  springBrakeParking: boolean;
 }
 
 export interface Microfilm {

--- a/src/app/shared/pipes/default-null-or-empty/default-null-or-empty.pipe.ts
+++ b/src/app/shared/pipes/default-null-or-empty/default-null-or-empty.pipe.ts
@@ -8,7 +8,13 @@ export class DefaultNullOrEmpty implements PipeTransform {
 
   transform(value: any): any {
     if (typeof value === 'string') {
-      return value.trim().length > 0 ? this.titleCaseFirstWord(value) : '-';
+      if (value.toLowerCase() === 'true') {
+        return 'Yes';
+      } else if (value.toLowerCase() === 'false') {
+        return 'No';
+      } else {
+        return value.trim().length > 0 ? this.titleCaseFirstWord(value) : '-';
+      }
     } else if (typeof value === 'boolean') {
       return value ? 'Yes' : 'No';
     } else {


### PR DESCRIPTION
## Spring Brake Parking Boolean Value Text

When data coming from the API includes `boolean` values that are in `string` format, the `defaultNullOrEmpty` directive shows them as "True" or "False", whereas they should be displayed as "Yes" or "No".

This PR addresses this edge case.

[CB2-6291](https://dvsa.atlassian.net/browse/CB2-6291)