### PR TITLE
fix(cb2-7173): fixed brake code prefix resizing with input

### DIFF
--- a/src/app/forms/components/autocomplete/autocomplete.component.scss
+++ b/src/app/forms/components/autocomplete/autocomplete.component.scss
@@ -18,7 +18,7 @@
   .prefix {
     border: 2px solid #0b0c0c;
     border-right: 0;
-    height: unset;
+    height: fit-content;
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
## CB2-7173

css styling fix

https://dvsa.atlassian.net/browse/CB2-7173

## Checklist

issue where brake prefix was expanding to fit the drop down input fixed. 