### PR TITLE
fix(cb2-6683): fix amending provisional record

### DIFF
--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -143,9 +143,16 @@ export class TechnicalRecordService {
       select(selectRouteNestedParams),
       map(params => {
         const createdAt = params['techCreatedAt'];
-        const isProvisional = this.router.url.split('/').pop() === 'provisional';
+        const lastTwoUrlParts = this.router.url.split('/').slice(-2)
 
-        if (isProvisional) {
+        function isProvisional() {
+          if (lastTwoUrlParts.includes('provisional')) {
+            return true
+          }
+          return false;
+        }
+
+        if (isProvisional()) {
           return vehicleRecord.techRecord.find(record => record.statusCode === StatusCodes.PROVISIONAL)
         }
 

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -144,8 +144,7 @@ export class TechnicalRecordService {
       map(params => {
         const createdAt = params['techCreatedAt'];
         const lastTwoUrlParts = this.router.url.split('/').slice(-2)
-
-       const isProvisional = () => lastTwoUrlParts.includes('provisional');
+        const isProvisional = () => lastTwoUrlParts.includes('provisional');
 
         if (isProvisional()) {
           return vehicleRecord.techRecord.find(record => record.statusCode === StatusCodes.PROVISIONAL)

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -145,12 +145,7 @@ export class TechnicalRecordService {
         const createdAt = params['techCreatedAt'];
         const lastTwoUrlParts = this.router.url.split('/').slice(-2)
 
-        function isProvisional() {
-          if (lastTwoUrlParts.includes('provisional')) {
-            return true
-          }
-          return false;
-        }
+       const isProvisional = () => lastTwoUrlParts.includes('provisional');
 
         if (isProvisional()) {
           return vehicleRecord.techRecord.find(record => record.statusCode === StatusCodes.PROVISIONAL)


### PR DESCRIPTION
Previously going to amend a provisional record caused for the record being amended to be the current record. 

This was an issue with the way the `viewableTechRecord` was being populated which is what populates the `editingTechRecord` state value. Now if `'provisional'` is contained within the last 2 parts of the URL, the provisional record will be selected from state.

Before;
![image](https://user-images.githubusercontent.com/92087051/201386115-262dd389-04e3-4b91-bc8d-0588547fb4b8.png)

After:
![image](https://user-images.githubusercontent.com/92087051/201385932-a8ca5f01-43a5-4d24-b518-99b47b621b7b.png)

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6683)

