### PR TITLE
fix(*): clear errors on navigation and stop errors in tech record non-edit mode

### DIFF
--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -130,6 +130,7 @@ describe('VehicleTechnicalRecordComponent', () => {
       component.vehicleTechRecord = mockVehicleTechnicalRecord();
       fixture.detectChanges();
 
+      component.isEditing = true;
       component.handleSubmit()
 
       expect(handleFormStateSpy).toHaveBeenCalled();

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -81,10 +81,12 @@ export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
   }
 
   handleFormState() {
-    const form = this.summary.sections.map(section => section.form).concat(this.summary.dimensions.form, this.summary.weights.form);
+    if (this.isEditing) {
+      const form = this.summary.sections.map(section => section.form).concat(this.summary.dimensions.form, this.summary.weights.form);
 
-    this.isDirty = form.some(form => form.dirty);
-    this.isInvalid = this.isAnyFormInvalid(form);
+      this.isDirty = form.some(form => form.dirty);
+      this.isInvalid = this.isAnyFormInvalid(form);
+    }
   }
 
   handleSubmit() {

--- a/src/app/store/global-error/reducers/global-error-service.reducer.spec.ts
+++ b/src/app/store/global-error/reducers/global-error-service.reducer.spec.ts
@@ -1,3 +1,4 @@
+import { routerNavigatedAction, RouterNavigatedPayload, SerializedRouterStateSnapshot } from '@ngrx/router-store';
 import { globalErrorReducer, GlobalErrorState, initialGlobalErrorState } from '@store/global-error/reducers/global-error-service.reducer';
 import { getByAllFailure, getByPartialVinFailure, getByTrailerIdFailure, getByVin, getByVinFailure } from '@store/technical-records';
 import { fetchTestResults, fetchTestResultsBySystemNumber, fetchTestResultsBySystemNumberFailed, fetchTestResultsFailed } from '@store/test-records';
@@ -39,6 +40,16 @@ describe('Global Error Reducer', () => {
       const newState = { ...initialGlobalErrorState, errors: [] };
       //all props must be supplied here
       const action = actionMethod({ systemNumber: '', vin: '' });
+      const state = globalErrorReducer(initialGlobalErrorState, action);
+
+      expect(state).toEqual(newState);
+      expect(state).not.toBe(newState);
+    });
+
+    it.each([routerNavigatedAction])('should reset the error state', actionMethod => {
+      const newState = { ...initialGlobalErrorState, errors: [] };
+      //all props must be supplied here
+      const action = actionMethod({payload: <RouterNavigatedPayload<SerializedRouterStateSnapshot>>{}});
       const state = globalErrorReducer(initialGlobalErrorState, action);
 
       expect(state).toEqual(newState);

--- a/src/app/store/global-error/reducers/global-error-service.reducer.ts
+++ b/src/app/store/global-error/reducers/global-error-service.reducer.ts
@@ -4,6 +4,7 @@ import * as TestResultActions from '@store/test-records';
 import * as TechnicalRecordServiceActions from '../../technical-records/actions/technical-record-service.actions';
 import * as GlobalErrorActions from '../actions/global-error.actions';
 import * as ReferenceDataActions from '../../reference-data/actions/reference-data.actions';
+import { routerNavigatedAction } from '@ngrx/router-store';
 
 export const STORE_FEATURE_GLOBAL_ERROR_KEY = 'globalError';
 
@@ -35,6 +36,7 @@ export const globalErrorReducer = createReducer(
     TestResultActions.fetchSelectedTestResult,
     ReferenceDataActions.fetchReferenceData,
     ReferenceDataActions.fetchReferenceDataByKey,
+    routerNavigatedAction,
     successMethod
   ),
 


### PR DESCRIPTION
Changes:
- Removes persistence of errors across pages, errors will now be cleared whenever user navigates through VTM 
- Errors will no longer be displayed on a tech record in non-edit mode that were previously caused by values on the tech record not matching the validations we have on the form. 
