### PR TITLE
fix(cb2-6474): fix the reasons for abandoning

### DIFF
--- a/src/app/forms/custom-sections/abandon-dialog/abandon-dialog.component.ts
+++ b/src/app/forms/custom-sections/abandon-dialog/abandon-dialog.component.ts
@@ -53,11 +53,14 @@ const ABANDON_FORM = (ReasonsForAbandoning: ReferenceDataResourceType | SpecialR
   selector: 'app-abandon-dialog',
   templateUrl: './abandon-dialog.component.html'
 })
-export class AbandonDialogComponent extends BaseDialogComponent {
+export class AbandonDialogComponent extends BaseDialogComponent implements OnInit {
   @ViewChild(DynamicFormGroupComponent) dynamicFormGroup?: DynamicFormGroupComponent;
   @Input() testResult?: TestResultModel;
   @Output() newTestResult = new EventEmitter<TestResultModel>();
-  template = this.getTemplate();
+  template?: FormNode;
+  ngOnInit() {
+    this.template = this.getTemplate();
+  }
 
   getTemplate(): FormNode {
     const testTypeId = this.testResult?.testTypes[0].testTypeId ?? '';


### PR DESCRIPTION
## Different Reasons for abandoning per vehicle type

So somewhat forgot/didn't know that the `@Input` decorator runs post-constructor time, meaning the `testResult` was undefined at constructor time, meaning the reasons for abandoning defaulted to the vehicle-specific ones over the specialist/TIR ones.
[CB2-6474](https://dvsa.atlassian.net/browse/CB2-6474)
