### PR TITLE
fix(cb2-6650): fix error message not staying visible on brake code

### DIFF
--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
@@ -40,7 +40,7 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
         debounceTime(400),
         takeUntil(this.destroy$),
         mergeMap((event: any) =>
-          event?.brakes?.brakeCodeOriginal ? this.referenceDataStore.select(selectBrakeByCode(event.brakes.brakeCodeOriginal)) : of()
+          event?.brakes?.brakeCodeOriginal ? this.referenceDataStore.select(selectBrakeByCode(event.brakes.brakeCodeOriginal)) : of(undefined)
         ),
         withLatestFrom(this.form.cleanValueChanges)
       )


### PR DESCRIPTION
## Brake code mandatory check gets reset if we change Gross weight values

Brake code mandatory check gets reset if we change Gross weight values
[Brake code mandatory check gets reset if we change Gross weight values](6650)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
