### PR TITLE
fix(cb2-6872): default noOfWheelsDriven to null if undefined

### DIFF
--- a/src/app/resolvers/contingency-test/contingency-test.resolver.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.ts
@@ -44,7 +44,7 @@ export class ContingencyTestResolver implements Resolve<boolean> {
               vehicleConfiguration: viewableTechRecord?.vehicleConfiguration,
               vehicleClass: viewableTechRecord?.vehicleClass,
               noOfAxles: viewableTechRecord?.noOfAxles,
-              numberOfWheelsDriven: viewableTechRecord?.numberOfWheelsDriven,
+              numberOfWheelsDriven: viewableTechRecord?.numberOfWheelsDriven ?? null,
               testStatus: 'submitted',
               regnDate: viewableTechRecord?.regnDate,
               numberOfSeats: (viewableTechRecord?.seatsLowerDeck ?? 0) + (viewableTechRecord?.seatsUpperDeck ?? 0),


### PR DESCRIPTION
## Pre-Prod Bug

_noOfWheels driven is required when creating a test. If undefined in tech record, default it to null._

[CB2-6872](https://dvsa.atlassian.net/browse/CB2-6872)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
