### PR TITLE
fix(cb2-6999): fix changing test type on desk-based tests

### DIFF
--- a/src/app/store/test-records/reducers/test-records.reducer.ts
+++ b/src/app/store/test-records/reducers/test-records.reducer.ts
@@ -128,15 +128,14 @@ function removeDefectAtIndex(testResultState: TestResultModel | undefined, index
 }
 
 function calculateTestResult(testResultState: TestResultModel | undefined): TestResultModel | undefined {
-  // don't update test result for DBA
-  if (!testResultState || TypeOfTest.DESK_BASED === testResultState?.typeOfTest) {
+  if (!testResultState) {
     return;
   }
 
   const testResult = cloneDeep(testResultState);
 
   const newTestTypes = testResult.testTypes.map(testType => {
-    if (testType.testResult === resultOfTestEnum.abandoned || !testType.defects) {
+    if (testType.testResult === resultOfTestEnum.abandoned || !testType.defects || TypeOfTest.DESK_BASED === testResultState?.typeOfTest) {
       return testType;
     }
 


### PR DESCRIPTION
## fix changing test type on desk-based tests

Can't change test test type for desk based test because the calculate result returns `void` which "deletes" the test type in the resolver, meaning it would default to the existing record in state. 

Instead of returning `void` the calculate result should return `testType` unchanged.

> Note:
We probably need to look into the impact of the `defectsHiddenSection` on this function since it relies on the presence or absence of `defects` as a key in the test type to calculate the result. If defects is empty array, it sets the result to a pass, so we need to investigate if things are still working properly.

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
