### PR TITLE
fix(cb2-6967): only create test in non-edit mode when viewing tech record

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
@@ -20,9 +20,6 @@ import {
 import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { clearError } from '@store/global-error/actions/global-error.actions';
-import { selectedAmendedTestResultState } from '@store/test-records';
-import { mockTestResult } from '@mocks/mock-test-result';
-import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
 
 let component: EditTechRecordButtonComponent;

--- a/src/app/features/tech-record/components/test-record-create-button/test-record-create-button.component.html
+++ b/src/app/features/tech-record/components/test-record-create-button/test-record-create-button.component.html
@@ -1,0 +1,3 @@
+<div class="govuk-button-group">
+  <a id="create-test" class="govuk-button" [routerLink]="'test-records/create-test/type'">Create a test for this vehicle</a>
+</div>

--- a/src/app/features/tech-record/components/test-record-create-button/test-record-create-button.component.spec.ts
+++ b/src/app/features/tech-record/components/test-record-create-button/test-record-create-button.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestRecordCreateButtonComponent } from './test-record-create-button.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '@shared/shared.module';
+import { By } from '@angular/platform-browser';
+
+describe('TestRecordSummaryComponent', () => {
+  let component: TestRecordCreateButtonComponent;
+  let fixture: ComponentFixture<TestRecordCreateButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestRecordCreateButtonComponent],
+      imports: [RouterTestingModule, SharedModule, RouterTestingModule.withRoutes([{ path: 'test', component: TestRecordCreateButtonComponent }])]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestRecordCreateButtonComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have correct url to redirect to', () => {
+    fixture.detectChanges();
+
+    const href = fixture.debugElement.query(By.css('#create-test')).nativeElement.getAttribute('href');
+
+    expect(href).toBe('/test-records/create-test/type');
+  });
+});

--- a/src/app/features/tech-record/components/test-record-create-button/test-record-create-button.component.ts
+++ b/src/app/features/tech-record/components/test-record-create-button/test-record-create-button.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-test-record-create-button',
+  templateUrl: './test-record-create-button.component.html'
+})
+export class TestRecordCreateButtonComponent {}

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.html
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.html
@@ -28,8 +28,3 @@
   </table>
   <app-pagination tableName="test-history" [numberOfItems]="numberOfRecords" (paginationOptions)="handlePaginationChange($event)"></app-pagination>
 </ng-container>
-<ng-container *appRoleRequired="[roles.TestResultCreateContingency, roles.TestResultCreateDeskAssesment]">
-  <div *ngIf="!isArchived" class="govuk-button-group">
-    <a class="govuk-button" [routerLink]="'test-records/create-test/type'">Create a test for this vehicle</a>
-  </div>
-</ng-container>

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.spec.ts
@@ -1,35 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
-import { RoleRequiredDirective } from '@directives/app-role-required.directive';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { resultOfTestEnum, TestType } from '@models/test-types/test-type.model';
-import { provideMockActions } from '@ngrx/effects/testing';
-import { Action } from '@ngrx/store';
-import { UserService } from '@services/user-service/user-service';
 import { SharedModule } from '@shared/shared.module';
-import { of, ReplaySubject } from 'rxjs';
 import { createMock, createMockList } from 'ts-auto-mock';
 import { TestRecordSummaryComponent } from './test-record-summary.component';
 
 describe('TestRecordSummaryComponent', () => {
   let component: TestRecordSummaryComponent;
   let fixture: ComponentFixture<TestRecordSummaryComponent>;
-  let actions$ = new ReplaySubject<Action>();
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TestRecordSummaryComponent, RoleRequiredDirective],
-      imports: [RouterTestingModule, SharedModule],
-      providers: [
-        provideMockActions(() => actions$),
-        {
-          provide: UserService,
-          useValue: {
-            roles$: of(['TestResult.CreateContingency'])
-          }
-        }
-      ]
+      declarations: [TestRecordSummaryComponent],
+      imports: [RouterTestingModule, SharedModule]
     }).compileComponents();
   });
 

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 import { TestResultModel } from '@models/test-results/test-result.model';
-import { TechRecordModel } from '@models/vehicle-tech-record.model';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
 import { Roles } from '@models/roles.enum';
 
