### PR TITLE
fix(cb2-6881): fix axle spacing issues with blank submissions

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -261,7 +261,6 @@ export class TechRecordSummaryComponent implements OnInit {
     let i = previousAxles ? previousAxles.length : 0;
 
     for (i; i < vehicleAxleSpacingsLength + 1; i++) {
-      const axleNumber = previousAxles ? i + 1 : i;
       axles.push(this.generateAxleObject(vehicleType, i + 1));
     }
 

--- a/src/app/forms/templates/hgv/hgv-dimensions.template.ts
+++ b/src/app/forms/templates/hgv/hgv-dimensions.template.ts
@@ -36,7 +36,7 @@ export const HgvDimensionsTemplate: FormNode = {
                 {
                   name: 'value',
                   label: 'Axle to axle (mm)',
-                  value: '',
+                  value: null,
                   editType: FormNodeEditTypes.NUMBER,
                   type: FormNodeTypes.CONTROL,
                   validators: [{ name: ValidatorNames.Max, args: 99999 }]

--- a/src/app/forms/templates/trl/trl-dimensions.template.ts
+++ b/src/app/forms/templates/trl/trl-dimensions.template.ts
@@ -37,7 +37,7 @@ export const TrlDimensionsTemplate: FormNode = {
                 {
                   name: 'value',
                   label: 'Axle to axle (mm)',
-                  value: '',
+                  value: null,
                   editType: FormNodeEditTypes.NUMBER,
                   type: FormNodeTypes.CONTROL,
                   validators: [{ name: ValidatorNames.Max, args: 99999 }]


### PR DESCRIPTION
## Spacing between axles shows an error when user removes axle 2 from the PSV vehicle

If you submitted after adding a blank spacing, and never clicked on the box it sent the default value of '' but that is not a number. Null is allowed.
[https://dvsa.atlassian.net/browse/CB2-6881](6881)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
