### PR TITLE
feat(cb2-397): add new vehicle body types

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -2,24 +2,23 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
 import { BodyComponent } from '@forms/custom-sections/body/body.component';
 import { DimensionsComponent } from '@forms/custom-sections/dimensions/dimensions.component';
+import { PsvBrakesComponent } from '@forms/custom-sections/psv-brakes/psv-brakes.component';
+import { TrlBrakesComponent } from '@forms/custom-sections/trl-brakes/trl-brakes.component';
+import { TyresComponent } from '@forms/custom-sections/tyres/tyres.component';
 import { WeightsComponent } from '@forms/custom-sections/weights/weights.component';
 import { FormNode } from '@forms/services/dynamic-form.types';
+import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
+import { BodyTypeCode, vehicleBodyTypeCodeMap } from '@models/body-type-enum';
+import { PsvMake, ReferenceDataResourceType } from '@models/reference-data.model';
 import { Axle, AxleSpacing, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
-import { Action, Store } from '@ngrx/store';
+import { Store } from '@ngrx/store';
+import { ReferenceDataService } from '@services/reference-data/reference-data.service';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { State } from '@store/index';
+import { ReferenceDataState, selectReferenceDataByResourceKey } from '@store/reference-data';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
-import { TyresComponent } from '@forms/custom-sections/tyres/tyres.component';
-import { TrlBrakesComponent } from '@forms/custom-sections/trl-brakes/trl-brakes.component';
-import { PsvBrakesComponent } from '@forms/custom-sections/psv-brakes/psv-brakes.component';
-import { BodyTypeCode, bodyTypeCodeMap } from '@models/body-type-enum';
-import { ReferenceDataResourceType, PsvMake } from '@models/reference-data.model';
-import { ReferenceDataState, selectReferenceDataByResourceKey } from '@store/reference-data';
 import { map, Observable, take } from 'rxjs';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
-import { ReferenceDataService } from '@services/reference-data/reference-data.service';
-import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
-import { State } from '@store/index';
-import { updateEditingTechRecordCancel } from '@store/technical-records';
 
 @Component({
   selector: 'app-tech-record-summary',
@@ -108,7 +107,7 @@ export class TechRecordSummaryComponent implements OnInit {
     }
 
     if (event.brakes?.dtpNumber && (event.brakes.dtpNumber.length === 4 || event.brakes.dtpNumber.length === 6)) {
-      this.setBodyFields();
+      this.setBodyFields(this.vehicleTechRecordCalculated.vehicleType);
     }
 
     if (this.vehicleTechRecordCalculated.vehicleType === VehicleTypes.PSV && (event.grossKerbWeight || event.grossLadenWeight || event.brakes)) {
@@ -234,11 +233,11 @@ export class TechRecordSummaryComponent implements OnInit {
     return { axleNumber, weights, tyres };
   }
 
-  setBodyFields(): void {
+  setBodyFields(vehicleType: VehicleTypes): void {
     this.psvFromDtp$.pipe(take(1)).subscribe(payload => {
       const code = payload?.psvBodyType.toLowerCase() as BodyTypeCode;
 
-      this.vehicleTechRecordCalculated.bodyType = { code, description: bodyTypeCodeMap.get(code) };
+      this.vehicleTechRecordCalculated.bodyType = { code, description: vehicleBodyTypeCodeMap.get(vehicleType)?.get(code) };
       this.vehicleTechRecordCalculated.bodyMake = payload?.psvBodyMake;
       this.vehicleTechRecordCalculated.chassisMake = payload?.psvChassisMake;
       this.vehicleTechRecordCalculated.chassisModel = payload?.psvChassisModel;

--- a/src/app/models/body-type-enum.ts
+++ b/src/app/models/body-type-enum.ts
@@ -1,10 +1,19 @@
 // The types and codes need to be lowercase for the API.
 
+import { VehicleTypes } from './vehicle-tech-record.model';
+
 export enum BodyTypeDescription {
+  ARTIC = 'artic',
   ARTICULATED = 'articulated',
   BOX = 'box',
+  CAR_TRANSPORTER = 'car transporter',
+  CONCRETE_MIXER = 'concrete mixer',
+  CURTAINSIDER = 'curtainsider',
   DOUBLE_DECKER = 'double decker',
   FLAT = 'flat',
+  LIVESTOCK_CARRIER = 'livestock carrier',
+  LOW_LOADER = 'low loader',
+  MINI_BUS = 'mini bus',
   OTHER = 'other',
   PETROL_OR_OIL_TANKER = 'petrol/oil tanker',
   REFUSE = 'refuse',
@@ -12,7 +21,8 @@ export enum BodyTypeDescription {
   SINGLE_DECKER = 'single decker',
   SKELETAL = 'skeletal',
   SKIP_LOADER = 'skip loader',
-  TIPPER = 'tipper'
+  TIPPER = 'tipper',
+  TRACTOR = 'tractor'
 }
 
 export enum BodyTypeCode {
@@ -20,22 +30,34 @@ export enum BodyTypeCode {
   B = 'b',
   C = 'c',
   D = 'd',
+  E = 'e',
   F = 'f',
+  I = 'i',
   K = 'k',
+  L = 'l',
   M = 'm',
   O = 'o',
   P = 'p',
   R = 'r',
   S = 's',
   T = 't',
-  X = 'x'
+  U = 'u',
+  X = 'x',
+  Y = 'y'
 }
 
 export const bodyTypeMap = new Map<BodyTypeDescription, BodyTypeCode>([
+  [BodyTypeDescription.ARTIC, BodyTypeCode.U],
   [BodyTypeDescription.ARTICULATED, BodyTypeCode.A],
   [BodyTypeDescription.BOX, BodyTypeCode.K],
+  [BodyTypeDescription.CAR_TRANSPORTER, BodyTypeCode.Y],
+  [BodyTypeDescription.CONCRETE_MIXER, BodyTypeCode.M],
+  [BodyTypeDescription.CURTAINSIDER, BodyTypeCode.E],
   [BodyTypeDescription.DOUBLE_DECKER, BodyTypeCode.D],
   [BodyTypeDescription.FLAT, BodyTypeCode.T],
+  [BodyTypeDescription.LIVESTOCK_CARRIER, BodyTypeCode.I],
+  [BodyTypeDescription.LOW_LOADER, BodyTypeCode.L],
+  [BodyTypeDescription.MINI_BUS, BodyTypeCode.M],
   [BodyTypeDescription.OTHER, BodyTypeCode.O],
   [BodyTypeDescription.PETROL_OR_OIL_TANKER, BodyTypeCode.M],
   [BodyTypeDescription.REFUSE, BodyTypeCode.B],
@@ -43,20 +65,51 @@ export const bodyTypeMap = new Map<BodyTypeDescription, BodyTypeCode>([
   [BodyTypeDescription.SINGLE_DECKER, BodyTypeCode.S],
   [BodyTypeDescription.SKELETAL, BodyTypeCode.X],
   [BodyTypeDescription.SKIP_LOADER, BodyTypeCode.F],
-  [BodyTypeDescription.TIPPER, BodyTypeCode.P]
+  [BodyTypeDescription.TIPPER, BodyTypeCode.P],
+  [BodyTypeDescription.TRACTOR, BodyTypeCode.A]
 ]);
 
-export const bodyTypeCodeMap = new Map<BodyTypeCode, BodyTypeDescription>([
-  [BodyTypeCode.A, BodyTypeDescription.ARTICULATED],
+const commonBodyTypeCodeMap = new Map<BodyTypeCode, BodyTypeDescription>([
   [BodyTypeCode.K, BodyTypeDescription.BOX],
   [BodyTypeCode.D, BodyTypeDescription.DOUBLE_DECKER],
   [BodyTypeCode.T, BodyTypeDescription.FLAT],
   [BodyTypeCode.O, BodyTypeDescription.OTHER],
-  [BodyTypeCode.M, BodyTypeDescription.PETROL_OR_OIL_TANKER],
   [BodyTypeCode.B, BodyTypeDescription.REFUSE],
   [BodyTypeCode.R, BodyTypeDescription.REFRIGERATED],
   [BodyTypeCode.S, BodyTypeDescription.SINGLE_DECKER],
   [BodyTypeCode.X, BodyTypeDescription.SKELETAL],
   [BodyTypeCode.F, BodyTypeDescription.SKIP_LOADER],
   [BodyTypeCode.P, BodyTypeDescription.TIPPER]
+]);
+
+const psvBodyTypeCodeMap = new Map<BodyTypeCode, BodyTypeDescription>([
+  ...commonBodyTypeCodeMap.entries(),
+  [BodyTypeCode.A, BodyTypeDescription.ARTICULATED],
+  [BodyTypeCode.M, BodyTypeDescription.MINI_BUS]
+]);
+
+const hgvBodyTypeCodeMap = new Map<BodyTypeCode, BodyTypeDescription>([
+  ...commonBodyTypeCodeMap.entries(),
+  [BodyTypeCode.U, BodyTypeDescription.ARTIC],
+  [BodyTypeCode.Y, BodyTypeDescription.CAR_TRANSPORTER],
+  [BodyTypeCode.M, BodyTypeDescription.CONCRETE_MIXER],
+  [BodyTypeCode.E, BodyTypeDescription.CURTAINSIDER],
+  [BodyTypeCode.I, BodyTypeDescription.LIVESTOCK_CARRIER],
+  [BodyTypeCode.A, BodyTypeDescription.TRACTOR]
+]);
+
+const trlBodyTypeCodeMap = new Map<BodyTypeCode, BodyTypeDescription>([
+  ...commonBodyTypeCodeMap.entries(),
+  [BodyTypeCode.A, BodyTypeDescription.ARTICULATED],
+  [BodyTypeCode.Y, BodyTypeDescription.CAR_TRANSPORTER],
+  [BodyTypeCode.E, BodyTypeDescription.CURTAINSIDER],
+  [BodyTypeCode.L, BodyTypeDescription.LIVESTOCK_CARRIER],
+  [BodyTypeCode.L, BodyTypeDescription.LOW_LOADER],
+  [BodyTypeCode.M, BodyTypeDescription.PETROL_OR_OIL_TANKER]
+]);
+
+export const vehicleBodyTypeCodeMap = new Map<VehicleTypes, Map<BodyTypeCode, BodyTypeDescription>>([
+  [VehicleTypes.PSV, psvBodyTypeCodeMap],
+  [VehicleTypes.HGV, hgvBodyTypeCodeMap],
+  [VehicleTypes.TRL, trlBodyTypeCodeMap]
 ]);


### PR DESCRIPTION
## Add new Body Type values to VTM

- Create body-type maps for each vehicle-type
- Update tech record summary to use the right body-type map based on vehicle-type

[CB2-397](https://dvsa.atlassian.net/browse/CB2-397)