### PR TITLE
fix(cb2-7043): record user name instead of email against edits

### DIFF
--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -65,20 +65,18 @@ export class TechnicalRecordService {
   putUpdateTechRecords(
     systemNumber: string,
     techRecord: TechRecordModel,
-    user: { username: string; id?: string },
+    user: { id?: string; name: string },
     recordToArchiveStatus?: StatusCodes,
     newStatus?: StatusCodes
   ) {
-    const { username, id } = user;
-    const url = `${environment.VTM_API_URI}/vehicles/${systemNumber}` + `${recordToArchiveStatus ? '?oldStatusCode=' + recordToArchiveStatus : ''}`;
     const newTechRecord = cloneDeep(techRecord);
-
     newTechRecord.statusCode = newStatus ?? newTechRecord.statusCode;
-
     this.removeUpdateType(techRecord, newTechRecord);
 
+    const url = `${environment.VTM_API_URI}/vehicles/${systemNumber}` + `${recordToArchiveStatus ? '?oldStatusCode=' + recordToArchiveStatus : ''}`;
+
     const body = {
-      msUserDetails: { msOid: id, msUser: username },
+      msUserDetails: { msOid: user.id, msUser: user.name },
       techRecord: [newTechRecord]
     };
 
@@ -91,27 +89,27 @@ export class TechnicalRecordService {
     }
   }
 
-  postProvisionalTechRecord(systemNumber: string, techRecord: TechRecordModel, user: { username: string; id?: string }) {
+  postProvisionalTechRecord(systemNumber: string, techRecord: TechRecordModel, user: { id?: string; name: string }) {
     // THIS ALLOWS US TO CREATE PROVISIONAL FROM THE CURRENT TECH RECORD
     const recordCopy = cloneDeep(techRecord);
     recordCopy.statusCode = StatusCodes.PROVISIONAL;
     this.removeUpdateType(techRecord, recordCopy);
 
-    const { username, id } = user;
     const url = `${environment.VTM_API_URI}/vehicles/add-provisional/${systemNumber}`;
+
     const body = {
-      msUserDetails: { msOid: id, msUser: username },
+      msUserDetails: { msOid: user.id, msUser: user.name },
       techRecord: [recordCopy]
     };
 
     return this.http.post<VehicleTechRecordModel>(url, body, { responseType: 'json' });
   }
 
-  archiveTechnicalRecord(systemNumber: string, techRecord: TechRecordModel, reason: string, user: { id?: string; username: string }) {
+  archiveTechnicalRecord(systemNumber: string, techRecord: TechRecordModel, reason: string, user: { id?: string; name: string }) {
     const url = `${environment.VTM_API_URI}/vehicles/archive/${systemNumber}`;
 
     const body = {
-      msUserDetails: { msOid: user.id, msUser: user.username },
+      msUserDetails: { msOid: user.id, msUser: user.name },
       techRecord: [techRecord],
       reasonForArchiving: reason
     };

--- a/src/app/services/user-service/user-service.ts
+++ b/src/app/services/user-service/user-service.ts
@@ -41,7 +41,7 @@ export class UserService implements OnDestroy {
   logIn({ name, username, oid, accessToken }: { name: string; username: string; oid: string; accessToken: string }): void {
     const decodedJWT = jwt_decode(accessToken);
     const roles: string[] = (decodedJWT as any).roles;
-    this.store.dispatch(UserServiceActions.Login({ name, oid, username, roles }));
+    this.store.dispatch(UserServiceActions.Login({ name, username, oid, roles }));
   }
 
   get name$(): Observable<string> {

--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -104,10 +104,10 @@ export class TechnicalRecordServiceEffects {
   updateTechnicalRecord$ = createEffect(() =>
     this.actions$.pipe(
       ofType(updateTechRecords),
-      withLatestFrom(this.technicalRecordService.editableTechRecord$, this.userService.userName$, this.userService.id$),
-      switchMap(([action, record, username, id]) =>
+      withLatestFrom(this.technicalRecordService.editableTechRecord$, this.userService.name$, this.userService.id$),
+      switchMap(([action, record, name, id]) =>
         this.technicalRecordService
-          .putUpdateTechRecords(action.systemNumber, record!, { username, id }, action.recordToArchiveStatus, action.newStatus)
+          .putUpdateTechRecords(action.systemNumber, record!, { id, name }, action.recordToArchiveStatus, action.newStatus)
           .pipe(
             map(vehicleTechRecord => updateTechRecordsSuccess({ vehicleTechRecords: [vehicleTechRecord] })),
             catchError(error => of(updateTechRecordsFailure({ error: this.getTechRecordErrorMessage(error, 'updateTechnicalRecord') })))
@@ -119,9 +119,9 @@ export class TechnicalRecordServiceEffects {
   postProvisionalTechRecord = createEffect(() =>
     this.actions$.pipe(
       ofType(createProvisionalTechRecord),
-      withLatestFrom(this.technicalRecordService.editableTechRecord$, this.userService.userName$, this.userService.id$),
-      switchMap(([action, record, username, id]) =>
-        this.technicalRecordService.postProvisionalTechRecord(action.systemNumber, record!, { username, id }).pipe(
+      withLatestFrom(this.technicalRecordService.editableTechRecord$, this.userService.name$, this.userService.id$),
+      switchMap(([action, record, name, id]) =>
+        this.technicalRecordService.postProvisionalTechRecord(action.systemNumber, record!, { id, name }).pipe(
           map(vehicleTechRecord => createProvisionalTechRecordSuccess({ vehicleTechRecords: [vehicleTechRecord] })),
           catchError(error => of(createProvisionalTechRecordFailure({ error: this.getTechRecordErrorMessage(error, 'createProvisionalTechRecord') })))
         )
@@ -132,9 +132,9 @@ export class TechnicalRecordServiceEffects {
   archiveTechRecord = createEffect(() =>
     this.actions$.pipe(
       ofType(archiveTechRecord),
-      withLatestFrom(this.technicalRecordService.editableTechRecord$, this.userService.userName$, this.userService.id$),
-      switchMap(([action, record, username, id]) =>
-        this.technicalRecordService.archiveTechnicalRecord(action.systemNumber, record!, action.reasonForArchiving, { username, id }).pipe(
+      withLatestFrom(this.technicalRecordService.editableTechRecord$, this.userService.name$, this.userService.id$),
+      switchMap(([action, record, name, id]) =>
+        this.technicalRecordService.archiveTechnicalRecord(action.systemNumber, record!, action.reasonForArchiving, { id, name }).pipe(
           map(vehicleTechRecord => archiveTechRecordSuccess({ vehicleTechRecords: [vehicleTechRecord] })),
           catchError(error => of(archiveTechRecordFailure({ error: this.getTechRecordErrorMessage(error, 'archiveTechRecord') })))
         )


### PR DESCRIPTION
## When amending a tech record the users email is saved to the createdBy field

[CB2-7043](https://dvsa.atlassian.net/browse/CB2-7043)
