### PR TITLE
fix(cb2-6981): match axle spacing and axle arrays on load

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -278,4 +278,88 @@ describe('TechRecordSummaryComponent', () => {
       ]);
     });
   });
+
+  describe('normaliseVehicleTechRecordAxles', () => {
+    it('should not change anything if the tech record is correct', () => {
+      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.normaliseVehicleTechRecordAxles();
+
+      const axleSpacingMock = jest.spyOn(component, 'generateAxleSpacing');
+      const axleMock = jest.spyOn(component, 'generateAxlesFromAxleSpacings');
+
+      expect(axleSpacingMock).toHaveBeenCalledTimes(0);
+      expect(axleMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should call generate spacings if there are more axles', () => {
+      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.vehicleTechRecordCalculated.axles.push({ axleNumber: 3 });
+
+      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.length).toBe(1);
+
+      component.normaliseVehicleTechRecordAxles();
+
+      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.length).toBe(2);
+    });
+
+    it('should call generate axles if there are more spacings', () => {
+      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.push({ axles: '2-3', value: 1 });
+
+      expect(component.vehicleTechRecordCalculated.axles.length).toBe(2);
+
+      component.normaliseVehicleTechRecordAxles();
+
+      expect(component.vehicleTechRecordCalculated.axles.length).toBe(3);
+    });
+
+    it('should call generate spacings if there are none but there is axles', () => {
+      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.vehicleTechRecordCalculated.dimensions!.axleSpacing = undefined;
+      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing).toBe(undefined);
+
+      component.normaliseVehicleTechRecordAxles();
+
+      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
+    });
+
+    it('should call generate spacings if there are none but there is axles and there is an object to start with', () => {
+      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.vehicleTechRecordCalculated.dimensions!.axleSpacing = [];
+      expect(component.vehicleTechRecordCalculated.axles.length).toBe(2);
+
+      component.normaliseVehicleTechRecordAxles();
+
+      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
+    });
+
+    it('should call generate axles if there are none but there is spacings', () => {
+      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.vehicleTechRecordCalculated.axles = [];
+      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
+
+      component.normaliseVehicleTechRecordAxles();
+
+      expect(component.vehicleTechRecordCalculated.axles.length).toBe(2);
+    });
+  });
+
+  describe('generateAxles', () => {
+    it('should generate 3 axles from no previous data', () => {
+      const res = component.generateAxlesFromAxleSpacings(VehicleTypes.HGV, 2);
+
+      expect(res.length).toBe(3);
+      expect(res[0].axleNumber).toBe(1);
+      expect(res[2].axleNumber).toBe(3);
+    });
+
+    it('should generate 3 axles from 1 previous axle', () => {
+      const previousAxles = [{ axleNumber: 1 }];
+      const res = component.generateAxlesFromAxleSpacings(VehicleTypes.HGV, 2, previousAxles);
+
+      expect(res.length).toBe(3);
+      expect(res[0].axleNumber).toBe(1);
+      expect(res[2].axleNumber).toBe(3);
+    });
+  });
 });

--- a/src/app/forms/templates/hgv/hgv-dimensions.template.ts
+++ b/src/app/forms/templates/hgv/hgv-dimensions.template.ts
@@ -1,5 +1,5 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
-import { FormNode, FormNodeTypes } from '../../services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes } from '../../services/dynamic-form.types';
 
 export const HgvDimensionsTemplate: FormNode = {
   name: 'dimensionsSection',
@@ -37,6 +37,7 @@ export const HgvDimensionsTemplate: FormNode = {
                   name: 'value',
                   label: 'Axle to axle (mm)',
                   value: '',
+                  editType: FormNodeEditTypes.NUMBER,
                   type: FormNodeTypes.CONTROL,
                   validators: [{ name: ValidatorNames.Max, args: 99999 }]
                 }

--- a/src/app/forms/templates/hgv/hgv-weight.template.ts
+++ b/src/app/forms/templates/hgv/hgv-weight.template.ts
@@ -1,5 +1,5 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
-import { FormNode, FormNodeTypes } from '../../services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes } from '../../services/dynamic-form.types';
 
 const requiredValidation = [
   { name: ValidatorNames.Numeric, args: 99999 },
@@ -38,6 +38,7 @@ export const HgvWeight: FormNode = {
       label: 'EEC (optional)',
       customValidatorErrorName: 'Gross EEC Weight',
       value: '',
+      editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
       validators: optionalValidation
     },
@@ -68,6 +69,7 @@ export const HgvWeight: FormNode = {
       label: 'EEC (optional)',
       customValidatorErrorName: 'Train EEC Weight',
       value: '',
+      editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
       validators: optionalValidation
     },
@@ -98,6 +100,7 @@ export const HgvWeight: FormNode = {
       label: 'EEC (optional)',
       customValidatorErrorName: 'Max Train EEC Weight',
       value: '',
+      editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
       validators: optionalValidation
     },
@@ -150,6 +153,7 @@ export const HgvWeight: FormNode = {
                   label: 'EEC (optional)',
                   customValidatorErrorName: 'Axle EEC Weight',
                   value: '',
+                  editType: FormNodeEditTypes.NUMBER,
                   type: FormNodeTypes.CONTROL,
                   validators: optionalValidation
                 },

--- a/src/app/forms/templates/trl/trl-dimensions.template.ts
+++ b/src/app/forms/templates/trl/trl-dimensions.template.ts
@@ -1,5 +1,5 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
-import { FormNode, FormNodeTypes } from '../../services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes } from '../../services/dynamic-form.types';
 
 export const TrlDimensionsTemplate: FormNode = {
   name: 'dimensionsSection',
@@ -28,6 +28,7 @@ export const TrlDimensionsTemplate: FormNode = {
         {
           name: 'axleSpacing',
           type: FormNodeTypes.ARRAY,
+          value: '',
           children: [
             {
               name: '0',
@@ -37,6 +38,7 @@ export const TrlDimensionsTemplate: FormNode = {
                   name: 'value',
                   label: 'Axle to axle (mm)',
                   value: '',
+                  editType: FormNodeEditTypes.NUMBER,
                   type: FormNodeTypes.CONTROL,
                   validators: [{ name: ValidatorNames.Max, args: 99999 }]
                 }

--- a/src/app/forms/templates/trl/trl-weight.template.ts
+++ b/src/app/forms/templates/trl/trl-weight.template.ts
@@ -1,5 +1,5 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
-import { FormNode, FormNodeTypes } from '../../services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes } from '../../services/dynamic-form.types';
 
 const requiredValidation = [
   { name: ValidatorNames.Numeric, args: 99999 },
@@ -38,6 +38,7 @@ export const TrlWeight: FormNode = {
       label: 'EEC (optional)',
       customValidatorErrorName: 'Gross EEC Weight',
       value: '',
+      editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
       validators: optionalValidation
     },
@@ -90,6 +91,7 @@ export const TrlWeight: FormNode = {
                   label: 'EEC (optional)',
                   customValidatorErrorName: 'Axle EEC Weight',
                   value: '',
+                  editType: FormNodeEditTypes.NUMBER,
                   type: FormNodeTypes.CONTROL,
                   validators: optionalValidation
                 },


### PR DESCRIPTION
## Axle spacings and axle array can become out of sync

The two arrays can be stored incorrectly in the database and be out of sync. This needs repaired on load of the tech record. This also addresses https://dvsa.atlassian.net/browse/CB2-6881
[https://dvsa.atlassian.net/browse/CB2-6981](6981)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
