### PR TITLE
fix(cb2-7192): fix how reference data labels are mapped

### DIFF
--- a/src/app/services/reference-data/reference-data.service.spec.ts
+++ b/src/app/services/reference-data/reference-data.service.spec.ts
@@ -1,11 +1,14 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { ReferenceDataApiResponse, ReferenceDataService as ReferenceDataApiService } from '@api/reference-data';
-import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { MultiOptions } from '@forms/models/options.model';
+import { ReferenceDataModelBase, ReferenceDataResourceType, User } from '@models/reference-data.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { initialAppState } from '@store/.';
 import { initialReferenceDataState, STORE_FEATURE_REFERENCE_DATA_KEY } from '@store/reference-data';
+import { ReferenceDataStateModule } from '@store/reference-data/reference-data.module';
 import { testCases } from '@store/reference-data/reference-data.test-cases';
+import { concat, concatMap, firstValueFrom, of, switchMap, take } from 'rxjs';
 import { ReferenceDataService } from './reference-data.service';
 
 describe('ReferenceDataService', () => {
@@ -180,6 +183,45 @@ describe('ReferenceDataService', () => {
           description: 'Alderney - GBA'
         });
         done();
+      });
+    });
+  });
+
+  describe('helper function', () => {
+    describe('mapReferenceDataOptions', () => {
+      it.each([
+        {
+          refData: [
+            {
+              resourceType: ReferenceDataResourceType.Brake,
+              resourceKey: 'banana',
+              description: 'yellow'
+            }
+          ] as ReferenceDataModelBase[],
+          output: [{ label: 'yellow', value: 'banana' }] as MultiOptions
+        },
+        {
+          refData: [
+            {
+              resourceType: ReferenceDataResourceType.User,
+              resourceKey: 'mike@mail.com',
+              name: 'Mike'
+            }
+          ] as Array<ReferenceDataModelBase & Partial<User>>,
+          output: [{ label: 'Mike', value: 'mike@mail.com' }]
+        },
+        {
+          refData: [
+            {
+              resourceType: ReferenceDataResourceType.User,
+              resourceKey: 'mike@mail.com'
+            }
+          ] as Array<ReferenceDataModelBase & Partial<User>>,
+          output: [{ label: 'mike@mail.com', value: 'mike@mail.com' }]
+        }
+      ])('should return MultiOption Array with description as label', async ({ refData, output }) => {
+        const options = await firstValueFrom(of(refData).pipe(take(1), service['mapReferenceDataOptions']));
+        expect(options).toEqual(output);
       });
     });
   });


### PR DESCRIPTION
## Tester Details not being fetched correctly

_VTM can detect that there are multiple entries for the Tester Details, but does not display them correctly_
[CB2-7192](https://dvsa.atlassian.net/browse/CB2-7192)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
