### PR TITLE
fix(CB2-6814): Tyre search criteria gets cleared after search result displayed

### DIFF
--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -1,8 +1,8 @@
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
 <header class="govuk-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-grid-row govuk-!-margin-bottom-2">
+  <div class="govuk-header__container">
+    <div class="govuk-grid-row govuk-!-margin-bottom-2 govuk-width-container">
       <div class="govuk-grid-column-one-half">
         <a href="/" class="govuk-header__link govuk-header__link--homepage">Vehicle testing management</a>
       </div>

--- a/src/app/features/tech-record/components/tyres-search/tyres-search.component.html
+++ b/src/app/features/tech-record/components/tyres-search/tyres-search.component.html
@@ -25,15 +25,15 @@
   <app-select
     #searchFilter
     label="Search filter"
-    [formControlName]="form.meta.children![1].name"
-    [name]="form.meta.children![1].name"
+    [formControlName]="form.meta.children![0].name"
+    [name]="form.meta.children![0].name"
     [options]="options!"
   ></app-select>
   <br />
   <input
     #searchTerm
-    [formControlName]="form.meta.children![0].name"
-    [name]="form.meta.children![0].name"
+    [formControlName]="form.meta.children![1].name"
+    [name]="form.meta.children![1].name"
     aria-describedby="term"
     type="text"
     class="govuk-input govuk-!-width-two-thirds"

--- a/src/app/features/tech-record/components/tyres-search/tyres-search.component.html
+++ b/src/app/features/tech-record/components/tyres-search/tyres-search.component.html
@@ -37,7 +37,7 @@
     aria-describedby="term"
     type="text"
     class="govuk-input govuk-!-width-two-thirds"
-    (keyup.enter)="handleSearch(searchTerm.value, searchFilter.value)"
+    (keyup.enter)="handleSearch(searchFilter.value, searchTerm.value)"
   />
   <button
     class="govuk-button margin-right search-btn"
@@ -45,7 +45,7 @@
     data-module="govuk-button"
     enterkeyhint="search"
     data-gem-track-click-module-started="true"
-    (click)="handleSearch(searchTerm.value, searchFilter.value)"
+    (click)="handleSearch(searchFilter.value, searchTerm.value)"
   >
     <svg
       class="gem-c-search__icon"

--- a/src/app/features/tech-record/components/tyres-search/tyres-search.component.spec.ts
+++ b/src/app/features/tech-record/components/tyres-search/tyres-search.component.spec.ts
@@ -27,6 +27,7 @@ const mockTechRecordService = {
   viewableTechRecord$: jest.fn()
 };
 const mockReferenceDataService = {
+  addSearchInformation: jest.fn(),
   getTyreSearchReturn$: jest.fn(),
   loadReferenceDataByKeySearch: jest.fn(),
   loadTyreReferenceDataByKeySearch: jest.fn(),
@@ -90,27 +91,27 @@ describe('TyresSearchComponent', () => {
       expect(mockGlobalErrorService.addError).toBeCalled();
     });
     it('should call correct endpoint if filter === code', () => {
-      const term = '103';
       const filter = 'code';
-      component.handleSearch(term, filter);
+      const term = '103';
+      component.handleSearch(filter, term);
       expect(mockReferenceDataService.loadReferenceDataByKeySearch).toBeCalledWith(ReferenceDataResourceType.Tyres, term);
     });
     it('should call correct endpoint if filter === plyrating', () => {
-      const term = '103';
       const filter = 'plyrating';
-      component.handleSearch(term, filter);
+      const term = '103';
+      component.handleSearch(filter, term);
       expect(mockReferenceDataService.loadTyreReferenceDataByKeySearch).toBeCalledWith(filter, term);
     });
     it('should call correct endpoint if filter === singleload', () => {
-      const term = '103';
       const filter = 'singleload';
-      component.handleSearch(term, filter);
+      const term = '103';
+      component.handleSearch(filter, term);
       expect(mockReferenceDataService.loadTyreReferenceDataByKeySearch).toBeCalledWith(filter, term);
     });
     it('should call correct endpoint if filter === doubleload', () => {
-      const term = '103';
       const filter = 'doubleload';
-      component.handleSearch(term, filter);
+      const term = '103';
+      component.handleSearch(filter, term);
       expect(mockReferenceDataService.loadTyreReferenceDataByKeySearch).toBeCalledWith(filter, term);
     });
   });