@@ -19,7 +18,6 @@ interface TestField {
 })
 export class TestRecordSummaryComponent {
   @Input() testRecords: TestResultModel[] = [];
-  @Input() currentTechRecord?: TechRecordModel;
 
   public get roles() {
     return Roles;

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 import { TestResultModel } from '@models/test-results/test-result.model';
-import { StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { TechRecordModel } from '@models/vehicle-tech-record.model';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
 import { Roles } from '@models/roles.enum';
 
@@ -27,10 +27,6 @@ export class TestRecordSummaryComponent {
 
   pageStart?: number;
   pageEnd?: number;
-
-  get isArchived(): boolean {
-    return !(this.currentTechRecord?.statusCode === StatusCodes.CURRENT || this.currentTechRecord?.statusCode === StatusCodes.PROVISIONAL);
-  }
 
   constructor(private cdr: ChangeDetectorRef) {}
 

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -21,12 +21,7 @@
           [vehicleTechRecord]="vehicleTechRecord"
         ></app-tech-record-history>
 
-        <app-test-record-summary
-          *appRoleRequired="roles.TestResultView"
-          [testRecords]="(records$ | async) || []"
-          [currentTechRecord]="(currentTechRecord$ | async) || undefined"
-        >
-        </app-test-record-summary>
+        <app-test-record-summary *appRoleRequired="roles.TestResultView" [testRecords]="(records$ | async) || []"> </app-test-record-summary>
 
         <ng-container *ngIf="!isArchived && !isEditing">
           <app-test-record-create-button *appRoleRequired="[roles.TestResultCreateContingency, roles.TestResultCreateDeskAssesment]">

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -27,6 +27,11 @@
           [currentTechRecord]="(currentTechRecord$ | async) || undefined"
         >
         </app-test-record-summary>
+
+        <ng-container *ngIf="!isArchived && !isEditing">
+          <app-test-record-create-button *appRoleRequired="[roles.TestResultCreateContingency, roles.TestResultCreateDeskAssesment]">
+          </app-test-record-create-button>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -57,7 +57,7 @@ describe('VehicleTechnicalRecordComponent', () => {
         {
           provide: UserService,
           useValue: {
-            roles$: of(['TestResult.View'])
+            roles$: of(['TestResult.View', 'TestResult.CreateContingency'])
           }
         },
         {

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -30,6 +30,7 @@ export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
 
   isDirty = false;
   isCurrent = false;
+  isArchived = false;
   isInvalid = false;
   isEditing = false;
   editingReason?: ReasonForEditing;
@@ -47,9 +48,12 @@ export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
-    this.currentTechRecord$ = this.technicalRecordService
-      .viewableTechRecord$(this.vehicleTechRecord!)
-      .pipe(tap(viewableTechRecord => (this.isCurrent = viewableTechRecord?.statusCode === StatusCodes.CURRENT)));
+    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$(this.vehicleTechRecord!).pipe(
+      tap(viewableTechRecord => {
+        this.isCurrent = viewableTechRecord?.statusCode === StatusCodes.CURRENT;
+        this.isArchived = viewableTechRecord?.statusCode === StatusCodes.ARCHIVED;
+      })
+    );
   }
 
   ngAfterViewInit(): void {

--- a/src/app/features/tech-record/tech-record.module.ts
+++ b/src/app/features/tech-record/tech-record.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { SharedModule } from '@shared/shared.module';
 import { DynamicFormsModule } from '../../forms/dynamic-forms.module';
 import { TestRecordSummaryComponent } from './components/test-record-summary/test-record-summary.component';
+import { TestRecordCreateButtonComponent } from './components/test-record-create-button/test-record-create-button.component';
 import { TechRecordsRoutingModule } from './tech-record-routing.module';
 import { TechRecordComponent } from './tech-record.component';
 import { TechRecordHistoryComponent } from './components/tech-record-history/tech-record-history.component';
@@ -22,6 +23,7 @@ import { TechRecordTitleComponent } from './components/tech-record-title/tech-re
     TechRecordHistoryComponent,
     TechRecordSummaryComponent,
     TestRecordSummaryComponent,
+    TestRecordCreateButtonComponent,
     VehicleTechnicalRecordComponent,
     TechAmendReasonComponent,
     TyresSearchComponent,


### PR DESCRIPTION
Changes:
- Button to create a test is now no longer visible when editing a tech record
- Refactored code so that create test button is it's own component

Non-edit mode:
![image](https://user-images.githubusercontent.com/92087051/207307326-093e2442-b356-45a2-a420-31017dfe14af.png)

Edit Mode:
![image](https://user-images.githubusercontent.com/92087051/207307234-634c73b5-287c-459a-b3a9-0516579310ba.png)

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6967)

