### PR TITLE
feat(cb2-6988): sort users before storing in state

### DIFF
--- a/src/app/store/reference-data/effects/operators/index.ts
+++ b/src/app/store/reference-data/effects/operators/index.ts
@@ -1,0 +1,1 @@
+export * from './reference-data.operators';

--- a/src/app/store/reference-data/effects/operators/reference-data.operators.spec.ts
+++ b/src/app/store/reference-data/effects/operators/reference-data.operators.spec.ts
@@ -1,0 +1,54 @@
+import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { of, take } from 'rxjs';
+import { handleNotFound, sortReferenceData } from './reference-data.operators';
+
+describe('Reference data operators', () => {
+  describe(handleNotFound.prototype.name, () => {
+    it('should emit source observable when there is data', done => {
+      of({ data: [{ resourceType: 'type', resourceKey: 'key' }] })
+        .pipe(take(1), handleNotFound('test'))
+        .subscribe({
+          next: val => {
+            expect(val).toEqual({ data: [{ resourceType: 'type', resourceKey: 'key' }] });
+            done();
+          }
+        });
+    });
+    it('should throw an error if data is empty', done => {
+      of({ data: [] })
+        .pipe(take(1), handleNotFound('test'))
+        .subscribe({
+          error: e => {
+            expect(e.message).toBe('Reference data not found for resource type test');
+            done();
+          }
+        });
+    });
+  });
+
+  describe(sortReferenceData.prototype.name, () => {
+    it('should sort strings', done => {
+      of({
+        data: [
+          { resourceType: ReferenceDataResourceType.User, resourceKey: 2, name: 'last name' },
+          { resourceType: ReferenceDataResourceType.User, resourceKey: 3, name: 'some name' },
+          { resourceType: ReferenceDataResourceType.User, resourceKey: 1, name: 'a name' }
+        ]
+      })
+        .pipe(take(1), sortReferenceData(ReferenceDataResourceType.User))
+        .subscribe({
+          next: val => {
+            expect(val).toEqual({
+              data: [
+                { resourceType: ReferenceDataResourceType.User, resourceKey: 1, name: 'a name' },
+                { resourceType: ReferenceDataResourceType.User, resourceKey: 2, name: 'last name' },
+                { resourceType: ReferenceDataResourceType.User, resourceKey: 3, name: 'some name' }
+              ]
+            });
+            done();
+          },
+          error: e => console.log('*** MCAD ***:', e)
+        });
+    });
+  });
+});

--- a/src/app/store/reference-data/effects/operators/reference-data.operators.ts
+++ b/src/app/store/reference-data/effects/operators/reference-data.operators.ts
@@ -1,0 +1,66 @@
+import { ReferenceDataApiResponse, ReferenceDataItem } from '@api/reference-data';
+import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { Observable } from 'rxjs';
+
+/**
+ * handles response from reference data API to throw an error if not found i.e. response is a success with empty objects or no data.
+ * @param args - lookup properties used by the API. will be used to construct error message when not found.
+ * @returns emitted source value or error if response is equivalent to not found.
+ */
+export function handleNotFound(...args: any[]) {
+  return function <T>(source: Observable<T>): Observable<T> {
+    const isEmpty = (val: any) => !Object.keys(val).length || (val.hasOwnProperty('data') && !val.data.length);
+    return new Observable(subscriber => {
+      source.subscribe({
+        next: val => {
+          if (val && isEmpty(val)) {
+            subscriber.error(new Error(`Reference data not found for resource type ${args}`));
+          }
+
+          subscriber.next(val);
+        },
+        error: e => subscriber.error(e),
+        complete: () => subscriber.complete()
+      });
+    });
+  };
+}
+
+export function sortReferenceData(resourceType: ReferenceDataResourceType) {
+  return function (source: Observable<ReferenceDataApiResponse>): Observable<ReferenceDataApiResponse> {
+    return new Observable(subscriber => {
+      source.subscribe({
+        next: val => {
+          const { data } = val;
+          subscriber.next({ ...val, data: _sort(resourceType, data) });
+        },
+        error: e => subscriber.error(e),
+        complete: () => subscriber.complete()
+      });
+    });
+  };
+}
+
+function _sort(type: ReferenceDataResourceType, data: ReferenceDataItem[]) {
+  const _data = [...(data as ReferenceData[])];
+  switch (type) {
+    case ReferenceDataResourceType.User:
+      return _data.sort(sorter('name'));
+    default:
+      return _data;
+  }
+}
+
+type ReferenceData = ReferenceDataItem & Record<string, string | number>;
+function sorter(sortkey: keyof ReferenceData | undefined = 'description') {
+  const compare = (a: any, b: any) => (typeof a === 'string' ? (a <= b ? (a < b ? -1 : 0) : 1) : a - b);
+  return (a: ReferenceData, b: ReferenceData) => {
+    let l, r;
+    if (sortkey && a.hasOwnProperty(sortkey)) {
+      l = a[sortkey];
+      r = b[sortkey];
+    }
+
+    return compare(l, r);
+  };
+}

--- a/src/app/store/reference-data/reducers/reference-data.reducer.ts
+++ b/src/app/store/reference-data/reducers/reference-data.reducer.ts
@@ -17,7 +17,7 @@ import {
   fetchTyreReferenceDataByKeySearchSuccess,
   removeTyreSearch
 } from '../actions/reference-data.actions';
-import { isResourceType } from '../selectors/reference-data.selectors';
+
 export const STORE_FEATURE_REFERENCE_DATA_KEY = 'referenceData';
 
 const selectResourceKey = (a: ReferenceDataModelBase): string | number => {
@@ -84,9 +84,7 @@ export const referenceDataReducer = createReducer(
       [resourceType]: { ...resourceTypeAdapters[resourceType].upsertMany(payload, state[resourceType]), loading: paginated }
     };
   }),
-
   on(fetchReferenceDataFailed, (state, action) => ({ ...state, [action.resourceType]: { ...state[action.resourceType], loading: false } })),
-
   on(fetchReferenceDataByKey, (state, action) => ({ ...state, [action.resourceType]: { ...state[action.resourceType], loading: true } })),
   on(fetchReferenceDataByKeySuccess, (state, action) => {
     const { resourceType, payload } = action;
@@ -96,7 +94,6 @@ export const referenceDataReducer = createReducer(
     };
   }),
   on(fetchReferenceDataByKeyFailed, (state, action) => ({ ...state, [action.resourceType]: { ...state[action.resourceType], loading: false } })),
-
   on(fetchReferenceDataByKeySearch, (state, action) => ({
     ...state,
     [action.resourceType]: { ...state[action.resourceType], searchReturn: null, loading: true }
@@ -112,7 +109,6 @@ export const referenceDataReducer = createReducer(
     ...state,
     [action.resourceType]: { ...state[action.resourceType], searchReturn: null, loading: false, filter: null, term: null }
   })),
-
   on(fetchTyreReferenceDataByKeySearch, (state, action) => ({
     ...state,
     [ReferenceDataResourceType.Tyres]: { ...state[ReferenceDataResourceType.Tyres], searchReturn: null, loading: true }


### PR DESCRIPTION
## Update VTM to use the (alphabetically sorted) ReferenceData as the source of USER data ('USER' is the key)

[CB2-6988](https://dvsa.atlassian.net/browse/CB2-6988)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
