### PR TITLE
fix(cb2-6524 & cb2-6523): amend maufactureyear and eurostandard form validation

### DIFF
--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -39,6 +39,7 @@ export const HgvTechRecord: FormNode = {
       editType: FormNodeEditTypes.TEXT,
       validators: [
         { name: ValidatorNames.Max, args: 9999 },
+        { name: ValidatorNames.Min, args: 1000 },
         { name: ValidatorNames.Numeric },
         { name: ValidatorNames.Required }
       ]

--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -38,7 +38,8 @@ export const HgvTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXT,
       validators: [
-        { name: ValidatorNames.MaxLength, args: 4 },
+        { name: ValidatorNames.Max, args: 9999 },
+        { name: ValidatorNames.Numeric },
         { name: ValidatorNames.Required }
       ]
     },
@@ -118,11 +119,10 @@ export const HgvTechRecord: FormNode = {
     {
       name: 'euroStandard',
       label: 'Euro standard',
-      value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
       options: getOptionsFromEnum(EmissionStandard),
-      validators: [{ name: ValidatorNames.Required }]
+      validators: [{ name: ValidatorNames.Defined }]
     },
     {
       name: 'roadFriendly',

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -38,7 +38,11 @@ export const PsvTechRecord: FormNode = {
       width: FormNodeWidth.XS,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXT,
-      validators: [{ name: ValidatorNames.MaxLength, args: 4 }, { name: ValidatorNames.Required }]
+      validators: [
+        { name: ValidatorNames.Max, args: 9999 },
+        { name: ValidatorNames.Numeric },
+        { name: ValidatorNames.Required }
+      ]
     },
     {
       name: 'noOfAxles',
@@ -113,11 +117,10 @@ export const PsvTechRecord: FormNode = {
     {
       name: 'euroStandard',
       label: 'Euro standard',
-      value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
       options: getOptionsFromEnum(EmissionStandard),
-      validators: [{ name: ValidatorNames.Required }]
+      validators: [{ name: ValidatorNames.Defined }]
     },
     {
       name: 'fuelPropulsionSystem',

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -40,6 +40,7 @@ export const PsvTechRecord: FormNode = {
       editType: FormNodeEditTypes.TEXT,
       validators: [
         { name: ValidatorNames.Max, args: 9999 },
+        { name: ValidatorNames.Min, args: 1000 },
         { name: ValidatorNames.Numeric },
         { name: ValidatorNames.Required }
       ]

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -38,7 +38,8 @@ export const TrlTechRecordTemplate: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXT,
       validators: [
-        { name: ValidatorNames.MaxLength, args: 4 },
+        { name: ValidatorNames.Max, args: 9999 },
+        { name: ValidatorNames.Numeric},
         { name: ValidatorNames.Required }]
     },
     {

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -39,6 +39,7 @@ export const TrlTechRecordTemplate: FormNode = {
       editType: FormNodeEditTypes.TEXT,
       validators: [
         { name: ValidatorNames.Max, args: 9999 },
+        { name: ValidatorNames.Min, args: 1000 },
         { name: ValidatorNames.Numeric},
         { name: ValidatorNames.Required }]
     },


### PR DESCRIPTION
- manufactureYear now must be a 4 digit number.
- euroStandard now must be selected.

[CB2-6523](https://dvsa.atlassian.net/browse/CB2-6523)
[CB2-6524](https://dvsa.atlassian.net/browse/CB2-6524)

![image](https://user-images.githubusercontent.com/92087051/199057911-e4c1ec85-f2f0-49ee-81fa-d189a04d48e5.png)
![image](https://user-images.githubusercontent.com/92087051/199057968-dc75e321-e81d-4760-ae0c-361454a139cb.png)
![image](https://user-images.githubusercontent.com/92087051/199058112-b2ba039b-b721-4d1a-841d-aac87f276a9b.png)
![image](https://user-images.githubusercontent.com/92087051/199058157-fe39d519-57d7-41a2-8a60-620844cd0e6b.png)


## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
