### PR TITLE
bug(CB2-6934):  Remove Odometer count and units (DBT HGV/TRL group 2). Unhide emissions section in Review mode

### DIFF
--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -37,6 +37,7 @@ import { DeskBasedTestSectionGroup3Psv } from './section-templates/test/desk-bas
 import { DeskBasedTestSectionGroup4Psv } from './section-templates/test/desk-based/desk-based-test-section-group4-PSV.template';
 import { DeskBasedEmissionsSection } from './section-templates/emissions/desk-based-emissions-section.template';
 import { DeskBasedTestSectionGroup1And3HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group1And3-HGV-TRL.template';
+import { DeskBasedVehicleSectionHgvGroup123 } from './section-templates/vehicle/desk-based-test-psv-hgv-vehicle-section-group2.template';
 
 const groups1and2Template: Record<string, FormNode> = {
   required: CreateRequiredSection,
@@ -290,7 +291,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup1: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionDefaultPsvHgv,
+      vehicle: DeskBasedVehicleSectionHgvGroup123,
       test: DeskBasedTestSectionGroup1And3HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
@@ -300,7 +301,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup2: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionDefaultPsvHgv,
+      vehicle: DeskBasedVehicleSectionHgvGroup123,
       test: DeskBasedTestSectionGroup2,
       emissions: DeskBasedEmissionsSection,
       visit: ContingencyVisitSection,
@@ -311,7 +312,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup3: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionDefaultPsvHgv,
+      vehicle: DeskBasedVehicleSectionHgvGroup123,
       test: DeskBasedTestSectionGroup1And3HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,

--- a/src/app/forms/templates/test-records/section-templates/emissions/desk-based-emissions-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/emissions/desk-based-emissions-section.template.ts
@@ -2,7 +2,7 @@ import { FormNode, FormNodeTypes, FormNodeEditTypes } from '@forms/services/dyna
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { AsyncValidatorNames } from '@forms/models/async-validators.enum';
 export const DeskBasedEmissionsSection: FormNode = {
-  name: 'emissionsSection',
+  name: 'deskBasedEmissionsSection',
   label: 'Emissions',
   type: FormNodeTypes.GROUP,
   children: [

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group1.template.ts
@@ -5,7 +5,6 @@ export const ContingencyTestSectionGroup1: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group12and14.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group12and14.template.ts
@@ -5,7 +5,6 @@ export const ContingencyTestSectionGroup12and14: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group15and16.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group15and16.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionGroup15and16: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group3And4And8.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group3And4And8.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionGroup3And4And8: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group5And13.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group5And13.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionGroup5And13: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group6And11.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group6And11.template.ts
@@ -5,7 +5,6 @@ export const ContingencyTestSectionGroup6And11: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group7.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group7.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionGroup7: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group9And10.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group9And10.template.ts
@@ -5,7 +5,6 @@ export const ContingencyTestSectionGroup9And10: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group1.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionSpecialistGroup1: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group2.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group2.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionSpecialistGroup2: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group3And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group3And4.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionSpecialistGroup3And4: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group5.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-specialist-group5.template.ts
@@ -6,7 +6,6 @@ export const ContingencyTestSectionSpecialistGroup5: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,
-  viewType: FormNodeViewTypes.SUBHEADING,
   children: [
     {
       name: 'contingencyTestNumber',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-psv-hgv-vehicle-section-group2.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-psv-hgv-vehicle-section-group2.template.ts
@@ -1,0 +1,75 @@
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { ReferenceDataResourceType } from '@models/reference-data.model';
+
+export const DeskBasedVehicleSectionHgvGroup123: FormNode = {
+  name: 'vehicleSection',
+  label: 'Vehicle Details',
+  type: FormNodeTypes.GROUP,
+  children: [
+    {
+      name: 'vin',
+      label: 'VIN/chassis number',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'vrm',
+      label: 'VRM',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'countryOfRegistration',
+      label: 'Country Of Registration',
+      value: '',
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
+      options: [],
+      referenceData: ReferenceDataResourceType.CountryOfRegistration,
+      type: FormNodeTypes.CONTROL
+    },
+    {
+      name: 'euVehicleCategory',
+      label: 'EU Vehicle Category',
+      value: '',
+      disabled: true,
+      type: FormNodeTypes.CONTROL,
+      width: FormNodeWidth.XXS
+    },
+    {
+      name: 'odometerReading',
+      label: 'Odometer Reading',
+      value: null,
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN
+    },
+    {
+      name: 'odometerReadingUnits',
+      label: 'Odometer Reading Units',
+      value: null,
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'preparerName',
+      label: 'Preparer Name',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'preparerId',
+      label: 'Preparer ID',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    }
+  ]
+};


### PR DESCRIPTION
Remove Odometer count and units (DBT HGV/TRL group 2). Unhide emissions section in Review mode

Hide odo in hgv group 1 2 3, show emissions in review psv hgv group 2, delete extra title in contingency tests

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6934)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
