### PR TITLE
fix(cb2-6768): change the route to not break in amend mode

### DIFF
--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
@@ -48,7 +48,7 @@
     <dd class="govuk-summary-list__value"></dd>
     <div *appRoleRequired="roles.TechRecordArchive">
       <dd *ngIf="queryableRecordActions.includes('archive')" class="govuk-summary-list__actions">
-        <a class="govuk-link" routerLink="archive">Archive</a>
+        <a class="govuk-link" style="cursor: pointer" (click)="navigateToArchive()">Archive</a>
       </dd>
     </div>
     <dd *ngIf="queryableRecordActions.includes('promote')" class="govuk-summary-list__actions">

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
@@ -44,4 +44,8 @@ export class TechRecordTitleComponent implements OnInit {
   navigateToPromotion(): void {
     this.router.navigateByUrl(`/tech-records/${this.vehicleTechRecord?.systemNumber}/${this.vehicleTechRecord?.vin}/provisional/promote`);
   }
+
+  navigateToArchive(): void {
+    this.router.navigateByUrl(`/tech-records/${this.vehicleTechRecord?.systemNumber}/${this.vehicleTechRecord?.vin}/archive`);
+  }
 }


### PR DESCRIPTION
## Archiving/Promoting link breaks when you are in amend mode.

The routing in amend mode was broken.
[https://dvsa.atlassian.net/browse/CB2-6824](6824)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
