### PR TITLE
fix(cb2-6509): fix validation on vehicle summary

### DIFF
--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -36,21 +36,12 @@ export const HgvTechRecord: FormNode = {
       value: '',
       width: FormNodeWidth.XS,
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.TEXT,
+      editType: FormNodeEditTypes.NUMBER,
       validators: [
         { name: ValidatorNames.Max, args: 9999 },
         { name: ValidatorNames.Min, args: 1000 },
-        { name: ValidatorNames.Numeric },
         { name: ValidatorNames.Required }
       ]
-    },
-    {
-      name: 'noOfAxles',
-      label: 'Number of axles',
-      value: '',
-      width: FormNodeWidth.XXS,
-      type: FormNodeTypes.CONTROL,
-      validators: [{ name: ValidatorNames.Required }],
     },
     {
       name: 'brakes',
@@ -64,33 +55,22 @@ export const HgvTechRecord: FormNode = {
           value: '',
           width: FormNodeWidth.M,
           type: FormNodeTypes.CONTROL,
-          validators: [{ name: ValidatorNames.Required }],
+          validators: [
+            { name: ValidatorNames.Required },
+            { name: ValidatorNames.MaxLength, args: 6 },
+          ]
         }
       ],
     },
-    // {
-    //   name: 'axles',
-    //   value: '',
-    //   type: FormNodeTypes.ARRAY,
-    //   children: [
-    //     {
-    //       name: '0',
-    //       label: 'Axle',
-    //       value: '',
-    //       type: FormNodeTypes.GROUP,
-    //       children: [
-    //         {
-    //           name: 'parkingBrakeMrk',
-    //           label: 'Axles fitted with a parking brake',
-    //           value: '',
-
-    //           type: FormNodeTypes.CONTROL,
-    //           viewType: FormNodeViewTypes.STRING
-    //         }
-    //       ]
-    //     }
-    //   ]
-    // },
+    {
+      name: 'noOfAxles',
+      label: 'Number of axles',
+      value: '',
+      width: FormNodeWidth.XXS,
+      type: FormNodeTypes.CONTROL,
+      validators: [{ name: ValidatorNames.Required }],
+      disabled: true
+    },
     {
       name: 'speedLimiterMrk',
       label: 'Speed limiter exempt',
@@ -208,7 +188,7 @@ export const HgvTechRecord: FormNode = {
       value: '' || null,
       width: FormNodeWidth.XXS,
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.NUMERICSTRING,
+      editType: FormNodeEditTypes.NUMBER,
       validators: [
         { name: ValidatorNames.Max, args: 99 },
       ]
@@ -223,6 +203,17 @@ export const HgvTechRecord: FormNode = {
         { value: true, label: 'Yes' },
         { value: false, label: 'No' }
       ]
+    },
+    {
+      name: 'alterationMarker',
+      label: 'Alteration marker',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.RADIO,
+      options: [
+        { value: true, label: 'Yes' },
+        { value: false, label: 'No' }
+      ],
     }
   ]
 };

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -37,11 +37,10 @@ export const PsvTechRecord: FormNode = {
       value: '',
       width: FormNodeWidth.XS,
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.TEXT,
+      editType: FormNodeEditTypes.NUMBER,
       validators: [
         { name: ValidatorNames.Max, args: 9999 },
         { name: ValidatorNames.Min, args: 1000 },
-        { name: ValidatorNames.Numeric },
         { name: ValidatorNames.Required }
       ]
     },
@@ -63,7 +62,10 @@ export const PsvTechRecord: FormNode = {
           value: '',
           width: FormNodeWidth.L,
           type: FormNodeTypes.CONTROL,
-          validators: [{ name: ValidatorNames.Required }],
+          validators: [
+            { name: ValidatorNames.Required },
+            { name: ValidatorNames.MaxLength, args: 6 },
+          ],
         }
       ],
       type: FormNodeTypes.GROUP,