--- a/src/app/features/tech-record/components/tyres-search/tyres-search.component.ts
+++ b/src/app/features/tech-record/components/tyres-search/tyres-search.component.ts
@@ -5,12 +5,12 @@ import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { MultiOptions } from '@forms/models/options.model';
-import { mergeMap, take } from 'rxjs';
+import { mergeMap, pipe, take } from 'rxjs';
 import { ReferenceDataResourceType, ReferenceDataTyre } from '@models/reference-data.model';
 import { Roles } from '@models/roles.enum';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { Router, ActivatedRoute } from '@angular/router';
-import { fetchReferenceDataByKeySearchSuccess, fetchTyreReferenceDataByKeySearchSuccess, ReferenceDataState } from '@store/reference-data';
+import { fetchReferenceDataByKeySearchSuccess, fetchTyreReferenceDataByKeySearchSuccess } from '@store/reference-data';
 import { Store } from '@ngrx/store';
 import { selectTyreSearchReturn } from '@store/reference-data/selectors/reference-data.selectors';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -84,6 +84,14 @@ export class TyresSearchComponent implements OnInit {
       .subscribe(data => {
         this.searchResults = data;
       });
+    this.referenceDataService
+      .getTyreSearchFilter$()
+      .pipe(take(1))
+      .subscribe(v => this.form.controls['filter'].patchValue(v));
+    this.referenceDataService
+      .getTyreSearchTerm$()
+      .pipe(take(1))
+      .subscribe(v => this.form.controls['term'].patchValue(v));
     if (!this.viewableTechRecord) {
       this.router.navigate(['../..'], { relativeTo: this.route });
     }
@@ -103,9 +111,10 @@ export class TyresSearchComponent implements OnInit {
   }
 
   handleSearch(term: string, filter: string): void {
+    term = term.trim();
     this.globalErrorService.clearErrors();
     this.searchResults = [];
-    term = term.trim();
+    this.referenceDataService.addSearchInformation(term, filter);
 
     if (!term) {
       this.globalErrorService.addError({ error: 'You must provide search criteria', anchorLink: 'term' });

--- a/src/app/features/tech-record/components/tyres-search/tyres-search.component.ts
+++ b/src/app/features/tech-record/components/tyres-search/tyres-search.component.ts
@@ -5,7 +5,7 @@ import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { MultiOptions } from '@forms/models/options.model';
-import { mergeMap, pipe, take } from 'rxjs';
+import { mergeMap, take } from 'rxjs';
 import { ReferenceDataResourceType, ReferenceDataTyre } from '@models/reference-data.model';
 import { Roles } from '@models/roles.enum';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
@@ -85,13 +85,13 @@ export class TyresSearchComponent implements OnInit {
         this.searchResults = data;
       });
     this.referenceDataService
-      .getTyreSearchFilter$()
+      .getTyreSearchCriteria$()
       .pipe(take(1))
-      .subscribe(v => this.form.controls['filter'].patchValue(v));
-    this.referenceDataService
-      .getTyreSearchTerm$()
-      .pipe(take(1))
-      .subscribe(v => this.form.controls['term'].patchValue(v));
+      .subscribe(v => {
+        this.form.controls['filter'].patchValue(v.filter);
+        this.form.controls['term'].patchValue(v.term);
+      });
+
     if (!this.viewableTechRecord) {
       this.router.navigate(['../..'], { relativeTo: this.route });
     }

--- a/src/app/features/tech-record/components/tyres-search/tyres-search.component.ts
+++ b/src/app/features/tech-record/components/tyres-search/tyres-search.component.ts
@@ -110,11 +110,11 @@ export class TyresSearchComponent implements OnInit {
     return this.searchResults?.length!;
   }
 
-  handleSearch(term: string, filter: string): void {
+  handleSearch(filter: string, term: string): void {
     term = term.trim();
     this.globalErrorService.clearErrors();
     this.searchResults = [];
-    this.referenceDataService.addSearchInformation(term, filter);
+    this.referenceDataService.addSearchInformation(filter, term);
 
     if (!term) {
       this.globalErrorService.addError({ error: 'You must provide search criteria', anchorLink: 'term' });

--- a/src/app/services/reference-data/reference-data.service.ts
+++ b/src/app/services/reference-data/reference-data.service.ts
@@ -8,7 +8,7 @@ import {
   ReferenceDataService as ReferenceDataApiService
 } from '@api/reference-data';
 import { MultiOptions } from '@forms/models/options.model';
-import { ReferenceDataModelBase, ReferenceDataResourceType, ReferenceDataTyre } from '@models/reference-data.model';
+import { ReferenceDataModelBase, ReferenceDataResourceType } from '@models/reference-data.model';
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { select, Store } from '@ngrx/store';
 import {
@@ -21,9 +21,8 @@ import {
   selectAllReferenceDataByResourceType,
   selectReasonsForAbandoning,
   selectReferenceDataByResourceKey,
-  selectTyreSearchFilter,
-  selectTyreSearchReturn,
-  selectTyreSearchTerm
+  selectTyreSearchCriteria,
+  selectTyreSearchReturn
 } from '@store/reference-data';
 import { map, Observable, of, throwError } from 'rxjs';
 
@@ -83,11 +82,8 @@ export class ReferenceDataService extends ReferenceDataApiService {
     return this.store.pipe(select(selectTyreSearchReturn()));
   };
 
-  getTyreSearchFilter$ = () => {
-    return this.store.pipe(select(selectTyreSearchFilter()));
-  };
-  getTyreSearchTerm$ = () => {
-    return this.store.pipe(select(selectTyreSearchTerm()));
+  getTyreSearchCriteria$ = () => {
+    return this.store.pipe(select(selectTyreSearchCriteria()));
   };
 
   getAll$ = (resourceType: ReferenceDataResourceType): Observable<ReferenceDataModelBase[] | undefined> => {

--- a/src/app/services/reference-data/reference-data.service.ts
+++ b/src/app/services/reference-data/reference-data.service.ts
@@ -12,6 +12,7 @@ import { ReferenceDataModelBase, ReferenceDataResourceType, ReferenceDataTyre } 
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { select, Store } from '@ngrx/store';
 import {
+  addSearchInformation,
   fetchReferenceData,
   fetchReferenceDataByKeySearch,
   fetchTyreReferenceDataByKeySearch,
@@ -20,7 +21,9 @@ import {
   selectAllReferenceDataByResourceType,
   selectReasonsForAbandoning,
   selectReferenceDataByResourceKey,
-  selectTyreSearchReturn
+  selectTyreSearchFilter,
+  selectTyreSearchReturn,
+  selectTyreSearchTerm
 } from '@store/reference-data';
 import { map, Observable, of, throwError } from 'rxjs';
 
@@ -67,11 +70,24 @@ export class ReferenceDataService extends ReferenceDataApiService {
   loadReferenceData(resourceType: ReferenceDataResourceType): void {
     this.store.dispatch(fetchReferenceData({ resourceType }));
   }
+
+  addSearchInformation(term: string, filter: string): void {
+    this.store.dispatch(addSearchInformation({ filter, term }));
+  }
+
   removeTyreSearch() {
     return this.store.dispatch(removeTyreSearch());
   }
+
   getTyreSearchReturn$ = () => {
     return this.store.pipe(select(selectTyreSearchReturn()));
+  };
+
+  getTyreSearchFilter$ = () => {
+    return this.store.pipe(select(selectTyreSearchFilter()));
+  };
+  getTyreSearchTerm$ = () => {
+    return this.store.pipe(select(selectTyreSearchTerm()));
   };
 
   getAll$ = (resourceType: ReferenceDataResourceType): Observable<ReferenceDataModelBase[] | undefined> => {

--- a/src/app/services/reference-data/reference-data.service.ts
+++ b/src/app/services/reference-data/reference-data.service.ts
@@ -71,7 +71,7 @@ export class ReferenceDataService extends ReferenceDataApiService {
     this.store.dispatch(fetchReferenceData({ resourceType }));
   }
 
-  addSearchInformation(term: string, filter: string): void {
+  addSearchInformation(filter: string, term: string): void {
     this.store.dispatch(addSearchInformation({ filter, term }));
   }
 

--- a/src/app/store/reference-data/actions/reference-data.actions.spec.ts
+++ b/src/app/store/reference-data/actions/reference-data.actions.spec.ts
@@ -11,7 +11,8 @@ import {
   fetchReferenceDataByKeySearchSuccess,
   fetchTyreReferenceDataByKeySearch,
   fetchTyreReferenceDataByKeySearchFailed,
-  fetchTyreReferenceDataByKeySearchSuccess
+  fetchTyreReferenceDataByKeySearchSuccess,
+  addSearchInformation
 } from './reference-data.actions';
 describe('Test Result Actions', () => {
   it('should return correct types', () => {
@@ -31,5 +32,7 @@ describe('Test Result Actions', () => {
     expect(fetchTyreReferenceDataByKeySearch.type).toBe('[API/reference-data] Fetch tyre by filter and term');
     expect(fetchTyreReferenceDataByKeySearchSuccess.type).toBe('[API/reference-data] Fetch tyre by filter and term Success');
     expect(fetchTyreReferenceDataByKeySearchFailed.type).toBe('[API/reference-data] Fetch tyre by filter and term Failed');
+
+    expect(addSearchInformation.type).toBe('[API/reference-data] Add Search Information to state');
   });
 });

--- a/src/app/store/reference-data/actions/reference-data.actions.ts
+++ b/src/app/store/reference-data/actions/reference-data.actions.ts
@@ -62,6 +62,15 @@ export const fetchTyreReferenceDataByKeySearchFailed = createAction(
   '[API/reference-data] Fetch tyre by filter and term Failed',
   props<featureError>()
 );
+
+export const addSearchInformation = createAction(
+  '[API/reference-data] Add Search Information to state',
+  props<{
+    filter: string;
+    term: string;
+  }>()
+);
+
 export const removeTyreSearch = createAction('[API/reference-data] Remove search return from state');
 
 export const fetchReasonsForAbandoning = createAction('[API/reference-data] Fetch reasons for abandoning');

--- a/src/app/store/reference-data/reducers/reference-data.reducer.spec.ts
+++ b/src/app/store/reference-data/reducers/reference-data.reducer.spec.ts
@@ -198,7 +198,9 @@ describe('Reference Data Reducer', () => {
           [ReferenceDataResourceType.Tyres]: {
             ...initialReferenceDataState[ReferenceDataResourceType.Tyres],
             searchReturn: null,
-            loading: false
+            loading: false,
+            filter: null,
+            term: null
           }
         };
         const action = fetchReferenceDataByKeySearchFailed({
@@ -279,7 +281,9 @@ describe('Reference Data Reducer', () => {
           [ReferenceDataResourceType.Tyres]: {
             ...initialReferenceDataState[ReferenceDataResourceType.Tyres],
             searchReturn: null,
-            loading: false
+            loading: false,
+            filter: null,
+            term: null
           }
         };
         const action = fetchTyreReferenceDataByKeySearchFailed({

--- a/src/app/store/reference-data/reducers/reference-data.reducer.spec.ts
+++ b/src/app/store/reference-data/reducers/reference-data.reducer.spec.ts
@@ -2,6 +2,7 @@ import { mockCountriesOfRegistration } from '@mocks/reference-data/mock-countrie
 import { ReferenceDataModelBase, ReferenceDataResourceType } from '@models/reference-data.model';
 import { Dictionary } from '@ngrx/entity';
 import {
+  addSearchInformation,
   fetchReferenceData,
   fetchReferenceDataByKey,
   fetchReferenceDataByKeyFailed,
@@ -13,10 +14,11 @@ import {
   fetchReferenceDataSuccess,
   fetchTyreReferenceDataByKeySearch,
   fetchTyreReferenceDataByKeySearchFailed,
-  fetchTyreReferenceDataByKeySearchSuccess
+  fetchTyreReferenceDataByKeySearchSuccess,
+  removeTyreSearch
 } from '../actions/reference-data.actions';
 import { testCases } from '../reference-data.test-cases';
-import { initialReferenceDataState, referenceDataReducer, ReferenceDataState } from './reference-data.reducer';
+import { initialReferenceDataState, ReferenceDataEntityStateTyres, referenceDataReducer, ReferenceDataState } from './reference-data.reducer';
 
 describe('Reference Data Reducer', () => {
   describe('unknown action', () => {
@@ -271,6 +273,43 @@ describe('Reference Data Reducer', () => {
 
         expect(state).toEqual(newState);
         expect(state).not.toBe(newState);
+      });
+    });
+
+    describe('addSearchInformation', () => {
+      it('should update state term and filter', () => {
+        const newState = {
+          ...initialReferenceDataState,
+          [ReferenceDataResourceType.Tyres]: {
+            ...initialReferenceDataState[ReferenceDataResourceType.Tyres],
+            loading: false,
+            filter: 'code',
+            term: '103'
+          }
+        };
+
+        const filter = 'code';
+        const term = '103';
+        const action = addSearchInformation({ filter, term });
+        const state = referenceDataReducer(initialReferenceDataState, action);
+
+        expect(state.TYRES).toStrictEqual(newState.TYRES);
+      });
+    });
+
+    describe('removeTyreSearch', () => {
+      it('should null search return', () => {
+        const action = removeTyreSearch();
+        const state = referenceDataReducer(initialReferenceDataState, action);
+
+        expect(state.TYRES).toStrictEqual({
+          ids: [],
+          entities: {},
+          loading: false,
+          searchReturn: null,
+          filter: null,
+          term: null
+        });
       });
     });
 

--- a/src/app/store/reference-data/reducers/reference-data.reducer.ts
+++ b/src/app/store/reference-data/reducers/reference-data.reducer.ts
@@ -2,6 +2,7 @@ import { ReferenceDataModelBase, ReferenceDataResourceType, ReferenceDataTyre } 
 import { createEntityAdapter, EntityAdapter, EntityState } from '@ngrx/entity';
 import { createFeatureSelector, createReducer, on } from '@ngrx/store';
 import {
+  addSearchInformation,
   fetchReferenceData,
   fetchReferenceDataByKey,
   fetchReferenceDataByKeyFailed,
@@ -29,6 +30,8 @@ interface ReferenceDataEntityState extends EntityState<ReferenceDataModelBase> {
 export interface ReferenceDataEntityStateTyres extends EntityState<ReferenceDataModelBase> {
   loading: boolean;
   searchReturn: ReferenceDataTyre[] | null;
+  term: string | null;
+  filter: string | null;
 }
 
 export type ReferenceDataState = Record<ReferenceDataResourceType, ReferenceDataEntityState | ReferenceDataEntityStateTyres>;
@@ -109,7 +112,7 @@ export const referenceDataReducer = createReducer(
   }),
   on(fetchReferenceDataByKeySearchFailed, (state, action) => ({
     ...state,
-    [action.resourceType]: { ...state[action.resourceType], searchReturn: null, loading: false }
+    [action.resourceType]: { ...state[action.resourceType], searchReturn: null, loading: false, filter: null, term: null }
   })),
 
   on(fetchTyreReferenceDataByKeySearch, (state, action) => ({
@@ -125,11 +128,15 @@ export const referenceDataReducer = createReducer(
   }),
   on(fetchTyreReferenceDataByKeySearchFailed, (state, action) => ({
     ...state,
-    [action.resourceType]: { ...state[action.resourceType], searchReturn: null, loading: false }
+    [action.resourceType]: { ...state[action.resourceType], searchReturn: null, loading: false, filter: null, term: null }
   })),
   on(removeTyreSearch, state => ({
     ...state,
-    [ReferenceDataResourceType.Tyres]: { ...state[ReferenceDataResourceType.Tyres], searchReturn: null }
+    [ReferenceDataResourceType.Tyres]: { ...state[ReferenceDataResourceType.Tyres], searchReturn: null, filter: null, term: null }
+  })),
+  on(addSearchInformation, (state, action) => ({
+    ...state,
+    [ReferenceDataResourceType.Tyres]: { ...state[ReferenceDataResourceType.Tyres], filter: action.filter, term: action.term }
   }))
 );
 

--- a/src/app/store/reference-data/selectors/reference-data.selectors.spec.ts
+++ b/src/app/store/reference-data/selectors/reference-data.selectors.spec.ts
@@ -72,6 +72,41 @@ describe('Reference Data Selectors', () => {
       expect(expectedState).toBe(value.payload);
     });
   });
+  describe('selectTyreSearchCriteria', () => {
+    it('should return the filter and term state to the user', () => {
+      const value = {
+        payload: [
+          {
+            tyreCode: '123',
+            resourceType: ReferenceDataResourceType.Tyres,
+            resourceKey: '123',
+            code: '123',
+            loadIndexSingleLoad: '102',
+            tyreSize: 'size',
+            dateTimeStamp: 'time',
+            userId: '1234',
+            loadIndexTwinLoad: '101',
+            plyRating: '18'
+          }
+        ]
+      };
+
+      const state: ReferenceDataState = {
+        ...initialReferenceDataState,
+        [ReferenceDataResourceType.Tyres]: {
+          ...initialReferenceDataState[ReferenceDataResourceType.Tyres],
+          loading: false,
+          searchReturn: value.payload,
+          filter: 'cake',
+          term: 'lies'
+        }
+      };
+
+      const expectedState = referenceDataSelectors.selectTyreSearchCriteria().projector(state);
+      expect(expectedState.filter).toBe('cake');
+      expect(expectedState.term).toBe('lies');
+    });
+  });
 
   it('should return true if any feature is loading state', () => {
     const state: ReferenceDataState = { ...initialReferenceDataState };

--- a/src/app/store/reference-data/selectors/reference-data.selectors.ts
+++ b/src/app/store/reference-data/selectors/reference-data.selectors.ts
@@ -33,6 +33,10 @@ export const selectReasonsForAbandoning = (vehicleType: VehicleTypes) => {
 
 export const selectTyreSearchReturn = () =>
   createSelector(referenceDataFeatureState, state => (state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres).searchReturn);
+export const selectTyreSearchFilter = () =>
+  createSelector(referenceDataFeatureState, state => (state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres).filter);
+export const selectTyreSearchTerm = () =>
+  createSelector(referenceDataFeatureState, state => (state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres).term);
 
 export const selectUserByResourceKey = (resourceKey: string) =>
   createSelector(referenceDataFeatureState, state => state[ReferenceDataResourceType.User].entities[resourceKey]);

--- a/src/app/store/reference-data/selectors/reference-data.selectors.ts
+++ b/src/app/store/reference-data/selectors/reference-data.selectors.ts
@@ -33,10 +33,8 @@ export const selectReasonsForAbandoning = (vehicleType: VehicleTypes) => {
 
 export const selectTyreSearchReturn = () =>
   createSelector(referenceDataFeatureState, state => (state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres).searchReturn);
-export const selectTyreSearchFilter = () =>
-  createSelector(referenceDataFeatureState, state => (state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres).filter);
-export const selectTyreSearchTerm = () =>
-  createSelector(referenceDataFeatureState, state => (state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres).term);
+export const selectTyreSearchCriteria = () =>
+  createSelector(referenceDataFeatureState, state => state[ReferenceDataResourceType.Tyres] as ReferenceDataEntityStateTyres);
 
 export const selectUserByResourceKey = (resourceKey: string) =>
   createSelector(referenceDataFeatureState, state => state[ReferenceDataResourceType.User].entities[resourceKey]);


### PR DESCRIPTION
Tyre search criteria gets cleared after search result displayed

Retain search criteria field pop on refresh and paginate, (filter and term not being uniform broke some tests)
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6814)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
