### PR TITLE
fix(cb2-6661): adding defect to new test result returns back to technical record

### DIFF
--- a/src/app/forms/custom-sections/abandon-dialog/abandon-dialog.component.spec.ts
+++ b/src/app/forms/custom-sections/abandon-dialog/abandon-dialog.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { SPECIALIST_TEST_TYPE_IDS, TEST_TYPES_GROUP5_13 } from '@forms/models/testTypeId.enum';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
@@ -18,7 +19,7 @@ describe('AbandonDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AbandonDialogComponent],
-      imports: [DynamicFormsModule, SharedModule],
+      imports: [DynamicFormsModule, SharedModule, RouterTestingModule],
       providers: [provideMockStore({ initialState: initialAppState }), DynamicFormService]
     }).compileComponents();
   });

--- a/src/app/shared/components/button/button.component.html
+++ b/src/app/shared/components/button/button.component.html
@@ -5,7 +5,6 @@
     class="govuk-button"
     data-module="govuk-button"
     draggable="false"
-    [routerLink]="routerLink"
     [id]="id"
     [ngClass]="design ? 'govuk-button--' + design : ''"
   >

--- a/src/app/shared/components/button/button.component.spec.ts
+++ b/src/app/shared/components/button/button.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ButtonComponent } from './button.component';
 
 describe('ButtonComponent', () => {
@@ -7,7 +8,8 @@ describe('ButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ButtonComponent]
+      declarations: [ButtonComponent],
+      imports: [RouterTestingModule]
     }).compileComponents();
   });
 

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-button',
@@ -6,12 +7,11 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
   styleUrls: ['./button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ButtonComponent {
+export class ButtonComponent extends RouterLink {
   @Input() id?: string;
   @Input() disabled = false;
   @Input() type: 'link' | 'button' = 'button';
   @Input() design: '' | 'secondary' | 'warning' | 'link' = '';
-  @Input() routerLink = [''];
 
   @Output() clicked = new EventEmitter();
 }


### PR DESCRIPTION
## BUG: Adding a Defect to a new Test Result returns the user to the Tech Record

_Button component was not handling router link directives properly._

Fixed by extending RouterLink from component to allow the use of all RouterLink features.
[CB2-6661](https://dvsa.atlassian.net/browse/CB2-6661)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
