### PR TITLE
fix(cb2-5712): psv required validation on dtp because bodytype is disabled

### DIFF
--- a/src/app/forms/templates/psv/psv-body.template.ts
+++ b/src/app/forms/templates/psv/psv-body.template.ts
@@ -18,7 +18,7 @@ export const PsvBodyTemplate: FormNode = {
           width: FormNodeWidth.S,
           type: FormNodeTypes.CONTROL,
           editType: FormNodeEditTypes.AUTOCOMPLETE,
-          validators: []
+          validators: [{ name: ValidatorNames.Required }]
         }
       ],
       type: FormNodeTypes.GROUP


### PR DESCRIPTION
Psv required validation on dtp because bodytype is disabled

https://dvsa.atlassian.net/browse/CB2-5712
https://dvsa.atlassian.net/browse/CB2-7398
