### PR TITLE
fix(cb2-6932): eu vehicle category can now be null

### DIFF
--- a/src/app/models/test-results/test-result.model.ts
+++ b/src/app/models/test-results/test-result.model.ts
@@ -24,7 +24,7 @@ export interface TestResultModel {
 
   trailerId: string;
   countryOfRegistration: string;
-  euVehicleCategory: EuVehicleCategory;
+  euVehicleCategory: EuVehicleCategory | null;
   odometerReading: number;
   odometerReadingUnits: OdometerReadingUnits;
   preparerName: string;

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.ts
@@ -39,7 +39,7 @@ export class ContingencyTestResolver implements Resolve<boolean> {
               systemNumber,
               vehicleType: viewableTechRecord?.vehicleType,
               testResultId: uuidv4(),
-              euVehicleCategory: viewableTechRecord?.euVehicleCategory,
+              euVehicleCategory: viewableTechRecord?.euVehicleCategory ?? null,
               vehicleSize: viewableTechRecord?.vehicleSize,
               vehicleConfiguration: viewableTechRecord?.vehicleConfiguration,
               vehicleClass: viewableTechRecord?.vehicleClass ?? null,


### PR DESCRIPTION
## CB2-6932 EU Vehicle Category is required when should be optional

_Allows EU vehicle category to be null when sent in payload_
[CB2-6932](https://dvsa.atlassian.net/browse/CB2-6932)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
