### PR TITLE
bug(CB2-681): Tyre search criteria gets cleared after search result displayed

### DIFF
--- a/src/app/forms/custom-sections/body/body.component.html
+++ b/src/app/forms/custom-sections/body/body.component.html
@@ -26,14 +26,13 @@
       [width]="widths.L"
     ></app-switchable-input>
   </div>
-
   <app-switchable-input
     [form]="bodyTypeForm"
     [type]="editTypes.TEXT"
     name="description"
     label="Body type"
     [isEditing]="isEditing"
-    [options]="bodyTypes"
+    [options]="bodyTypeOptions"
     [width]="widths.L"
   ></app-switchable-input>
 </ng-container>
@@ -67,7 +66,7 @@
     name="description"
     label="Body type"
     [isEditing]="isEditing"
-    [options]="bodyTypes"
+    [options]="bodyTypeOptions"
     [width]="widths.L"
   ></app-switchable-input>
 </ng-container>
@@ -78,8 +77,11 @@
   name="functionCode"
   label="Function code"
   [isEditing]="isEditing"
-  [options]="numberOptions"
-  [width]="widths.XXS"
+  [options]="[
+    { value: 'R', label: 'R' },
+    { value: 'A', label: 'A' }
+  ]"
+  [width]="widths.XS"
 ></app-switchable-input>
 
 <app-switchable-input

--- a/src/app/forms/custom-sections/body/body.component.ts
+++ b/src/app/forms/custom-sections/body/body.component.ts
@@ -7,7 +7,7 @@ import { MultiOptionsService } from '@forms/services/multi-options.service';
 import { HgvAndTrlBodyTemplate } from '@forms/templates/general/hgv-trl-body.template';
 import { PsvBodyTemplate } from '@forms/templates/psv/psv-body.template';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
-import { BodyTypeDescription, bodyTypeMap } from '@models/body-type-enum';
+import { BodyTypeCode, BodyTypeDescription, bodyTypeMap } from '@models/body-type-enum';
 import { BodyModel, ReferenceDataResourceType } from '@models/reference-data.model';
 import { BodyType, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
@@ -19,7 +19,7 @@ import { Subject, debounceTime, takeUntil, Observable, map } from 'rxjs';
   templateUrl: './body.component.html',
   styleUrls: ['./body.component.scss']
 })
-export class BodyComponent implements OnInit, OnChanges, OnDestroy {
+export class BodyComponent implements OnInit, OnDestroy {
   @Input() vehicleTechRecord!: TechRecordModel;
   @Input() isEditing = false;
 
@@ -27,6 +27,7 @@ export class BodyComponent implements OnInit, OnChanges, OnDestroy {
 
   form!: CustomFormGroup;
   template!: FormNode;
+  bodyTypeOptions: MultiOptions = getOptionsFromEnum(BodyTypeDescription);
 
   private destroy$ = new Subject<void>();
 
@@ -44,20 +45,11 @@ export class BodyComponent implements OnInit, OnChanges, OnDestroy {
       if (bodyType?.description) {
         event.bodyType['code'] = bodyTypeMap.get(bodyType.description);
       }
-
       this.formChange.emit(event);
     });
 
     this.optionsService.loadOptions(ReferenceDataResourceType.BodyMake);
     this.optionsService.loadOptions(ReferenceDataResourceType.BodyModel);
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    const { vehicleTechRecord } = changes;
-
-    if (this.form && vehicleTechRecord?.currentValue && vehicleTechRecord.currentValue !== vehicleTechRecord.previousValue) {
-      this.form.patchValue(vehicleTechRecord.currentValue, { emitEvent: false });
-    }
   }
 
   ngOnDestroy(): void {
@@ -71,14 +63,6 @@ export class BodyComponent implements OnInit, OnChanges, OnDestroy {
 
   get widths(): typeof FormNodeWidth {
     return FormNodeWidth;
-  }
-
-  get numberOptions(): MultiOptions {
-    return Array.from(Array(10).keys()).map(i => ({ value: i, label: `${i}` }));
-  }
-
-  get bodyTypes(): MultiOptions {
-    return getOptionsFromEnum(BodyTypeDescription);
   }
 
   get bodyMakes$(): Observable<MultiOptions | undefined> {


### PR DESCRIPTION
Tyre search criteria gets cleared after search result displayed

Corrected function code options (A for artic, R for rigid as in data reqs) and removed duplicate form patch function that was interfering with options binding (the if statement was double patching and clearing out the field, it now auto fills as expected)

[[link to ticket number]()](https://dvsa.atlassian.net/browse/CB2-6814)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
