### PR TITLE
fix(cb2-6768): add noOfAxles to psv and trl

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -163,6 +163,7 @@ export class TechRecordSummaryComponent implements OnInit {
       this.setBrakesForces();
     }
 
+    this.vehicleTechRecordCalculated.noOfAxles = this.vehicleTechRecordCalculated.axles.length ?? 0;
     this.store.dispatch(updateEditingTechRecord({ techRecord: this.vehicleTechRecordCalculated }));
     this.formChange.emit();
   }

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -60,6 +60,15 @@ export function getPsvTechRecord(dtpNumbersFromRefData: FormNodeOption<string>[]
         type: FormNodeTypes.GROUP
       },
       {
+        name: 'noOfAxles',
+        label: 'Number of axles',
+        value: '',
+        width: FormNodeWidth.XXS,
+        type: FormNodeTypes.CONTROL,
+        validators: [{ name: ValidatorNames.Required }],
+        disabled: true
+      },
+      {
         name: 'speedLimiterMrk',
         label: 'Speed limiter exempt',
         value: '',

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -68,6 +68,15 @@ export const TrlTechRecordTemplate: FormNode = {
       viewType: FormNodeViewTypes.STRING
     },
     {
+      name: 'noOfAxles',
+      label: 'Number of axles',
+      value: '',
+      width: FormNodeWidth.XXS,
+      type: FormNodeTypes.CONTROL,
+      validators: [{ name: ValidatorNames.Required }],
+      disabled: true
+    },
+    {
       name: 'roadFriendly',
       label: 'Road friendly suspension',
       value: '',


### PR DESCRIPTION
## Ticket title
Adds number of axles field to vehicle summary pages of PSV and TRL and fixes issue where noOfAxles wasn't being updated when an additional axle was added...

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6768)
