### PR TITLE
feat(cb2-5694): separate the psv type approval section into its own template

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -11,14 +11,13 @@ import { PsvBrakesTemplate } from '@forms/templates/psv/psv-brakes.template';
 import { TrlTechRecordTemplate } from '@forms/templates/trl/trl-tech-record.template';
 import { Axle, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { DocumentsTemplate } from '@forms/templates/general/documents.template';
-import { getTypeApprovalSection } from '@forms/templates/general/approval-type.template';
 import { NotesTemplate } from '@forms/templates/general/notes.template';
 import { ManufacturerTemplate } from '@forms/templates/general/manufacturer.template';
 import { PlatesTemplate } from '@forms/templates/general/plates.template';
 import { PsvBodyTemplate } from '@forms/templates/psv/psv-body.template';
 import { PsvDdaTemplate } from '@forms/templates/psv/psv-dda.template';
 import { PsvNotes } from '@forms/templates/psv/psv-notes.template';
-import { PsvWeight } from '@forms/templates/psv/psv-weight.template';
+import { PsvWeightsTemplate } from '@forms/templates/psv/psv-weight.template';
 import { getPsvTechRecord } from '@forms/templates/psv/psv-tech-record.template';
 import { reasonForCreationSection } from '@forms/templates/general/resonForCreation.template';
 import { Store } from '@ngrx/store';
@@ -33,7 +32,7 @@ import { updateEditingTechRecord } from '@store/technical-records';
 import { TrlBrakesComponent } from '@forms/custom-sections/trl-brakes/trl-brakes.component';
 import { PsvBrakesComponent } from '@forms/custom-sections/psv-brakes/psv-brakes.component';
 import { tyresTemplateHgv } from '@forms/templates/hgv/hgv-tyres.template';
-import { tyresTemplatePsv } from '@forms/templates/psv/psv-tyres.template';
+import { PsvTyresTemplate } from '@forms/templates/psv/psv-tyres.template';
 import { tyresTemplateTrl } from '@forms/templates/trl/trl-tyres.template';
 import { PsvDimensionsTemplate } from '@forms/templates/psv/psv-dimensions.template';
 import { HgvDimensionsTemplate } from '@forms/templates/hgv/hgv-dimensions.template';
@@ -45,6 +44,8 @@ import { ReferenceDataState, selectAllReferenceDataByResourceType, selectReferen
 import { Observable } from 'rxjs';
 import { HgvAndTrlBodyTemplate } from '@forms/templates/general/hgv-trl-body.template';
 import { HgvWeight } from '@forms/templates/hgv/hgv-weight.template';
+import { PsvTypeApprovalTemplate } from '@forms/templates/psv/psv-approval-type.template';
+import { HgvAndTrlTypeApprovalTemplate } from '@forms/templates/general/approval-type.template';
 
 @Component({
   selector: 'app-tech-record-summary',
@@ -219,13 +220,13 @@ export class TechRecordSummaryComponent implements OnInit {
       /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ PsvNotes,
       /*  3 */ getPsvTechRecord(this.dtpNumbersFromRefData),
-      /*  4 */ getTypeApprovalSection(VehicleTypes.PSV),
+      /*  4 */ PsvTypeApprovalTemplate,
       /*  5 */ PsvBrakesTemplate,
       /*  6 */ PsvDdaTemplate,
       /*  7 */ DocumentsTemplate,
       /*  8 */ PsvBodyTemplate,
-      /*  9 */ PsvWeight,
-      /* 10 */ tyresTemplatePsv,
+      /*  9 */ PsvWeightsTemplate,
+      /* 10 */ PsvTyresTemplate,
       /* 11 */ PsvDimensionsTemplate
     ];
   }
@@ -235,7 +236,7 @@ export class TechRecordSummaryComponent implements OnInit {
       /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ NotesTemplate,
       /*  3 */ HgvTechRecord,
-      /*  4 */ getTypeApprovalSection(VehicleTypes.HGV),
+      /*  4 */ HgvAndTrlTypeApprovalTemplate,
       /*  5 */ ApplicantDetails,
       /*  6 */ DocumentsTemplate,
       /*  7 */ HgvAndTrlBodyTemplate,
@@ -251,7 +252,7 @@ export class TechRecordSummaryComponent implements OnInit {
       /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ NotesTemplate,
       /*  3 */ TrlTechRecordTemplate,
-      /*  4 */ getTypeApprovalSection(VehicleTypes.TRL),
+      /*  4 */ HgvAndTrlTypeApprovalTemplate,
       /*  5 */ ApplicantDetails,
       /*  6 */ DocumentsTemplate,
       /*  7 */ HgvAndTrlBodyTemplate,

--- a/src/app/forms/custom-sections/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.ts
@@ -3,7 +3,7 @@ import { MultiOptions } from '@forms/models/options.model';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode, FormNodeEditTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { tyresTemplateHgv } from '@forms/templates/hgv/hgv-tyres.template';
-import { tyresTemplatePsv } from '@forms/templates/psv/psv-tyres.template';
+import { PsvTyresTemplate } from '@forms/templates/psv/psv-tyres.template';
 import { tyresTemplateTrl } from '@forms/templates/trl/trl-tyres.template';
 import { getOptionsFromEnum, getOptionsFromEnumOneChar } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType, ReferenceDataTyre } from '@models/reference-data.model';
@@ -51,7 +51,7 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
   get template(): FormNode {
     switch (this.vehicleTechRecord.vehicleType) {
       case VehicleTypes.PSV:
-        return tyresTemplatePsv;
+        return PsvTyresTemplate;
       case VehicleTypes.HGV:
         return tyresTemplateHgv;
       case VehicleTypes.TRL:

--- a/src/app/forms/custom-sections/weights/weights.component.ts
+++ b/src/app/forms/custom-sections/weights/weights.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } 
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode, FormNodeEditTypes } from '@forms/services/dynamic-form.types';
 import { HgvWeight } from '@forms/templates/hgv/hgv-weight.template';
-import { PsvWeight } from '@forms/templates/psv/psv-weight.template';
+import { PsvWeightsTemplate } from '@forms/templates/psv/psv-weight.template';
 import { TrlWeight } from '@forms/templates/trl/trl-weight.template';
 import { Axle, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { debounceTime, Subscription } from 'rxjs';
@@ -41,7 +41,7 @@ export class WeightsComponent implements OnInit, OnDestroy, OnChanges {
   get template(): FormNode {
     switch (this.vehicleTechRecord.vehicleType) {
       case VehicleTypes.PSV:
-        return PsvWeight;
+        return PsvWeightsTemplate;
       case VehicleTypes.HGV:
         return HgvWeight;
       case VehicleTypes.TRL:

--- a/src/app/forms/templates/psv/psv-approval-type.template.ts
+++ b/src/app/forms/templates/psv/psv-approval-type.template.ts
@@ -1,9 +1,9 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { approvalType } from '@models/vehicle-tech-record.model';
-import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeWidth } from '../../services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '../../services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 
-export const HgvAndTrlTypeApprovalTemplate: FormNode = {
+export const PsvTypeApprovalTemplate: FormNode = {
   name: 'approvalSection',
   label: 'Type approval',
   type: FormNodeTypes.GROUP,
@@ -27,8 +27,30 @@ export const HgvAndTrlTypeApprovalTemplate: FormNode = {
       name: 'ntaNumber',
       label: 'National type number',
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XXL,
+      width: FormNodeWidth.XL,
       validators: [{ name: ValidatorNames.MaxLength, args: 40 }]
+    },
+    {
+      name: 'coifSerialNumber',
+      label: 'COIF Serial number',
+      type: FormNodeTypes.CONTROL,
+      width: FormNodeWidth.M,
+      validators: [{ name: ValidatorNames.MaxLength, args: 8 }]
+    },
+    {
+      name: 'coifCertifierName',
+      label: 'COIF Certifier name',
+      type: FormNodeTypes.CONTROL,
+      width: FormNodeWidth.XL,
+      validators: [{ name: ValidatorNames.MaxLength, args: 20 }]
+    },
+    {
+      name: 'coifDate',
+      label: 'COIF Certifier date',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.DATE,
+      editType: FormNodeEditTypes.DATE,
+      isoDate: false
     },
     {
       name: 'variantNumber',
@@ -41,7 +63,7 @@ export const HgvAndTrlTypeApprovalTemplate: FormNode = {
       name: 'variantVersionNumber',
       label: 'Variant version number',
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XXL,
+      width: FormNodeWidth.XL,
       validators: [{ name: ValidatorNames.MaxLength, args: 35 }]
     }
   ]

--- a/src/app/forms/templates/psv/psv-tyres.template.ts
+++ b/src/app/forms/templates/psv/psv-tyres.template.ts
@@ -1,7 +1,7 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes } from '@forms/services/dynamic-form.types';
 
-export const tyresTemplatePsv: FormNode = {
+export const PsvTyresTemplate: FormNode = {
   name: 'tyreSection',
   type: FormNodeTypes.GROUP,
   label: 'Tyres',

--- a/src/app/forms/templates/psv/psv-weight.template.ts
+++ b/src/app/forms/templates/psv/psv-weight.template.ts
@@ -14,7 +14,7 @@ const optionalValidation = [
   { name: ValidatorNames.Min, args: 0 }
 ];
 
-export const PsvWeight: FormNode = {
+export const PsvWeightsTemplate: FormNode = {
   name: 'weightsSection',
   label: 'Weights',
   type: FormNodeTypes.GROUP,

--- a/src/mocks/psv-record.mock.ts
+++ b/src/mocks/psv-record.mock.ts
@@ -416,7 +416,7 @@ const currentTechRecord = {
   ntaNumber: 'nta789',
   coifSerialNumber: 'coifSerial123456',
   coifCertifierName: 'coifName',
-  coifDate: new Date(),
+  coifDate: '1233-12-31',
   variantNumber: 'variant123456',
   variantVersionNumber: 'variantversion123456',
   applicantDetails: {


### PR DESCRIPTION
## Amend PSV Type Approval section for provisional record

- Separate the templates and update their validation rules.

[CB2-5694](https://dvsa.atlassian.net/browse/CB2-5694)