@@ -175,7 +177,7 @@ export const PsvTechRecord: FormNode = {
       value: '' || null,
       width: FormNodeWidth.XXS,
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.NUMERICSTRING,
+      editType: FormNodeEditTypes.NUMBER,
       validators: [
         { name: ValidatorNames.Max, args: 99 },
       ]
@@ -258,6 +260,17 @@ export const PsvTechRecord: FormNode = {
         { value: true, label: 'Yes' },
         { value: false, label: 'No' }
       ]
+    },
+    {
+      name: 'alterationMarker',
+      label: 'Alteration marker',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.RADIO,
+      options: [
+        { value: true, label: 'Yes' },
+        { value: false, label: 'No' }
+      ],
     }
   ]
 };

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -36,11 +36,10 @@ export const TrlTechRecordTemplate: FormNode = {
       value: '',
       width: FormNodeWidth.XS,
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.TEXT,
+      editType: FormNodeEditTypes.NUMBER,
       validators: [
         { name: ValidatorNames.Max, args: 9999 },
         { name: ValidatorNames.Min, args: 1000 },
-        { name: ValidatorNames.Numeric},
         { name: ValidatorNames.Required }]
     },
     {
@@ -53,13 +52,6 @@ export const TrlTechRecordTemplate: FormNode = {
       validators: [{ name: ValidatorNames.Required }],
       isoDate: false
     },
-
-    // {
-    //   name: 'noOfAxles',
-    //   label: 'Number of axles',
-    //   value: '',
-    //   type: FormNodeTypes.CONTROL,
-    // },
     {
       name: 'brakes',
       label: 'DTP number',
@@ -71,34 +63,16 @@ export const TrlTechRecordTemplate: FormNode = {
           value: '',
           width: FormNodeWidth.L,
           type: FormNodeTypes.CONTROL,
-          viewType: FormNodeViewTypes.STRING
+          viewType: FormNodeViewTypes.STRING,
+          validators: [
+            { name: ValidatorNames.MaxLength, args: 6 },
+            { name: ValidatorNames.Required }
+          ]
         }
       ],
       type: FormNodeTypes.GROUP,
       viewType: FormNodeViewTypes.STRING
     },
-    // {
-    //   name: 'axles',
-    //   value: '',
-    //   type: FormNodeTypes.ARRAY,
-    //   children: [
-    //     {
-    //       name: '0',
-    //       label: 'Axle',
-    //       value: '',
-    //       type: FormNodeTypes.GROUP,
-    //       children: [
-    //         {
-    //           name: 'parkingBrakeMrk',
-    //           label: 'Axles fitted with a parking brake',
-    //           value: '',
-    //           type: FormNodeTypes.CONTROL,
-    //           viewType: FormNodeViewTypes.STRING
-    //         }
-    //       ]
-    //     }
-    //   ]
-    // },
     {
       name: 'roadFriendly',
       label: 'Road friendly suspension',
@@ -155,6 +129,7 @@ export const TrlTechRecordTemplate: FormNode = {
       value: '',
       width: FormNodeWidth.M,
       type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.NUMBER,
       validators: [{ name: ValidatorNames.MaxLength, args: 5 }],
       class: 'flex--half'
     },
@@ -195,6 +170,17 @@ export const TrlTechRecordTemplate: FormNode = {
       editType: FormNodeEditTypes.SELECT,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
+    },
+    {
+      name: 'alterationMarker',
+      label: 'Alteration marker',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.RADIO,
+      options: [
+        { value: true, label: 'Yes' },
+        { value: false, label: 'No' }
+      ],
     }
   ]
 };


### PR DESCRIPTION
- Provides alterationMarker as an editable field on PSV, HGV and TRL
- Validates dtpNumber to be 6 char string
- Shows numberOfAxles on HGV record but is disabled for editing
- Makes manufactureYear a `number` and not a `string`

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6509)
