### PR TITLE
fix(cb2-6915): add max validator to seatbelts fitted

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/seatbelt/seatbelt-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/seatbelt/seatbelt-section.template.ts
@@ -34,7 +34,10 @@ export const SeatbeltSection: FormNode = {
               type: FormNodeTypes.CONTROL,
               editType: FormNodeEditTypes.NUMBER,
               value: null,
-              validators: [{ name: ValidatorNames.RequiredIfEquals, args: { sibling: 'seatbeltInstallationCheckDate', value: true } }],
+              validators: [
+                { name: ValidatorNames.RequiredIfEquals, args: { sibling: 'seatbeltInstallationCheckDate', value: true } },
+                { name: ValidatorNames.Max, args: 99 }
+              ],
               width: FormNodeWidth.M
             },
             {


### PR DESCRIPTION
## CB2-6915 Number of seatbelts fitted value should not be more than 99

_Adds validation to ensure seatbelts fitted doesn't exceed 99_
[CB2-6915](https://dvsa.atlassian.net/browse/CB2-6915)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
