### PR TITLE
CB2-6054 Fix userEmail disappearing

### DIFF
--- a/src/app/services/user-service/user-service.spec.ts
+++ b/src/app/services/user-service/user-service.spec.ts
@@ -43,7 +43,7 @@ describe('User-Service', () => {
       service.logIn(user);
     });
 
-    it('should get the username', done => {
+    it('should get the userEmail', done => {
       service.userEmail$.pipe(take(1)).subscribe(data => {
         expect(data).toEqual(user.userEmail);
         done();

--- a/src/app/store/user/user-state.module.ts
+++ b/src/app/store/user/user-state.module.ts
@@ -5,7 +5,7 @@ import { localStorageSync } from 'ngrx-store-localstorage';
 import { STORE_FEATURE_USER_KEY, userServiceReducer } from './user-service.reducer';
 
 export function localStorageSyncReducer(reducer: ActionReducer<any>): ActionReducer<any> {
-  return localStorageSync({ keys: ['name', 'username', 'oid', 'roles'], rehydrate: true })(reducer);
+  return localStorageSync({ keys: ['name', 'userEmail', 'oid', 'roles'], rehydrate: true })(reducer);
 }
 
 const metaReducers: Array<MetaReducer<any, any>> = [localStorageSyncReducer];


### PR DESCRIPTION
The logged in users userEmail property was not being persisted to state correctly and would be lost during a users session.
