### PR TITLE
Allow EU Vehicle Category to be editable in a test

### DIFF
--- a/src/app/forms/templates/car/car-tech-record.template.ts
+++ b/src/app/forms/templates/car/car-tech-record.template.ts
@@ -60,6 +60,7 @@ export const CarTechRecord: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     }

--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -156,6 +156,7 @@ export const HgvTechRecord: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/lgv/lgv-tech-record.template.ts
+++ b/src/app/forms/templates/lgv/lgv-tech-record.template.ts
@@ -59,6 +59,7 @@ export const LgvTechRecord: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     }

--- a/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
+++ b/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
@@ -61,6 +61,7 @@ export const MotorcycleTechRecord: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -128,6 +128,7 @@ export function getPsvTechRecord(_isEditing: boolean): FormNode {
         value: '',
         type: FormNodeTypes.CONTROL,
         editType: FormNodeEditTypes.SELECT,
+        width: FormNodeWidth.S,
         options: getOptionsFromEnum(EuVehicleCategories),
         validators: [{ name: ValidatorNames.Required }]
       },

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -59,6 +59,7 @@ export const SmallTrailerTechRecord: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     }

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-light-vehicle-section.template.ts
@@ -1,7 +1,9 @@
 import { AsyncValidatorNames } from '@forms/models/async-validators.enum';
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const ContingencyVehicleSectionDefaultPsvHgvLight: FormNode = {
   name: 'vehicleSection',
@@ -40,9 +42,10 @@ export const ContingencyVehicleSectionDefaultPsvHgvLight: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XXS
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'odometerReading',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-light-vehicle-section.template.ts
@@ -44,6 +44,7 @@ export const ContingencyVehicleSectionDefaultPsvHgvLight: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
@@ -46,6 +46,7 @@ export const ContingencyVehicleSectionDefaultTrl: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
@@ -1,6 +1,9 @@
 import { AsyncValidatorNames } from '@forms/models/async-validators.enum';
+import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const ContingencyVehicleSectionDefaultTrl: FormNode = {
   name: 'vehicleSection',
@@ -41,9 +44,10 @@ export const ContingencyVehicleSectionDefaultTrl: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XS
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'preparerName',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-light-vehicle-section.template.ts
@@ -44,6 +44,7 @@ export const VehicleSectionDefaultPsvHgvLight: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-light-vehicle-section.template.ts
@@ -1,6 +1,8 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const VehicleSectionDefaultPsvHgvLight: FormNode = {
   name: 'vehicleSection',
@@ -40,9 +42,10 @@ export const VehicleSectionDefaultPsvHgvLight: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
-      width: FormNodeWidth.XXS,
-      type: FormNodeTypes.CONTROL
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'odometerCombination',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
@@ -1,6 +1,8 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const VehicleSectionDefaultTrl: FormNode = {
   name: 'vehicleSection',
@@ -42,9 +44,10 @@ export const VehicleSectionDefaultTrl: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
-      width: FormNodeWidth.XXS,
-      type: FormNodeTypes.CONTROL
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'preparerCombination',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
@@ -46,6 +46,7 @@ export const VehicleSectionDefaultTrl: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
@@ -41,6 +41,7 @@ export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
@@ -1,6 +1,8 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
   name: 'vehicleSection',
@@ -37,9 +39,10 @@ export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XXS
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'odometerReading',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
@@ -43,6 +43,7 @@ export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
@@ -1,5 +1,8 @@
+import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
   name: 'vehicleSection',
@@ -38,9 +41,10 @@ export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XXS
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'preparerName',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
@@ -1,5 +1,8 @@
+import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
   name: 'vehicleSection',
@@ -36,9 +39,10 @@ export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
       name: 'euVehicleCategory',
       label: 'EU Vehicle Category',
       value: '',
-      disabled: true,
       type: FormNodeTypes.CONTROL,
-      width: FormNodeWidth.XXS
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(EuVehicleCategories),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'odometerReading',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
@@ -41,6 +41,7 @@ export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -159,6 +159,7 @@ export const TrlTechRecordTemplate: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
       options: getOptionsFromEnum(EuVehicleCategories),
       validators: [{ name: ValidatorNames.Required }]
     },


### PR DESCRIPTION
## Description
Currently the EU Vehicle Category field is disabled when creating/amending a test for a vehicle. This restriction needs to be changed so the user can add or amend the EU Vehicle Category.
[CB2-7221](https://dvsa.atlassian.net/browse/CB2-7221)

Ticket created to [Move EU Vehicle Category to the reference data service](https://dvsa.atlassian.net/browse/CB2-7231). This is to restore the template back to pure json.