### PR TITLE
feature(cb2-6989): allow the autocomplete to be fully resizable

### DIFF
--- a/src/app/forms/components/autocomplete/autocomplete.component.scss
+++ b/src/app/forms/components/autocomplete/autocomplete.component.scss
@@ -1,5 +1,4 @@
 .autocomplete__wrapper {
-  width: 30rem;
   z-index: 0;
 
   .govuk-label,
@@ -13,8 +12,6 @@
 }
 
 .internal-wrapper {
-  align-items: flex-start;
-  display: flex;
   margin-top: 10px;
 
   .prefix {

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
@@ -10,6 +10,7 @@
     [options$]="options"
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
+    [width]="control.value.meta.width"
   ></app-autocomplete>
 
   <app-date

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-vehicle-section.template.ts
@@ -30,8 +30,8 @@ export const ContingencyVehicleSectionDefaultPsvHgv: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL,
       asyncValidators: [{ name: AsyncValidatorNames.RequiredIfNotAbandoned }]

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
@@ -30,8 +30,9 @@ export const ContingencyVehicleSectionDefaultTrl: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      width: FormNodeWidth.XXL,
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL,
       asyncValidators: [{ name: AsyncValidatorNames.RequiredIfNotAbandoned }]

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-vehicle-section.template.ts
@@ -29,8 +29,9 @@ export const VehicleSectionDefaultPsvHgv: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      width: FormNodeWidth.XXL,
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL,
       validators: [{ name: ValidatorNames.Required }]

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
@@ -31,8 +31,9 @@ export const VehicleSectionDefaultTrl: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      width: FormNodeWidth.XXL,
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL,
       validators: [{ name: ValidatorNames.Required }]

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
@@ -27,8 +27,9 @@ export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      width: FormNodeWidth.XXL,
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
@@ -28,8 +28,9 @@ export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      width: FormNodeWidth.XXL,
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
@@ -26,8 +26,9 @@ export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
       name: 'countryOfRegistration',
       label: 'Country Of Registration',
       value: '',
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
       options: [],
+      width: FormNodeWidth.XXL,
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.CountryOfRegistration,
       type: FormNodeTypes.CONTROL
     },

--- a/src/app/forms/templates/test-records/section-templates/visit/contingency-visit-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/visit/contingency-visit-section.template.ts
@@ -37,6 +37,7 @@ export const ContingencyVisitSection: FormNode = {
       name: 'testerStaffId',
       type: FormNodeTypes.CONTROL,
       label: 'Tester details',
+      width: FormNodeWidth.XXL,
       viewType: FormNodeViewTypes.HIDDEN,
       editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.User,

--- a/src/app/forms/templates/test-records/section-templates/visit/visit-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/visit/visit-section.template.ts
@@ -48,6 +48,7 @@ export const VisitSection: FormNode = {
       name: 'testerStaffId',
       type: FormNodeTypes.CONTROL,
       label: 'Tester details',
+      width: FormNodeWidth.XXL,
       viewType: FormNodeViewTypes.HIDDEN,
       editType: FormNodeEditTypes.AUTOCOMPLETE,
       referenceData: ReferenceDataResourceType.User,


### PR DESCRIPTION
## Update the VTM UI to make the Tester Details dropdown box wider (full width?)

- Update the autocomplete component, enabling it to extend beyond 30 rem.
- Update the dynamic form field to pass on the width into the autocomplete.

[CB2-6989](https://dvsa.atlassian.net/browse/CB2-6989)