### PR TITLE
feat(cb2-6550): move groups 3 and 4 HGV and TRL desk based

### DIFF
--- a/src/app/features/test-records/amend/views/test-record/test-record.component.spec.ts
+++ b/src/app/features/test-records/amend/views/test-record/test-record.component.spec.ts
@@ -162,7 +162,7 @@ describe('TestRecordComponent', () => {
       const testRecord = { testResultId: '1', testTypes: [{ testTypeId: '2' }] } as TestResultModel;
       store.overrideSelector(isTestTypeKeySame('testTypeId'), false);
       store.overrideSelector(testResultInEdit, testRecord);
-      store.overrideSelector(sectionTemplates, Object.values(masterTpl.psv['testTypesGroup1']));
+      store.overrideSelector(sectionTemplates, Object.values(masterTpl.psv['testTypesGroup1']!));
 
       tick();
       fixture.detectChanges();

--- a/src/app/features/test-records/create/views/create-test-record/create-test-record.component.spec.ts
+++ b/src/app/features/test-records/create/views/create-test-record/create-test-record.component.spec.ts
@@ -97,7 +97,7 @@ describe('CreateTestRecordComponent', () => {
     const createTestResultSpy = jest.spyOn(testRecordsService, 'createTestResult').mockImplementation(() => {});
     const testRecord = { testResultId: '1', testTypes: [{ testTypeId: '2' }] } as TestResultModel;
     store.overrideSelector(testResultInEdit, testRecord);
-    store.overrideSelector(sectionTemplates, Object.values(contingencyTestTemplates.psv['testTypesGroup1']));
+    store.overrideSelector(sectionTemplates, Object.values(contingencyTestTemplates.psv['testTypesGroup1']!));
 
     tick();
     fixture.detectChanges();
@@ -116,7 +116,7 @@ describe('CreateTestRecordComponent', () => {
     const createTestResultSpy = jest.spyOn(testRecordsService, 'createTestResult').mockImplementation(() => {});
     const testRecord = { testResultId: '1', testTypes: [{ testTypeId: '2' }] } as TestResultModel;
     store.overrideSelector(testResultInEdit, testRecord);
-    store.overrideSelector(sectionTemplates, Object.values(contingencyTestTemplates.psv['testTypesGroup1']));
+    store.overrideSelector(sectionTemplates, Object.values(contingencyTestTemplates.psv['testTypesGroup1']!));
 
     tick();
     fixture.detectChanges();
@@ -203,7 +203,7 @@ describe('CreateTestRecordComponent', () => {
     const createTestResultSpy = jest.spyOn(testRecordsService, 'createTestResult').mockImplementation(() => {});
     const testRecord = { testResultId: '1', testTypes: [{ testTypeId: '2' }] } as TestResultModel;
     store.overrideSelector(testResultInEdit, testRecord);
-    store.overrideSelector(sectionTemplates, Object.values(contingencyTestTemplates.psv['testTypesGroup1']));
+    store.overrideSelector(sectionTemplates, Object.values(contingencyTestTemplates.psv['testTypesGroup1']!));
 
     tick();
     fixture.detectChanges();

--- a/src/app/forms/models/testTypeId.enum.ts
+++ b/src/app/forms/models/testTypeId.enum.ts
@@ -190,8 +190,8 @@ export const SPECIALIST_TEST_TYPE_IDS: string[] = [
 
 export const TEST_TYPES_GROUP1_DESK_BASED_TEST: string[] = ['417', '418'];
 export const TEST_TYPES_GROUP2_DESK_BASED_TEST: string[] = ['403', '404', '415'];
-export const TEST_TYPES_GROUP3_DESK_BASED_TEST: string[] = ['407', '408', '414', '423', '424', '425'];
-export const TEST_TYPES_GROUP4_DESK_BASED_TEST: string[] = ['409', '411', '412', '414', '420'];
+export const TEST_TYPES_GROUP3_DESK_BASED_TEST: string[] = ['407', '408', '414', '420'];
+export const TEST_TYPES_GROUP4_DESK_BASED_TEST: string[] = ['409', '411', '412', '423', '424', '425'];
 
 export const TEST_TYPES = {
   testTypesGroup1: TEST_TYPES_GROUP1,

--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -30,14 +30,16 @@ import { ContingencyTestSectionSpecialistGroup3And4 } from './section-templates/
 import { ContingencyTestSectionSpecialistGroup5 } from './section-templates/test/contingency/contingency-test-section-specialist-group5.template';
 import { DeskBasedVehicleSectionDefaultPsvHgv } from './section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template';
 import { DeskBasedVehicleSectionDefaultTrl } from './section-templates/vehicle/desk-based-default-trl-vehicle-section.template';
-import { DeskBasedTestSectionGroup4HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group4-HGV-TRL.template';
+import { DeskBasedTestSectionGroup3HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group3-HGV-TRL.template';
 import { DeskBasedTestSectionGroup1Psv } from './section-templates/test/desk-based/desk-based-test-section-group1-PSV.template';
 import { DeskBasedTestSectionGroup2 } from './section-templates/test/desk-based/desk-based-test-section-group2.template';
 import { DeskBasedTestSectionGroup3Psv } from './section-templates/test/desk-based/desk-based-test-section-group3-PSV.template';
 import { DeskBasedTestSectionGroup4Psv } from './section-templates/test/desk-based/desk-based-test-section-group4-PSV.template';
 import { DeskBasedEmissionsSection } from './section-templates/emissions/desk-based-emissions-section.template';
-import { DeskBasedTestSectionGroup1And3HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group1And3-HGV-TRL.template';
-import { DeskBasedVehicleSectionHgvGroup123 } from './section-templates/vehicle/desk-based-test-psv-hgv-vehicle-section-group2.template';
+import { DeskBasedTestSectionGroup1And4HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group1And4-HGV-TRL.template';
+import { DeskBasedVehicleSectionHgvGroup124 } from './section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template';
+import { TEST_TYPES } from '@forms/models/testTypeId.enum';
+import { type } from 'os';
 
 const groups1and2Template: Record<string, FormNode> = {
   required: CreateRequiredSection,
@@ -50,6 +52,8 @@ const groups1and2Template: Record<string, FormNode> = {
   customDefects: CustomDefectsHiddenSection,
   reasonForCreation: reasonForCreationSection
 };
+
+type testTypeKeys = keyof typeof TEST_TYPES | 'default';
 
 export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Record<string, FormNode>>> = {
   psv: {
@@ -291,8 +295,8 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup1: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionHgvGroup123,
-      test: DeskBasedTestSectionGroup1And3HgvTrl,
+      vehicle: DeskBasedVehicleSectionHgvGroup124,
+      test: DeskBasedTestSectionGroup1And4HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
       defects: defectsHiddenSection,
@@ -301,7 +305,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup2: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionHgvGroup123,
+      vehicle: DeskBasedVehicleSectionHgvGroup124,
       test: DeskBasedTestSectionGroup2,
       emissions: DeskBasedEmissionsSection,
       visit: ContingencyVisitSection,
@@ -312,8 +316,8 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup3: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionHgvGroup123,
-      test: DeskBasedTestSectionGroup1And3HgvTrl,
+      vehicle: DeskBasedVehicleSectionDefaultPsvHgv,
+      test: DeskBasedTestSectionGroup3HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
       defects: defectsHiddenSection,
@@ -322,8 +326,8 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     },
     testTypesDeskBasedGroup4: {
       required: CreateRequiredSectionHgvTrl,
-      vehicle: DeskBasedVehicleSectionDefaultPsvHgv,
-      test: DeskBasedTestSectionGroup4HgvTrl,
+      vehicle: DeskBasedVehicleSectionHgvGroup124,
+      test: DeskBasedTestSectionGroup1And4HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
       defects: defectsHiddenSection,
@@ -424,7 +428,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     testTypesDeskBasedGroup1: {
       required: CreateRequiredSectionHgvTrl,
       vehicle: DeskBasedVehicleSectionDefaultTrl,
-      test: DeskBasedTestSectionGroup1And3HgvTrl,
+      test: DeskBasedTestSectionGroup1And4HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
       defects: defectsHiddenSection,
@@ -445,7 +449,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     testTypesDeskBasedGroup3: {
       required: CreateRequiredSectionHgvTrl,
       vehicle: DeskBasedVehicleSectionDefaultTrl,
-      test: DeskBasedTestSectionGroup1And3HgvTrl,
+      test: DeskBasedTestSectionGroup3HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
       defects: defectsHiddenSection,
@@ -455,7 +459,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Recor
     testTypesDeskBasedGroup4: {
       required: CreateRequiredSectionHgvTrl,
       vehicle: DeskBasedVehicleSectionDefaultTrl,
-      test: DeskBasedTestSectionGroup4HgvTrl,
+      test: DeskBasedTestSectionGroup1And4HgvTrl,
       visit: ContingencyVisitSection,
       notes: NotesSection,
       defects: defectsHiddenSection,

--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -39,7 +39,6 @@ import { DeskBasedEmissionsSection } from './section-templates/emissions/desk-ba
 import { DeskBasedTestSectionGroup1And4HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group1And4-HGV-TRL.template';
 import { DeskBasedVehicleSectionHgvGroup124 } from './section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template';
 import { TEST_TYPES } from '@forms/models/testTypeId.enum';
-import { type } from 'os';
 
 const groups1and2Template: Record<string, FormNode> = {
   required: CreateRequiredSection,
@@ -53,9 +52,7 @@ const groups1and2Template: Record<string, FormNode> = {
   reasonForCreation: reasonForCreationSection
 };
 
-type testTypeKeys = keyof typeof TEST_TYPES | 'default';
-
-export const contingencyTestTemplates: Record<VehicleTypes, Record<string, Record<string, FormNode>>> = {
+export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof typeof TEST_TYPES | 'default', Record<string, FormNode>>>> = {
   psv: {
     default: {
       vehicle: ContingencyVehicleSectionDefaultPsvHgv,

--- a/src/app/forms/templates/test-records/master.template.ts
+++ b/src/app/forms/templates/test-records/master.template.ts
@@ -32,11 +32,12 @@ import { defectsHiddenSection } from './section-templates/required/defect-hidden
 import { SeatbeltHiddenSection } from './section-templates/required/seatbelt-hidden-section.template';
 import { ContingencyVehicleSectionDefaultPsvHgv } from './section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template';
 import { DeskBasedTestSectionGroup2 } from './section-templates/test/desk-based/desk-based-test-section-group2.template';
+import { TEST_TYPES } from '@forms/models/testTypeId.enum';
 //Keys of root object must a a valid vehicle type.
 //Keys of child object must be a valid test type id.
 //Child object must ALWAYS have a 'default' key.
 
-export const masterTpl: Record<VehicleTypes, Record<string, Record<string, FormNode>>> = {
+export const masterTpl: Record<VehicleTypes, Partial<Record<keyof typeof TEST_TYPES | 'default', Record<string, FormNode>>>> = {
   psv: {
     default: {
       vehicle: VehicleSectionDefaultPsvHgv,

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group1And4-HGV-TRL.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group1And4-HGV-TRL.template.ts
@@ -1,6 +1,6 @@
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 
-export const DeskBasedTestSectionGroup1And3HgvTrl: FormNode = {
+export const DeskBasedTestSectionGroup1And4HgvTrl: FormNode = {
   name: 'requiredSection',
   type: FormNodeTypes.GROUP,
   children: [

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group3-HGV-TRL.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group3-HGV-TRL.template.ts
@@ -1,7 +1,7 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 
-export const DeskBasedTestSectionGroup4HgvTrl: FormNode = {
+export const DeskBasedTestSectionGroup3HgvTrl: FormNode = {
   name: 'testSection',
   label: 'Test',
   type: FormNodeTypes.GROUP,

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
@@ -1,7 +1,7 @@
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
 
-export const DeskBasedVehicleSectionHgvGroup123: FormNode = {
+export const DeskBasedVehicleSectionHgvGroup124: FormNode = {
   name: 'vehicleSection',
   label: 'Vehicle Details',
   type: FormNodeTypes.GROUP,

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -316,7 +316,7 @@ describe('TestResultsEffects', () => {
 
         expectObservable(effects.generateSectionTemplatesAndtestResultToUpdate$).toBe('-(bc)', {
           b: templateSectionsChanged({
-            sectionTemplates: Object.values(masterTpl.psv['testTypesGroup1']),
+            sectionTemplates: Object.values(masterTpl.psv['testTypesGroup1']!),
             sectionsValue: { testTypes: [{ testTypeId: '1' }] } as unknown as TestResultModel
           }),
           c: updateResultOfTest()
@@ -438,7 +438,7 @@ describe('TestResultsEffects', () => {
 
         expectObservable(effects.generateSectionTemplatesAndtestResultToUpdate$).toBe('-(bc)', {
           b: templateSectionsChanged({
-            sectionTemplates: Object.values(masterTpl.psv['default']),
+            sectionTemplates: Object.values(masterTpl.psv['default']!),
             sectionsValue: { testTypes: [{ testTypeId: '39' }] } as unknown as TestResultModel
           }),
           c: updateResultOfTest()
@@ -470,7 +470,7 @@ describe('TestResultsEffects', () => {
 
         expectObservable(effects.generateContingencyTestTemplatesAndtestResultToUpdate$).toBe('-b', {
           b: templateSectionsChanged({
-            sectionTemplates: Object.values(contingencyTestTemplates.psv['testTypesGroup1']),
+            sectionTemplates: Object.values(contingencyTestTemplates.psv['testTypesGroup1']!),
             sectionsValue: {
               contingencyTestNumber: undefined,
               countryOfRegistration: '',

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
+import { TEST_TYPES } from '@forms/models/testTypeId.enum';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { contingencyTestTemplates } from '@forms/templates/test-records/create-master.template';
 import { masterTpl } from '@forms/templates/test-records/master.template';
@@ -132,7 +133,7 @@ export class TestResultsEffects {
 
         let tpl;
         if (testTypeGroup && vehicleTpl.hasOwnProperty(testTypeGroup)) {
-          tpl = vehicleTpl[testTypeGroup];
+          tpl = vehicleTpl[testTypeGroup as keyof typeof TEST_TYPES];
         } else {
           if (isEditing === 'true') {
             tpl = undefined;
@@ -183,10 +184,11 @@ export class TestResultsEffects {
         const testTypeGroup = TestRecordsService.getTestTypeGroup(id);
         const vehicleTpl = contingencyTestTemplates[vehicleType];
 
-        const tpl = testTypeGroup && vehicleTpl.hasOwnProperty(testTypeGroup) ? vehicleTpl[testTypeGroup] : vehicleTpl['default'];
+        const tpl =
+          testTypeGroup && vehicleTpl.hasOwnProperty(testTypeGroup) ? vehicleTpl[testTypeGroup as keyof typeof TEST_TYPES] : vehicleTpl['default'];
 
         const mergedForms = {} as TestResultModel;
-        Object.values(tpl).forEach(node => {
+        Object.values(tpl!).forEach(node => {
           const form = this.dfs.createForm(node, editingTestResult);
           merge(mergedForms, form.getCleanValue(form));
         });
@@ -211,7 +213,7 @@ export class TestResultsEffects {
           mergedForms.testStationType = TestStationType.ATF;
         }
 
-        return of(templateSectionsChanged({ sectionTemplates: Object.values(tpl), sectionsValue: mergedForms }));
+        return of(templateSectionsChanged({ sectionTemplates: Object.values(tpl!), sectionsValue: mergedForms }));
       })
     )
   );


### PR DESCRIPTION
## There are some bugs that need fixing

_test type if was both in group 3 and 4 causing some bugs and the wrong template being entered_
- also makes sure the keys in master templates are valid keys from the TEST_TYPES object (or `default`)
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6550)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
