### PR TITLE
fix(cb2-6815): repair reason for creation

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -142,7 +142,7 @@ export class TechRecordSummaryComponent implements OnInit {
           .subscribe(data => {
             this.vehicleTechRecordCalculated = data;
           })
-      : (this.vehicleTechRecordCalculated = this.vehicleTechRecord);
+      : (this.vehicleTechRecordCalculated = { ...this.vehicleTechRecord, reasonForCreation: '' });
     this.store.dispatch(updateEditingTechRecord({ techRecord: this.vehicleTechRecordCalculated }));
   }
 


### PR DESCRIPTION
## Reason for creation gets pre-populated when create a new provisional record from current record

Reason for creation wasn't being cleared when you enter/exit amend mode.
[https://dvsa.atlassian.net/browse/CB2-6815](6815)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
