### PR TITLE
feat(cb2-6092): hide emissions section

### DIFF
--- a/src/app/forms/models/async-validators.enum.ts
+++ b/src/app/forms/models/async-validators.enum.ts
@@ -5,5 +5,6 @@ export enum AsyncValidatorNames {
   RequiredIfNotFail = 'requiredIfNotfail',
   RequiredIfNotAbandoned = 'requiredIfNotabandoned',
   RequiredIfNotResultAndSiblingEquals = 'requiredIfNotResultAndSiblingEquals',
-  RequiredIfNotResult = 'requiredIfNotResult'
+  RequiredIfNotResult = 'requiredIfNotResult',
+  HideIfEqualsWithCondition = 'hideIfEqualsWithCondition'
 }

--- a/src/app/forms/models/condition.model.ts
+++ b/src/app/forms/models/condition.model.ts
@@ -5,7 +5,6 @@ export enum operatorEnum {
 
 export interface Condition {
   field: string;
-  operator: operatorEnum,
+  operator: operatorEnum;
   value: any;
-  //value: string | number | boolean | string[] | number[] | boolean[];
 }

--- a/src/app/forms/models/condition.model.ts
+++ b/src/app/forms/models/condition.model.ts
@@ -1,0 +1,11 @@
+export enum operatorEnum {
+  Equals = 'equals',
+  NotEquals = 'not equals'
+}
+
+export interface Condition {
+  field: string;
+  operator: operatorEnum,
+  value: any;
+  //value: string | number | boolean | string[] | number[] | boolean[];
+}

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -10,6 +10,7 @@ import { Store } from '@ngrx/store';
 import { AsyncValidatorNames } from '@forms/models/async-validators.enum';
 import { CustomAsyncValidators } from '@forms/validators/custom-async-validators';
 import { State } from '@store/.';
+import { Condition } from '@forms/models/condition.model';
 
 type CustomFormFields = CustomFormControl | CustomFormArray | CustomFormGroup;
 
@@ -55,7 +56,8 @@ export class DynamicFormService {
     [AsyncValidatorNames.RequiredIfNotFail]: () => CustomAsyncValidators.requiredIfNotFail(this.store),
     [AsyncValidatorNames.RequiredIfNotAbandoned]: () => CustomAsyncValidators.requiredIfNotAbandoned(this.store),
     [AsyncValidatorNames.RequiredIfNotResult]: (args: { testResult: any }) => CustomAsyncValidators.requiredIfNotResult(this.store, args.testResult),
-    [AsyncValidatorNames.RequiredIfNotResultAndSiblingEquals]: (args: { testResult: any, sibling: string; value: any }) => CustomAsyncValidators.requiredIfNotResultAndSiblingEquals(this.store, args.testResult, args.sibling, args.value)
+    [AsyncValidatorNames.RequiredIfNotResultAndSiblingEquals]: (args: { testResult: any, sibling: string; value: any }) => CustomAsyncValidators.requiredIfNotResultAndSiblingEquals(this.store, args.testResult, args.sibling, args.value),
+    [AsyncValidatorNames.HideIfEqualsWithCondition]: (args: { sibling: string, value: string; conditions: Condition | Condition[]}) => CustomAsyncValidators.hideIfEqualsWithCondition(this.store, args.sibling, args.value, args.conditions)
   };
 
   createForm(formNode: FormNode, data?: any): CustomFormGroup | CustomFormArray {

--- a/src/app/forms/templates/test-records/section-templates/test/contingency-test-section-specialist-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency-test-section-specialist-group1.template.ts
@@ -49,10 +49,10 @@ export const ContingencyTestSectionSpecialistGroup1: FormNode = {
                 { value: 'pass', label: 'Pass' },
                 { value: 'fail', label: 'Fail' }
               ],
-              asyncValidators: [{ name: AsyncValidatorNames.ResultDependantOnCustomDefects }],
+              asyncValidators: [{ name: AsyncValidatorNames.ResultDependantOnCustomDefects }, { name: AsyncValidatorNames.HideIfEqualsWithCondition, args: { sibling: 'certificateNumber', value: 'fail', conditions: { field: 'testTypeId', operator: 'equals', value: ['150', '151', '181', '182'] }} }],
               type: FormNodeTypes.CONTROL
             },
-            {
+            { 
               name: 'testTypeName',
               label: 'Description',
               value: '',

--- a/src/app/forms/templates/test-records/section-templates/test/specialist-test-section-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/specialist-test-section-group1.template.ts
@@ -58,7 +58,7 @@ export const SpecialistTestSectionGroup1: FormNode = {
                 { name: ValidatorNames.HideIfNotEqual, args: { sibling: 'reasonForAbandoning', value: 'abandoned' } },
                 { name: ValidatorNames.HideIfNotEqual, args: { sibling: 'additionalCommentsForAbandon', value: 'abandoned' } }
               ],
-              asyncValidators: [{ name: AsyncValidatorNames.ResultDependantOnCustomDefects }],
+              asyncValidators: [{ name: AsyncValidatorNames.ResultDependantOnCustomDefects }, { name: AsyncValidatorNames.HideIfEqualsWithCondition, args: { sibling: 'certificateNumber', value: 'fail', conditions: { field: 'testTypeId', operator: 'equals', value: ['150', '151', '181', '182'] }} }],
               type: FormNodeTypes.CONTROL
             },
             {

--- a/src/app/forms/validators/custom-async-validators.spec.ts
+++ b/src/app/forms/validators/custom-async-validators.spec.ts
@@ -13,6 +13,7 @@ import { masterTpl } from '@forms/templates/test-records/master.template';
 import { ValueConverter } from '@angular/compiler/src/render3/view/template';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
 import { TestResultModel } from '@models/test-results/test-result.model';
+import { operatorEnum } from '@forms/models/condition.model';
 
 describe('resultDependantOnCustomDefects', () => {
   let form: FormGroup;
@@ -451,4 +452,84 @@ describe('requiredIfNotResultAndSiblingEquals', () => {
 
 
 
+});
+
+describe('hide if equals with condition', () => {
+  let form: FormGroup;
+  let store: MockStore<State>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideMockStore({ initialState: initialAppState })]
+    });
+
+    store = TestBed.inject(MockStore);
+
+
+    form = new FormGroup({
+      foo: new CustomFormControl({ name: 'foo', type: FormNodeTypes.CONTROL, children: [] }, null),
+      bar: new CustomFormControl({ name: 'bar', type: FormNodeTypes.CONTROL, children: [] }, null)
+    });
+  });
+
+  it('"bar" should be hidden when "foo" is "x" and testTypeId is "1" and validator specifies hideIfEqualsWithCondition for current field equals "x" with the condition that the "testTypeId" field has a value in "1,2,3,4"', async () => {
+    form.controls['foo'].patchValue('x');
+
+    const testResult = { testTypes: [{ testTypeId: '1' }] } as TestResultModel;
+
+    store.overrideSelector(testResultInEdit, testResult);
+
+    await firstValueFrom(CustomAsyncValidators.hideIfEqualsWithCondition(store, 'bar', 'x', { field: 'testTypeId', operator: operatorEnum.Equals, value: ['1', '2', '3', '4'] })(form.controls['foo']) as Observable<ValidationErrors | null>);
+
+    expect((form.controls['bar'] as CustomFormControl).meta.hide).toEqual(true);
+  });
+
+  it('"bar" should not be hidden when "foo" is "x" and testTypeId is "1" and validator specifies hideIfEqualsWithCondition for current field equals "y" with the condition that the "testTypeId" field has a value in "1,2,3,4"', async () => {
+    form.controls['foo'].patchValue('x');
+
+    const testResult = { testTypes: [{ testTypeId: '1' }] } as TestResultModel;
+
+    store.overrideSelector(testResultInEdit, testResult);
+
+    await firstValueFrom(CustomAsyncValidators.hideIfEqualsWithCondition(store, 'bar', 'y', { field: 'testTypeId', operator: operatorEnum.Equals, value: ['1', '2', '3', '4'] })(form.controls['foo']) as Observable<ValidationErrors | null>);
+
+    expect((form.controls['bar'] as CustomFormControl).meta.hide).toEqual(false);
+  });
+
+  it('"bar" should not be hidden when "foo" is "x" and testTypeId is "5" and validator specifies hideIfEqualsWithCondition for current field equals "x" with the condition that the "testTypeId" field has a value in "1,2,3,4"', async () => {
+    form.controls['foo'].patchValue('x');
+
+    const testResult = { testTypes: [{ testTypeId: '5' }] } as TestResultModel;
+
+    store.overrideSelector(testResultInEdit, testResult);
+
+    await firstValueFrom(CustomAsyncValidators.hideIfEqualsWithCondition(store, 'bar', 'x', { field: 'testTypeId', operator: operatorEnum.Equals, value: ['1', '2', '3', '4'] })(form.controls['foo']) as Observable<ValidationErrors | null>);
+
+    expect((form.controls['bar'] as CustomFormControl).meta.hide).toEqual(false);
+  });
+
+  it('"bar" should be hidden when "foo" is "x" and testTypeId is "1" and "odometerReading" is 100 and validator specifies hideIfEqualsWithCondition for current field equals "x" with the condition that the "testTypeId" field has a value in "1,2,3,4" and "odometerReading" is 100', async () => {
+    form.controls['foo'].patchValue('x');
+
+    const testResult = { odometerReading: 100, testTypes: [{ testTypeId: '1' }] } as TestResultModel;
+
+    store.overrideSelector(testResultInEdit, testResult);
+
+    await firstValueFrom(CustomAsyncValidators.hideIfEqualsWithCondition(store, 'bar', 'x', [{ field: 'testTypeId', operator: operatorEnum.Equals, value: ['1', '2', '3', '4'] }, { field: 'odometerReading', operator: operatorEnum.Equals, value: 100 }])(form.controls['foo']) as Observable<ValidationErrors | null>);
+
+    expect((form.controls['bar'] as CustomFormControl).meta.hide).toEqual(true);
+  });
+
+  it('"bar" should not be hidden when "foo" is "x" and testTypeId is "1" and "odometerReading" is 101 and validator specifies hideIfEqualsWithCondition for current field equals "x" with the condition that the "testTypeId" field has a value in "1,2,3,4" and "odometerReading" is 100', async () => {
+    form.controls['foo'].patchValue('x');
+
+    const testResult = { odometerReading: 101, testTypes: [{ testTypeId: '1' }] } as TestResultModel;
+
+    store.overrideSelector(testResultInEdit, testResult);
+
+    await firstValueFrom(CustomAsyncValidators.hideIfEqualsWithCondition(store, 'bar', 'x', [{ field: 'testTypeId', operator: operatorEnum.Equals, value: ['1', '2', '3', '4'] }, { field: 'odometerReading', operator: operatorEnum.Equals, value: 100 }])(form.controls['foo']) as Observable<ValidationErrors | null>);
+
+    expect((form.controls['bar'] as CustomFormControl).meta.hide).toEqual(false);
+  });
+  
 });

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -139,17 +139,17 @@ export class CustomAsyncValidators {
   }
 
   static checkConditions(testResult: TestResultModel, conditions: Condition | Condition[] ){
-    if(Array.isArray(conditions)){
-      let failed: boolean = false;
-
-      conditions.forEach((condition) => {
-        if(!CustomAsyncValidators.checkCondition(testResult, condition)) failed = true;
-      });
-
-      return !failed;
-    }else{
+    if (!Array.isArray(conditions)) {
       return CustomAsyncValidators.checkCondition(testResult, conditions);
     }
+
+    for (const condition of conditions) {
+      if(!CustomAsyncValidators.checkCondition(testResult, condition)) {
+        return false;
+      }
+    }
+    
+    return true;
   }
 
   static checkCondition(testResult: TestResultModel, condition: Condition ){

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -140,7 +140,7 @@ export class CustomAsyncValidators {
       );
   }
 
-  static checkConditions(testResult: TestResultModel, conditions: Condition | Condition[] ){
+  private static checkConditions(testResult: TestResultModel, conditions: Condition | Condition[] ){
     if (!Array.isArray(conditions)) {
       return CustomAsyncValidators.checkCondition(testResult, conditions);
     }
@@ -148,15 +148,15 @@ export class CustomAsyncValidators {
     return conditions.every(condition => CustomAsyncValidators.checkCondition(testResult,condition))
   }
 
-  static checkCondition(testResult: TestResultModel, condition: Condition ){
+  private static checkCondition(testResult: TestResultModel, condition: Condition ){
     const {field, operator, value} = condition
 
     const fieldValue = testResult.testTypes[0].hasOwnProperty(field)
-      ? (testResult?.testTypes[0] as any)[field]
+      ? (testResult.testTypes[0] as any)[field]
       : (testResult as any)[field];
 
     const isTrue = Array.isArray(value) ? value.includes(fieldValue) : fieldValue === value;
 
     return operator === operatorEnum.Equals ? isTrue : !isTrue;
-    }
+  }
 }

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -153,7 +153,7 @@ export class CustomAsyncValidators {
 
     const fieldValue = testResult.testTypes[0].hasOwnProperty(field)
       ? (testResult.testTypes[0] as any)[field]
-      : (testResult as any)[field as keyof TestType];
+      : (testResult as any)[field as keyof TestResultModel];
 
     const isTrue = Array.isArray(value) ? value.includes(fieldValue) : fieldValue === value;
 

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -145,13 +145,7 @@ export class CustomAsyncValidators {
       return CustomAsyncValidators.checkCondition(testResult, conditions);
     }
 
-    for (const condition of conditions) {
-      if(!CustomAsyncValidators.checkCondition(testResult, condition)) {
-        return false;
-      }
-    }
-    
-    return true;
+    return conditions.every(condition => CustomAsyncValidators.checkCondition(testResult,condition))
   }
 
   static checkCondition(testResult: TestResultModel, condition: Condition ){

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -153,7 +153,7 @@ export class CustomAsyncValidators {
 
     const fieldValue = testResult.testTypes[0].hasOwnProperty(field)
       ? (testResult.testTypes[0] as any)[field]
-      : (testResult as any)[field];
+      : (testResult as any)[field as keyof TestType];
 
     const isTrue = Array.isArray(value) ? value.includes(fieldValue) : fieldValue === value;
 

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -153,22 +153,14 @@ export class CustomAsyncValidators {
   }
 
   static checkCondition(testResult: TestResultModel, condition: Condition ){
-
     const {field, operator, value} = condition
 
-    let fieldValue: any;
+    const fieldValue = testResult.testTypes[0].hasOwnProperty(field)
+      ? (testResult?.testTypes[0] as any)[field]
+      : (testResult as any)[field];
 
-    if(testResult?.testTypes[0].hasOwnProperty(field)) {
-      fieldValue = (testResult?.testTypes[0] as any)[field];
-    }else if(testResult?.hasOwnProperty(field)) {
-      fieldValue = (testResult as any)[field];
-    }
+    const isTrue = Array.isArray(value) ? value.includes(fieldValue) : fieldValue === value;
 
-    if(operator === operatorEnum.Equals){
-        return Array.isArray(value) ? value.includes(fieldValue) : fieldValue === value
-      }else if(operator === operatorEnum.NotEquals){
-        return Array.isArray(value) ? !value.includes(fieldValue) : fieldValue !== value
-      }
-      return false;
+    return operator === operatorEnum.Equals ? isTrue : !isTrue;
     }
 }

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -134,6 +134,8 @@ export class CustomAsyncValidators {
           const conditionsPassed = CustomAsyncValidators.checkConditions(testResult, conditions);
 
           siblingControl.meta.hide = conditionsPassed && (Array.isArray(value) ? value.includes(control.value) : control.value === value);
+
+          return null;
         })
       );
   }

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -127,17 +127,13 @@ export class CustomAsyncValidators {
         take(1),
         select(testResultInEdit),
         map(testResult => {
+          if (!testResult || !control?.parent) { return null; }
 
-          if(testResult){
-            const conditionsPassed = CustomAsyncValidators.checkConditions(testResult, conditions);
+          const siblingControl = control.parent.get(sibling) as CustomFormControl;
 
-            if (control?.parent) {
-              const siblingControl = control.parent.get(sibling) as CustomFormControl;
-              siblingControl.meta.hide = Array.isArray(value) ? (conditionsPassed && value.includes(control.value)) : (conditionsPassed && control.value === value);
-            }
-          }
+          const conditionsPassed = CustomAsyncValidators.checkConditions(testResult, conditions);
 
-          return null;
+          siblingControl.meta.hide = conditionsPassed && (Array.isArray(value) ? value.includes(control.value) : control.value === value);
         })
       );
   }

--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -11,9 +11,7 @@ import { State } from '@store/.';
 import { selectUserByResourceKey } from '@store/reference-data';
 import { testResultInEdit } from '@store/test-records';
 import { getTestStationFromProperty } from '@store/test-stations';
-import { cond } from 'lodash';
 import { catchError, map, Observable, of, take, tap } from 'rxjs';
-import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
 
 export class CustomAsyncValidators {
   static resultDependantOnCustomDefects(store: Store<State>): AsyncValidatorFn {


### PR DESCRIPTION
## Hide emissions section and certificate number - new validator

New custom validator to allow the certificate number for Specialist testTypeIds 150, 151, 181, 182 to be hidden - these testTypeIds are part of Specialist Test Group 1 but the certificate field needs to be displayed for the rest of the testTypeIds in Group 1.

[https://dvsa.atlassian.net/browse/CB2-6092]

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
