### PR TITLE
Use name rather than username for createdBy field

### DIFF
--- a/src/app/services/test-records/test-records.service.ts
+++ b/src/app/services/test-records/test-records.service.ts
@@ -99,16 +99,16 @@ export class TestRecordsService {
 
   saveTestResult(
     systemNumber: string,
-    user: { username: string; id?: string },
+    user: { name: string; id?: string },
     body: TestResultModel,
     observe?: 'body',
     reportProgress?: boolean
   ): Observable<TestResultModel> {
-    const { username, id } = user;
+    const { name, id } = user;
     const tr = cloneDeep(body);
     delete tr.testHistory;
     return this.updateTestResultsService.testResultsSystemNumberPut(
-      { msUserDetails: { msOid: id, msUser: username }, testResult: tr as any } as CompleteTestResults,
+      { msUserDetails: { msOid: id, msUser: name }, testResult: tr as any } as CompleteTestResults,
       systemNumber,
       observe,
       reportProgress

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -112,7 +112,7 @@ describe('TestResultsEffects', () => {
         }),
         {
           provide: UserService,
-          useValue: { user$: of({ name: 'testername', username: 'username', oid: '123zxc' }), userName$: of('username'), id$: of('iod') }
+          useValue: { user$: of({ name: 'testername', username: 'username', oid: '123zxc' }), name$: of('name'), id$: of('iod') }
         },
         RouterService,
         DynamicFormService

--- a/src/app/store/test-records/effects/test-records.effects.ts
+++ b/src/app/store/test-records/effects/test-records.effects.ts
@@ -86,13 +86,10 @@ export class TestResultsEffects {
     this.actions$.pipe(
       ofType(updateTestResult),
       mergeMap(action =>
-        of(action.value).pipe(
-          withLatestFrom(this.userService.userName$, this.userService.id$, this.store.pipe(select(selectRouteNestedParams))),
-          take(1)
-        )
+        of(action.value).pipe(withLatestFrom(this.userService.name$, this.userService.id$, this.store.pipe(select(selectRouteNestedParams))), take(1))
       ),
-      mergeMap(([testResult, username, id, { systemNumber }]) => {
-        return this.testRecordsService.saveTestResult(systemNumber, { username, id }, testResult).pipe(
+      mergeMap(([testResult, name, id, { systemNumber }]) => {
+        return this.testRecordsService.saveTestResult(systemNumber, { name, id }, testResult).pipe(
           take(1),
           map(responseBody => updateTestResultSuccess({ payload: { id: responseBody.testResultId, changes: responseBody } })),
           catchError(e => {


### PR DESCRIPTION
## Description

The logged-in user's **username** is used for **Created by**, rather than **name**.
[CB2-7042](https://dvsa.atlassian.net/browse/CB2-7042)
![image](https://user-images.githubusercontent.com/13391709/207645415-7bd6981d-6f40-4089-9264-c08119e7d69e.png)

## Evidence of Completion

Amending a test result has the user's **name** in **Created by**.
![image](https://user-images.githubusercontent.com/13391709/207645966-f398859a-2b6e-469f-8fc0-e207cf1b1623.png)

