### PR TITLE
fix(cb2-6642): check the right weights property

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -141,7 +141,7 @@ export class TechRecordSummaryComponent implements OnInit {
       this.setBodyFields();
     }
 
-    if (event.weights) {
+    if (event.grossKerbWeight || event.grossLadenWeight) {
       this.setBrakesForces();
     }
 
@@ -191,14 +191,14 @@ export class TechRecordSummaryComponent implements OnInit {
     this.vehicleTechRecordCalculated.brakes = {
       ...this.vehicleTechRecordCalculated.brakes,
       brakeForceWheelsNotLocked: {
-        parkingBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 16) / 100),
+        serviceBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 16) / 100),
         secondaryBrakeForceA: Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 22.5) / 100),
-        serviceBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 45) / 100)
+        parkingBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 45) / 100),
       },
       brakeForceWheelsUpToHalfLocked: {
-        parkingBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 16) / 100),
+        serviceBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 16) / 100),
         secondaryBrakeForceB: Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 25) / 100),
-        serviceBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 50) / 100)
+        parkingBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 50) / 100),
       }
     };
   }

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -193,12 +193,12 @@ export class TechRecordSummaryComponent implements OnInit {
       brakeForceWheelsNotLocked: {
         serviceBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 16) / 100),
         secondaryBrakeForceA: Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 22.5) / 100),
-        parkingBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 45) / 100),
+        parkingBrakeForceA:   Math.round(((this.vehicleTechRecord.grossLadenWeight || 0) * 45) / 100)
       },
       brakeForceWheelsUpToHalfLocked: {
         serviceBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 16) / 100),
         secondaryBrakeForceB: Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 25) / 100),
-        parkingBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 50) / 100),
+        parkingBrakeForceB:   Math.round(((this.vehicleTechRecord.grossKerbWeight || 0) * 50) / 100)
       }
     };
   }


### PR DESCRIPTION
## Can't save new values of Brakes due to previously displayed section locked and half locked values

It turns out that the form event coming from the weights section is not encapsulated by `weights` object like the other sections. This is a quick fix to address that.

[CB2-6642](https://dvsa.atlassian.net/browse/CB2-6642)