### PR TITLE
fix(cb2-7285): remap resourceKey as email for tester details

### DIFF
--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -84,7 +84,7 @@ export class CustomAsyncValidators {
           const testerEmail = control.parent?.get('testerEmailAddress');
           if (user && testerName && testerEmail) {
             testerName.setValue((user as User).name, { emitEvent: false, onlySelf: true });
-            testerEmail.setValue((user as User).email, { emitEvent: false, onlySelf: true });
+            testerEmail.setValue((user as User).resourceKey, { emitEvent: false, onlySelf: true });
           }
         }),
         map(() => null),


### PR DESCRIPTION
## Missing tester email

_When creating a test and picking a user from tester details field. The email is not being set because of the new USER reference data model. The email now come as the resourceKey (previously thought to be the staff ID)._
[CB2-7285](https://dvsa.atlassian.net/browse/CB2-7285)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
