### PR TITLE
fix(cb2-7078): fix view test record from provisional tech record

### DIFF
--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -108,6 +108,13 @@ const routes: Routes = [
     loadChildren: () => import('../test-records/amend/amend-test-records.module').then(m => m.AmendTestRecordsModule)
   },
   {
+    path: 'provisional/test-records/test-result/:testResultId/:testNumber',
+    data: { title: 'Test record', roles: Roles.TestResultView },
+    canActivate: [MsalGuard, RoleGuard],
+    resolve: { techRecord: TechRecordViewResolver },
+    loadChildren: () => import('../test-records/amend/amend-test-records.module').then(m => m.AmendTestRecordsModule)
+  },
+  {
     path: 'test-records/create-test',
     data: { roles: Roles.TestResultCreateContingency },
     canActivate: [MsalGuard, RoleGuard],


### PR DESCRIPTION
## Unable to view test record from a provisional tech record

_Add a route for test records from provisional tech record_
[CB2-7078](https://dvsa.atlassian.net/browse/CB2-7078)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
