### PR TITLE
fix(cb-7173): brake code prefix appears alongside dropdown

### DIFF
--- a/src/app/forms/components/autocomplete/autocomplete.component.scss
+++ b/src/app/forms/components/autocomplete/autocomplete.component.scss
@@ -13,6 +13,7 @@
 
 .internal-wrapper {
   margin-top: 10px;
+  display: flex;
 
   .prefix {
     border: 2px solid #0b0c0c;


### PR DESCRIPTION
## CB-7173

https://dvsa.atlassian.net/browse/CB2-7173

I have added display flex to the internal-wrapper class so that when amending a vehicle technical record a PSV vehicle the prefix appears next to the dropdown rather than above it. 


