### PR TITLE
fix(cb2-6362 & cb2-6447): provide provisional with own path and allow test to be conducted on provisional

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
@@ -139,7 +139,7 @@ describe('EditTechRecordButtonComponent', () => {
         tick();
 
         expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
-        expect(router.navigateByUrl).toHaveBeenCalledWith('/tech-records/1/1/historic/' + expectedDate.getTime());
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/tech-records/1/1/provisional');
       }));
 
       it('router should be called on createProvisionalTechRecordSuccess', fakeAsync(() => {
@@ -150,7 +150,7 @@ describe('EditTechRecordButtonComponent', () => {
         tick();
 
         expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
-        expect(router.navigateByUrl).toHaveBeenCalledWith('/tech-records/1/1/historic/' + expectedDate.getTime());
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/tech-records/1/1/provisional');
       }));
     })
 

--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -41,7 +41,7 @@ export class EditTechRecordButtonComponent implements OnInit {
       .subscribe(vehicleTechRecord => {
         const techRecord = vehicleTechRecord!.techRecord[0];
 
-        const routeSuffix = techRecord.statusCode === StatusCodes.CURRENT ? '' : `/historic/${this.getLatestRecordTimestamp(vehicleTechRecord!)}`;
+        const routeSuffix = techRecord.statusCode === StatusCodes.CURRENT ? '' : '/provisional';
 
         this.router.navigateByUrl(`/tech-records/${vehicleTechRecord!.systemNumber}/${vehicleTechRecord!.vin}${routeSuffix}`);
       });

--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -48,7 +48,7 @@ export class EditTechRecordButtonComponent implements OnInit {
   }
 
   get isArchived(): boolean {
-    return this.viewableTechRecord?.statusCode === StatusCodes.ARCHIVED;
+    return !(this.viewableTechRecord?.statusCode === StatusCodes.CURRENT || this.viewableTechRecord?.statusCode === StatusCodes.PROVISIONAL);
   }
 
   getLatestRecordTimestamp(record: VehicleTechRecordModel): number {

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
@@ -22,9 +22,7 @@
           <ng-container *ngIf="techRecord.createdAt !== currentRecord?.createdAt">
             <a
               id="view-test-{{ vehicleTechRecord!.vin }}"
-              href="/tech-records/{{ vehicleTechRecord!.systemNumber }}/{{ vehicleTechRecord!.vin }}/historic/{{
-                convertToUnix(techRecord.createdAt)
-              }}"
+              href="/tech-records/{{ vehicleTechRecord!.systemNumber }}/{{ vehicleTechRecord!.vin }}{{ summaryLinkUrl(techRecord) }}"
             >
               View
             </a>

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
@@ -36,4 +36,8 @@ export class TechRecordHistoryComponent {
   trackByFn(i: number, tr: TechRecordModel) {
     return tr.createdAt;
   }
+
+  summaryLinkUrl(techRecord: TechRecordModel) {
+    return techRecord.statusCode !== 'current' ? `/historic/${this.convertToUnix(techRecord.createdAt)}`: ''
+  }
 }

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
-import { TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
 
 @Component({
   selector: 'app-tech-record-history',
@@ -38,6 +38,13 @@ export class TechRecordHistoryComponent {
   }
 
   summaryLinkUrl(techRecord: TechRecordModel) {
-    return techRecord.statusCode !== 'current' ? `/historic/${this.convertToUnix(techRecord.createdAt)}`: ''
+    switch (techRecord.statusCode) {
+      case StatusCodes.PROVISIONAL:
+        return '/provisional'
+      case StatusCodes.ARCHIVED:
+        return `/historic/${this.convertToUnix(techRecord.createdAt)}`
+      default:
+        return ''
+    }
   }
 }

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.html
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.html
@@ -28,6 +28,6 @@
   </table>
   <app-pagination tableName="test-history" [numberOfItems]="numberOfRecords" (paginationOptions)="handlePaginationChange($event)"></app-pagination>
 </ng-container>
-<div *ngIf="vehicleTechRecord" class="govuk-button-group">
+<div *ngIf="!isArchived" class="govuk-button-group">
   <a class="govuk-button" [routerLink]="'test-records/create-test/type'">Create a test for this vehicle</a>
 </div>

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 import { TestResultModel } from '@models/test-results/test-result.model';
-import { VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
 
 interface TestField {
@@ -18,10 +18,15 @@ interface TestField {
 })
 export class TestRecordSummaryComponent {
   @Input() testRecords: TestResultModel[] = [];
-  @Input() vehicleTechRecord?: VehicleTechRecordModel;
+  @Input() currentTechRecord?: TechRecordModel;
+
 
   pageStart?: number;
   pageEnd?: number;
+
+  get isArchived(): boolean {
+    return !(this.currentTechRecord?.statusCode === StatusCodes.CURRENT || this.currentTechRecord?.statusCode === StatusCodes.PROVISIONAL);
+  }
 
   constructor(private cdr: ChangeDetectorRef) {}
 

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -62,7 +62,7 @@
       [vehicleTechRecord]="vehicleTechRecord"
     ></app-tech-record-history>
 
-    <app-test-record-summary *appRoleRequired="roles.TestResultView" [testRecords]="(records$ | async) || []" [vehicleTechRecord]="vehicleTechRecord">
+    <app-test-record-summary *appRoleRequired="roles.TestResultView" [testRecords]="(records$ | async) || []" [currentTechRecord]="(currentTechRecord$ | async) || undefined">
     </app-test-record-summary>
   </div>
 </div>

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -62,7 +62,11 @@
       [vehicleTechRecord]="vehicleTechRecord"
     ></app-tech-record-history>
 
-    <app-test-record-summary *appRoleRequired="roles.TestResultView" [testRecords]="(records$ | async) || []" [currentTechRecord]="(currentTechRecord$ | async) || undefined">
+    <app-test-record-summary
+      *appRoleRequired="roles.TestResultView"
+      [testRecords]="(records$ | async) || []"
+      [currentTechRecord]="(currentTechRecord$ | async) || undefined"
+    >
     </app-test-record-summary>
   </div>
 </div>

--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -35,14 +35,14 @@ const routes: Routes = [
     canActivate: [MsalGuard, RoleGuard],
   },
   {
-    path: ':provisional',
+    path: 'provisional',
     component: TechRecordComponent,
     data: { title: 'Provisional tech record' },
     canActivate: [MsalGuard],
     resolve: { load: TechRecordViewResolver }
   },
   {
-    path: ':provisional/notifiable-alteration-needed',
+    path: 'provisional/notifiable-alteration-needed',
     component: TechRecordComponent,
     canActivate: [MsalGuard],
     data: { roles: Roles.TechRecordAmend, isEditing: true, reason: ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED },
@@ -63,6 +63,13 @@ const routes: Routes = [
   },
   {
     path: 'test-records/create-test',
+    data: { roles: Roles.TestResultAmend },
+    canActivate: [MsalGuard, RoleGuard],
+    resolve: { techRecord: TechRecordViewResolver },
+    loadChildren: () => import('../test-records/create/create-test-records.module').then(m => m.CreateTestRecordsModule)
+  },
+  {
+    path: 'provisional/test-records/create-test',
     data: { roles: Roles.TestResultAmend },
     canActivate: [MsalGuard, RoleGuard],
     resolve: { techRecord: TechRecordViewResolver },

--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -35,10 +35,17 @@ const routes: Routes = [
     canActivate: [MsalGuard, RoleGuard],
   },
   {
-    path: 'historic/:techCreatedAt/notifiable-alteration-needed',
+    path: ':provisional',
     component: TechRecordComponent,
+    data: { title: 'Provisional tech record' },
+    canActivate: [MsalGuard],
+    resolve: { load: TechRecordViewResolver }
+  },
+  {
+    path: ':provisional/notifiable-alteration-needed',
+    component: TechRecordComponent,
+    canActivate: [MsalGuard],
     data: { roles: Roles.TechRecordAmend, isEditing: true, reason: ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED },
-    canActivate: [MsalGuard, RoleGuard],
   },
   {
     path: 'historic/:techCreatedAt',

--- a/src/app/features/test-records/amend/views/amended-test-record/amended-test-record.component.spec.ts
+++ b/src/app/features/test-records/amend/views/amended-test-record/amended-test-record.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ApiModule as TestResultsApiModule } from '@api/test-results';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { mockDefectList } from '@mocks/mock-defects';
@@ -25,7 +26,7 @@ describe('AmendedTestRecordComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AmendedTestRecordComponent, BaseTestRecordComponent, VehicleHeaderComponent, ResultOfTestComponent],
-      imports: [HttpClientTestingModule, SharedModule, DynamicFormsModule, TestResultsApiModule],
+      imports: [HttpClientTestingModule, SharedModule, DynamicFormsModule, TestResultsApiModule, RouterTestingModule],
       providers: [
         TestRecordsService,
         provideMockStore({ initialState: initialAppState }),

--- a/src/app/features/test-records/components/base-test-record/base-test-record.component.spec.ts
+++ b/src/app/features/test-records/components/base-test-record/base-test-record.component.spec.ts
@@ -17,6 +17,7 @@ import { VehicleHeaderComponent } from '../vehicle-header/vehicle-header.compone
 import { UserService } from '@services/user-service/user-service';
 import { of } from 'rxjs';
 import { Roles } from '@models/roles.enum';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('BaseTestRecordComponent', () => {
   let component: BaseTestRecordComponent;
@@ -25,7 +26,7 @@ describe('BaseTestRecordComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [BaseTestRecordComponent, ResultOfTestComponent, DefaultNullOrEmpty, VehicleHeaderComponent],
-      imports: [DynamicFormsModule, HttpClientTestingModule, SharedModule],
+      imports: [DynamicFormsModule, HttpClientTestingModule, SharedModule, RouterTestingModule],
       providers: [
         RouterService,
         provideMockStore({ initialState: initialAppState }),

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.spec.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.spec.ts
@@ -9,6 +9,7 @@ import { of } from 'rxjs';
 import { ResultOfTestComponent } from '../result-of-test/result-of-test.component';
 import { VehicleHeaderComponent } from './vehicle-header.component';
 import { TechRecordModel, VehicleTypes, VehicleConfigurations } from '@models/vehicle-tech-record.model';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('VehicleHeaderComponent', () => {
   let component: VehicleHeaderComponent;
@@ -17,7 +18,7 @@ describe('VehicleHeaderComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [VehicleHeaderComponent, ResultOfTestComponent],
-      imports: [SharedModule, HttpClientTestingModule],
+      imports: [SharedModule, HttpClientTestingModule, RouterTestingModule],
       providers: [TestTypesService, provideMockStore({ initialState: initialAppState }), ResultOfTestService]
     }).compileComponents();
   }));

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -19,7 +20,7 @@ describe('ContingencyTestResolver', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
         provideMockStore({ initialState: initialAppState }),
         provideMockActions(() => actions$),

--- a/src/app/services/technical-record/technical-record.service.spec.ts
+++ b/src/app/services/technical-record/technical-record.service.spec.ts
@@ -1,5 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialAppState } from '@store/.';
@@ -14,7 +16,7 @@ describe('TechnicalRecordService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule,RouterTestingModule],
       providers: [TechnicalRecordService, provideMockStore({ initialState: initialAppState })]
     });
 

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -15,7 +15,7 @@ import {
   vehicleTechRecords
 } from '@store/technical-records';
 import { cloneDeep } from 'lodash';
-import { map, Observable, of, switchMap, take } from 'rxjs';
+import { map, Observable, of, switchMap } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 export enum SEARCH_TYPES {

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -142,9 +142,17 @@ export class TechnicalRecordService {
       select(selectRouteNestedParams),
       map(params => {
         const createdAt = params['techCreatedAt'];
-        return createdAt
-          ? vehicleRecord.techRecord.find(techRecord => new Date(techRecord.createdAt).getTime() == createdAt)
-          : this.filterTechRecordByStatusCode(vehicleRecord);
+        const isProvisional = params['provisional'] === 'provisional';
+
+        if (isProvisional) {
+          return vehicleRecord.techRecord.find(record => record.statusCode === StatusCodes.PROVISIONAL)
+        }
+
+        if (createdAt) {
+          vehicleRecord.techRecord.find(techRecord => new Date(techRecord.createdAt).getTime() == createdAt && techRecord.statusCode === StatusCodes.ARCHIVED)
+        }
+
+        return this.filterTechRecordByStatusCode(vehicleRecord);
       })
     );
   }


### PR DESCRIPTION
## Ticket title

Changes in this PR:
- When navigating back to a current tech record via the tech record history component, the breadcrumbs and URL will no longer have `historic` in them.
- Provisional tech records now have their own unique URL path - previously they would be provided with `historic`
- Now possible to conduct a test against a provisional tech record whereas previously it would navigate you to an invalid path
- Not possible to conduct a test against an archived tech record.

[CB2-6362](https://dvsa.atlassian.net/browse/CB2-6362) & [CB2-6447](https://dvsa.atlassian.net/browse/CB2-6447)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
