### PR TITLE
fix(CB2-5695): Amend PSV Vehicle Summary section for provisional record

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -236,7 +236,7 @@ export class TechRecordSummaryComponent implements OnInit {
     return [
       /*  1 */ // reasonForCreationSection added when editing
       /*  2 */ PsvNotes,
-      /*  3 */ getPsvTechRecord(this.dtpNumbersFromRefData),
+      /*  3 */ getPsvTechRecord(this.dtpNumbersFromRefData, this._isEditing),
       /*  4 */ PsvTypeApprovalTemplate,
       /*  5 */ PsvBrakesTemplate,
       /*  6 */ PsvDdaTemplate,

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.scss
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.scss
@@ -18,14 +18,14 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  column-gap: 1rem;
+  column-gap: 2rem;
 
   & > * {
-    min-width: 250px;
+    min-width: 150px;
     flex-basis: 100%;
   }
 
   &--half {
-    flex-basis: calc(50% - 1rem) !important;
+    flex-basis: content !important;
   }
 }

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -7,7 +7,7 @@ import { EuVehicleCategories, FuelTypes } from '@models/vehicle-tech-record.mode
 import { VehicleSize } from '@models/vehicle-size.enum';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 
-export function getPsvTechRecord(dtpNumbersFromRefData: FormNodeOption<string>[]): FormNode {
+export function getPsvTechRecord(dtpNumbersFromRefData: FormNodeOption<string>[], _isEditing: boolean): FormNode {
   const PsvTechRecord: FormNode = {
     name: 'techRecordSummary',
     type: FormNodeTypes.GROUP,
@@ -149,12 +149,12 @@ export function getPsvTechRecord(dtpNumbersFromRefData: FormNodeOption<string>[]
         editType: FormNodeEditTypes.NUMBER,
         validators: [{ name: ValidatorNames.Max, args: 99 }]
       },
-      { name: 'seatsTitle', label: 'Seats:', type: FormNodeTypes.TITLE },
+      { name: 'seatsTitle', label: `${_isEditing ? 'Seats:' : ''}`, type: FormNodeTypes.TITLE },
       {
         name: 'seatsUpperDeck',
-        label: `Upper deck`,
+        label: `${_isEditing ? 'Upper deck' : 'Seats upper deck'}`,
         value: '',
-        width: FormNodeWidth.XS,
+        width: FormNodeWidth.M,
         type: FormNodeTypes.CONTROL,
         editType: FormNodeEditTypes.NUMBER,
         validators: [{ name: ValidatorNames.Max, args: 99 }, { name: ValidatorNames.Required }],
@@ -162,9 +162,9 @@ export function getPsvTechRecord(dtpNumbersFromRefData: FormNodeOption<string>[]
       },
       {
         name: 'seatsLowerDeck',
-        label: 'Lower deck',
+        label: `${_isEditing ? 'Lower Deck' : 'Seats lower deck'}`,
         value: '',
-        width: FormNodeWidth.XS,
+        width: FormNodeWidth.M,
         type: FormNodeTypes.CONTROL,
         editType: FormNodeEditTypes.NUMBER,
         validators: [{ name: ValidatorNames.Max, args: 999 }, { name: ValidatorNames.Required }],


### PR DESCRIPTION
Amend PSV Vehicle Summary section for provisional record

When this ticket originally went through, I didn't have the Figma for non-edit mode. 
This fix is purely aesthetic: https://www.figma.com/file/rnPv9njRc4UkFjjoJRYceO/Working-Draft_VTM?node-id=20604%3A50891&t=KkWZciaeSIDk2WeL-0

[Original Ticket](https://dvsa.atlassian.net/browse/CB2-5695)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
