### PR TITLE
chore(*): add more tests for edit tech record button

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
@@ -71,12 +71,7 @@ describe('EditTechRecordButtonComponent', () => {
   
       const button = fixture.debugElement.query(By.css('#edit'));
       
-      if (expected) {
-        expect(button).toBeTruthy;
-      }
-      else {
-        expect(button).toBeFalsy;
-      }
+      expected ? expect(button).toBeTruthy() : expect(button).toBeFalsy();
     });
   })
 


### PR DESCRIPTION
Adds more tests to the edit tech record button, mainly todo with router navigation and user journeys when going to cancel an amendment