### PR TITLE
fix(cb2-6248): set optional booleans to undefined as default

### DIFF
--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -187,7 +187,7 @@ export const HgvTechRecord: FormNode = {
     {
       name: 'departmentalVehicleMarker',
       label: 'Departmental vehicle marker',
-      value: '',
+      value: undefined,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
       options: [
@@ -198,7 +198,7 @@ export const HgvTechRecord: FormNode = {
     {
       name: 'alterationMarker',
       label: 'Alteration marker',
-      value: '',
+      value: undefined,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
       options: [

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -237,7 +237,18 @@ export function getPsvTechRecord(dtpNumbersFromRefData: FormNodeOption<string>[]
       {
         name: 'departmentalVehicleMarker',
         label: 'Departmental vehicle marker',
-        value: '',
+        value: undefined,
+        type: FormNodeTypes.CONTROL,
+        editType: FormNodeEditTypes.RADIO,
+        options: [
+          { value: true, label: 'Yes' },
+          { value: false, label: 'No' }
+        ]
+      },
+      {
+        name: 'alterationMarker',
+        label: 'Alteration marker',
+        value: undefined,
         type: FormNodeTypes.CONTROL,
         editType: FormNodeEditTypes.RADIO,
         options: [

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -148,7 +148,7 @@ export const TrlTechRecordTemplate: FormNode = {
     {
       name: 'departmentalVehicleMarker',
       label: 'Departmental vehicle marker',
-      value: '',
+      value: undefined,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
       options: [
@@ -168,7 +168,7 @@ export const TrlTechRecordTemplate: FormNode = {
     {
       name: 'alterationMarker',
       label: 'Alteration marker',
-      value: '',
+      value: undefined,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
       options: [


### PR DESCRIPTION
- `alterationMarker` and `departmentalVehicleMaker` are optional `boolean` fields, if an option for them is not selected for them via the radio button input, then their value should be set to `undefined` and not `''` as the backend is expecting a `boolean` value if either of these attributes are defined.
- `alterationMarker` was missing from PSV and has now been added

Before:
![image](https://user-images.githubusercontent.com/92087051/200304461-d541e8b5-060c-4039-a870-e20af160c7b7.png)

After:
![image](https://user-images.githubusercontent.com/92087051/200304382-d62be0b3-d653-4443-956b-f1f53ccf614b.png)
