### PR TITLE
refactor(cb2-7456): big tech records refactor

### DIFF
--- a/src/app/features/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.html
+++ b/src/app/features/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.html
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-one-third">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <app-tech-record-title [vehicleTechRecord]="vehicle" [hideActions]="true"></app-tech-record-title>
+        <app-tech-record-title [vehicle]="vehicle" [hideActions]="true"></app-tech-record-title>
         <app-button id="submit-record-continue" (clicked)="handleSubmit()">Submit new record</app-button>
       </div>
     </div>
@@ -10,11 +10,7 @@
 
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-grid-column-full">
-      <app-tech-record-summary
-        [isEditing]="true"
-        [vehicleTechRecord]="vehicle.techRecord[0]"
-        (formChange)="handleFormState()"
-      ></app-tech-record-summary>
+      <app-tech-record-summary [techRecord]="vehicle.techRecord[0]" [isEditing]="true" (isFormInvalid)="isInvalid = $event"></app-tech-record-summary>
     </div>
   </div>
 </div>

--- a/src/app/features/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -36,6 +36,8 @@ export class HydrateNewVehicleRecordComponent {
   }
 
   handleSubmit() {
+    this.summary?.checkForms();
+
     if (!this.isInvalid) {
       this.store.dispatch(createVehicleRecord());
       this.actions$.pipe(ofType(createVehicleRecordSuccess), take(1)).subscribe(() => this.navigateBack());

--- a/src/app/features/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -1,10 +1,7 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { DynamicFormService } from '@forms/services/dynamic-form.service';
-import { CustomFormGroup, CustomFormArray } from '@forms/services/dynamic-form.types';
-import { VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -20,7 +17,6 @@ import { TechRecordSummaryComponent } from '../../../tech-record/components/tech
 export class HydrateNewVehicleRecordComponent {
   @ViewChild(TechRecordSummaryComponent) summary?: TechRecordSummaryComponent;
   isInvalid: boolean = false;
-  vehicleType?: VehicleTypes;
 
   constructor(
     private actions$: Actions,
@@ -35,48 +31,15 @@ export class HydrateNewVehicleRecordComponent {
     return this.technicalRecordService.editableVehicleTechRecord$.pipe(
       tap(vehicle => {
         if (!vehicle) this.navigateBack();
-        this.vehicleType = vehicle?.techRecord[0].vehicleType;
       })
     );
   }
 
-  get customSectionForms(): Array<CustomFormGroup> {
-    if (this.summary && this.vehicleType) {
-      const commonCustomSections = [this.summary.body.form, this.summary.dimensions.form, this.summary.tyres.form, this.summary.weights.form];
-
-      switch (this.vehicleType) {
-        case VehicleTypes.PSV:
-          return [...commonCustomSections, this.summary.psvBrakes!.form];
-        case VehicleTypes.HGV:
-          return commonCustomSections;
-        case VehicleTypes.TRL:
-          return [...commonCustomSections, this.summary.trlBrakes!.form];
-        default:
-          return [];
-      }
-    } else return [];
-  }
-
-  handleFormState(): void {
-    const form = this.summary?.sections.map(section => section.form).concat(this.customSectionForms);
-    if (form) {
-      this.isInvalid = this.isAnyFormInvalid(form);
-    }
-  }
-
   handleSubmit() {
-    this.handleFormState();
     if (!this.isInvalid) {
       this.store.dispatch(createVehicleRecord());
       this.actions$.pipe(ofType(createVehicleRecordSuccess), take(1)).subscribe(() => this.navigateBack());
     }
-  }
-
-  isAnyFormInvalid(forms: Array<CustomFormGroup | CustomFormArray>): boolean {
-    const errors: GlobalError[] = [];
-    forms.forEach(form => DynamicFormService.updateValidity(form, errors));
-    errors.length ? this.globalErrorService.setErrors(errors) : this.globalErrorService.clearErrors();
-    return forms.some(form => form.invalid);
   }
 
   navigateBack() {

--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.spec.ts
@@ -51,6 +51,8 @@ describe('EditTechRecordButtonComponent', () => {
     router = TestBed.inject(Router);
     store = TestBed.inject(MockStore);
     component = fixture.componentInstance;
+    component.vehicle = <VehicleTechRecordModel>{ techRecord: [<TechRecordModel>{ statusCode: 'current', vehicleType: 'psv' }] };
+    component.viewableTechRecord = component.vehicle.techRecord[0];
 
     fixture.detectChanges();
 
@@ -117,7 +119,7 @@ describe('EditTechRecordButtonComponent', () => {
         ]
       };
       store.overrideSelector(selectVehicleTechnicalRecordsBySystemNumber, expectedResult.vehicleTechRecords[0]);
-      component.vehicleTechRecord = <VehicleTechRecordModel>{ techRecord: [{ statusCode: 'current', vehicleType: 'psv' }] };
+      component.vehicle = <VehicleTechRecordModel>{ techRecord: [{ statusCode: 'current', vehicleType: 'psv' }] };
       component.viewableTechRecord = <TechRecordModel>{ statusCode: 'current', vehicleType: 'psv' };
       component.isEditing = true;
     });

--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -1,27 +1,27 @@
-import { Component, Input, OnInit, EventEmitter, Output } from '@angular/core';
+import { ViewportScroller } from '@angular/common';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import {
   createProvisionalTechRecordSuccess,
   selectVehicleTechnicalRecordsBySystemNumber,
   updateEditingTechRecordCancel,
   updateTechRecordsSuccess
 } from '@store/technical-records';
-import { ofType, Actions } from '@ngrx/effects';
-import { mergeMap, take, withLatestFrom } from 'rxjs';
-import { ActivatedRoute, Router } from '@angular/router';
-import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { ViewportScroller } from '@angular/common';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { take, withLatestFrom } from 'rxjs';
 
 @Component({
-  selector: 'app-edit-tech-record-button',
+  selector: 'app-edit-tech-record-button[vehicle][viewableTechRecord]',
   templateUrl: './edit-tech-record-button.component.html',
   styleUrls: ['./edit-tech-record-button.component.scss']
 })
 export class EditTechRecordButtonComponent implements OnInit {
-  @Input() vehicleTechRecord?: VehicleTechRecordModel;
-  @Input() viewableTechRecord?: TechRecordModel;
+  @Input() vehicle!: VehicleTechRecordModel;
+  @Input() viewableTechRecord!: TechRecordModel;
   @Input() isEditing = false;
   @Input() isDirty = false;
 
@@ -45,7 +45,7 @@ export class EditTechRecordButtonComponent implements OnInit {
         withLatestFrom(this.store.select(selectVehicleTechnicalRecordsBySystemNumber), this.technicalRecordService.techRecord$),
         take(1)
       )
-      .subscribe(([action, vehicleTechRecord, techRecord]) => {
+      .subscribe(([, vehicleTechRecord, techRecord]) => {
         const routeSuffix = techRecord?.statusCode === StatusCodes.CURRENT ? '' : '/provisional';
 
         this.router.navigateByUrl(`/tech-records/${vehicleTechRecord!.systemNumber}${routeSuffix}`);
@@ -53,7 +53,7 @@ export class EditTechRecordButtonComponent implements OnInit {
   }
 
   get isArchived(): boolean {
-    return !(this.viewableTechRecord?.statusCode === StatusCodes.CURRENT || this.viewableTechRecord?.statusCode === StatusCodes.PROVISIONAL);
+    return !(this.viewableTechRecord.statusCode === StatusCodes.CURRENT || this.viewableTechRecord.statusCode === StatusCodes.PROVISIONAL);
   }
 
   getLatestRecordTimestamp(record: VehicleTechRecordModel): number {
@@ -61,10 +61,10 @@ export class EditTechRecordButtonComponent implements OnInit {
   }
 
   checkIfEditableReasonRequired() {
-    this.viewableTechRecord?.statusCode !== StatusCodes.PROVISIONAL
+    this.viewableTechRecord.statusCode !== StatusCodes.PROVISIONAL
       ? this.router.navigate(['amend-reason'], { relativeTo: this.route })
       : this.router.navigate(['notifiable-alteration-needed'], { relativeTo: this.route });
-    this.technicalRecordService.clearReasonForCreation(this.vehicleTechRecord);
+    this.technicalRecordService.clearReasonForCreation(this.vehicle);
   }
 
   toggleEditMode() {

--- a/src/app/features/tech-record/components/tech-record-change-status/tech-record-change-status.component.html
+++ b/src/app/features/tech-record/components/tech-record-change-status/tech-record-change-status.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <app-tech-record-title [vehicleTechRecord]="(vehicleTechRecord$ | async) || undefined" [hideActions]="true"></app-tech-record-title>
+    <app-tech-record-title [vehicle]="(vehicle$ | async) || undefined" [hideActions]="true"></app-tech-record-title>
 
     <form [formGroup]="form" (submit)="handleSubmit(form.value)">
       <app-text-area name="reason" [label]="label" formControlName="reason"></app-text-area>

--- a/src/app/features/tech-record/components/tech-record-change-status/tech-record-change-status.component.ts
+++ b/src/app/features/tech-record/components/tech-record-change-status/tech-record-change-status.component.ts
@@ -19,7 +19,7 @@ import { Observable, take } from 'rxjs';
   styleUrls: ['./tech-record-change-status.component.scss']
 })
 export class TechRecordChangeStatusComponent implements OnInit {
-  vehicleTechRecord$: Observable<VehicleTechRecordModel | undefined>;
+  vehicle$: Observable<VehicleTechRecordModel | undefined>;
 
   techRecord?: TechRecordModel;
 
@@ -35,7 +35,7 @@ export class TechRecordChangeStatusComponent implements OnInit {
     private store: Store<State>,
     private technicalRecordService: TechnicalRecordService
   ) {
-    this.vehicleTechRecord$ = this.technicalRecordService.selectedVehicleTechRecord$;
+    this.vehicle$ = this.technicalRecordService.selectedVehicleTechRecord$;
 
     this.technicalRecordService.techRecord$.subscribe(techRecord => (this.techRecord = techRecord));
 

--- a/src/app/features/tech-record/components/tech-record-change-visibility/tech-record-change-visibility.component.html
+++ b/src/app/features/tech-record/components/tech-record-change-visibility/tech-record-change-visibility.component.html
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <app-tech-record-title [vehicleTechRecord]="(vehicleTechRecord$ | async) || undefined" [hideActions]="true"></app-tech-record-title>
+    <app-tech-record-title [vehicle]="(vehicle$ | async) || undefined" [hideActions]="true"></app-tech-record-title>
 
     <form [formGroup]="form" (submit)="handleSubmit(form.value)">
       <h1 class="govuk-heading-l">{{ title }}</h1>

--- a/src/app/features/tech-record/components/tech-record-change-visibility/tech-record-change-visibility.component.ts
+++ b/src/app/features/tech-record/components/tech-record-change-visibility/tech-record-change-visibility.component.ts
@@ -1,4 +1,3 @@
-import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -20,7 +19,7 @@ import { Observable, take } from 'rxjs';
   styleUrls: ['./tech-record-change-visibility.component.scss']
 })
 export class TechRecordChangeVisibilityComponent implements OnInit {
-  vehicleTechRecord$: Observable<VehicleTechRecordModel | undefined>;
+  vehicle$: Observable<VehicleTechRecordModel | undefined>;
   techRecord?: TechRecordModel;
 
   form: CustomFormGroup;
@@ -33,7 +32,7 @@ export class TechRecordChangeVisibilityComponent implements OnInit {
     private store: Store<State>,
     private technicalRecordService: TechnicalRecordService
   ) {
-    this.vehicleTechRecord$ = this.technicalRecordService.selectedVehicleTechRecord$;
+    this.vehicle$ = this.technicalRecordService.selectedVehicleTechRecord$;
 
     this.technicalRecordService.techRecord$.subscribe(techRecord => (this.techRecord = techRecord));
 

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
@@ -22,7 +22,14 @@
         <td class="govuk-table__cell" [id]="techRecord.statusCode + '-created-at-' + i">{{ techRecord.createdAt | date: 'dd/MM/yyyy HH:mm' }}</td>
         <td class="govuk-table__cell">
           <ng-container *ngIf="techRecord.createdAt !== currentTechRecord.createdAt">
-            <a id="view-test-{{ vehicle.vin }}" href="/tech-records/{{ vehicle.systemNumber }}{{ summaryLinkUrl(techRecord) }}">View</a>
+            <app-button
+              id="view-test-{{ vehicle.vin }}"
+              type="link"
+              design="link"
+              [routerLink]="['/', 'tech-records', vehicle.systemNumber, summaryLinkUrl(techRecord)]"
+            >
+              View
+            </app-button>
           </ng-container>
         </td>
       </tr>

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.html
@@ -21,10 +21,8 @@
         <td class="govuk-table__cell word-break" [id]="techRecord.statusCode + '-created-by-' + i">{{ techRecord.createdByName }}</td>
         <td class="govuk-table__cell" [id]="techRecord.statusCode + '-created-at-' + i">{{ techRecord.createdAt | date: 'dd/MM/yyyy HH:mm' }}</td>
         <td class="govuk-table__cell">
-          <ng-container *ngIf="techRecord.createdAt !== currentRecord?.createdAt">
-            <a id="view-test-{{ vehicleTechRecord!.vin }}" href="/tech-records/{{ vehicleTechRecord!.systemNumber }}{{ summaryLinkUrl(techRecord) }}">
-              View
-            </a>
+          <ng-container *ngIf="techRecord.createdAt !== currentTechRecord.createdAt">
+            <a id="view-test-{{ vehicle.vin }}" href="/tech-records/{{ vehicle.systemNumber }}{{ summaryLinkUrl(techRecord) }}">View</a>
           </ng-container>
         </td>
       </tr>

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.spec.ts
@@ -23,8 +23,8 @@ describe('TechRecordHistoryComponent', () => {
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
     route = TestBed.inject(ActivatedRoute);
-    component.vehicleTechRecord = mockVehicleTechnicalRecord();
-    component.currentRecord = mockVehicleTechnicalRecord().techRecord[0];
+    component.vehicle = mockVehicleTechnicalRecord();
+    component.currentTechRecord = mockVehicleTechnicalRecord().techRecord[0];
     fixture.detectChanges();
   });
   it('should create', () => {

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
@@ -2,19 +2,27 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@a
 import { StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
 
 @Component({
-  selector: 'app-tech-record-history',
+  selector: 'app-tech-record-history[vehicle][currentTechRecord]',
   templateUrl: './tech-record-history.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./tech-record-history.component.scss']
 })
 export class TechRecordHistoryComponent {
-  @Input() vehicleTechRecord?: VehicleTechRecordModel;
-  @Input() currentRecord?: TechRecordModel;
+  @Input() vehicle!: VehicleTechRecordModel;
+  @Input() currentTechRecord!: TechRecordModel;
 
   pageStart?: number;
   pageEnd?: number;
 
   constructor(private cdr: ChangeDetectorRef) {}
+
+  get techRecords() {
+    return this.vehicle.techRecord.slice(this.pageStart, this.pageEnd) ?? [];
+  }
+
+  get numberOfRecords(): number {
+    return this.vehicle.techRecord.length || 0;
+  }
 
   convertToUnix(date: Date): number {
     return new Date(date).getTime();
@@ -24,14 +32,6 @@ export class TechRecordHistoryComponent {
     this.pageStart = start;
     this.pageEnd = end;
     this.cdr.detectChanges();
-  }
-
-  get numberOfRecords(): number {
-    return this.vehicleTechRecord?.techRecord.length || 0;
-  }
-
-  get techRecords() {
-    return this.vehicleTechRecord?.techRecord.slice(this.pageStart, this.pageEnd) ?? [];
   }
 
   trackByFn(i: number, tr: TechRecordModel) {

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.ts
@@ -41,9 +41,9 @@ export class TechRecordHistoryComponent {
   summaryLinkUrl(techRecord: TechRecordModel) {
     switch (techRecord.statusCode) {
       case StatusCodes.PROVISIONAL:
-        return '/provisional';
+        return 'provisional';
       case StatusCodes.ARCHIVED:
-        return `/historic/${this.convertToUnix(techRecord.createdAt)}`;
+        return `historic/${this.convertToUnix(techRecord.createdAt)}`;
       default:
         return '';
     }

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -21,49 +21,49 @@
   <ng-container [ngSwitch]="sectionName">
     <app-body
       *ngSwitchCase="'bodySection'"
-      [vehicleTechRecord]="vehicleTechRecordCalculated"
+      [vehicleTechRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-body>
 
     <app-dimensions
       *ngSwitchCase="'dimensionsSection'"
-      [vehicleTechRecord]="vehicleTechRecordCalculated"
+      [vehicleTechRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-dimensions>
 
     <app-psv-brakes
       *ngSwitchCase="'psvBrakesSection'"
-      [vehicleTechRecord]="vehicleTechRecordCalculated"
+      [vehicleTechRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-psv-brakes>
 
     <app-trl-brakes
       *ngSwitchCase="'trlBrakesSection'"
-      [vehicleTechRecord]="vehicleTechRecordCalculated"
+      [vehicleTechRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-trl-brakes>
 
     <app-tyres
       *ngSwitchCase="'tyreSection'"
-      [vehicleTechRecord]="vehicleTechRecordCalculated"
+      [vehicleTechRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-tyres>
 
     <app-weights
       *ngSwitchCase="'weightsSection'"
-      [vehicleTechRecord]="vehicleTechRecordCalculated"
+      [vehicleTechRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-weights>
 
     <app-dynamic-form-group
       *ngSwitchDefault
-      [data]="vehicleTechRecordCalculated"
+      [data]="techRecordCalculated"
       [template]="section"
       [edit]="isEditing"
       (formChange)="handleFormState($event)"

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -11,6 +11,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { editableVehicleTechRecord, updateEditingTechRecord } from '@store/technical-records';
 import { SharedModule } from '@shared/shared.module';
 import { MultiOptionsService } from '@forms/services/multi-options.service';
+import { QueryList } from '@angular/core';
+import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
 
 describe('TechRecordSummaryComponent', () => {
   let component: TechRecordSummaryComponent;
@@ -46,7 +48,7 @@ describe('TechRecordSummaryComponent', () => {
   describe('TechRecordSummaryComponent View', () => {
     it('should show PSV record found', () => {
       component.isEditing = false;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -54,8 +56,8 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show PSV record found without dimensions', () => {
       component.isEditing = false;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
-      component.vehicleTechRecord!.dimensions = undefined;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.techRecord!.dimensions = undefined;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -63,7 +65,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show HGV record found', () => {
       component.isEditing = false;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -71,8 +73,8 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show HGV record found without dimensions', () => {
       component.isEditing = false;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
-      component.vehicleTechRecord!.dimensions = undefined;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
+      component.techRecord!.dimensions = undefined;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -80,7 +82,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show TRL record found', () => {
       component.isEditing = false;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -88,8 +90,8 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show TRL record found without dimensions', () => {
       component.isEditing = false;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
-      component.vehicleTechRecord!.dimensions = undefined;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
+      component.techRecord!.dimensions = undefined;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -99,7 +101,7 @@ describe('TechRecordSummaryComponent', () => {
   describe('TechRecordSummaryComponent Amend', () => {
     it('should make reason for change null in editMode', () => {
       component.isEditing = true;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -108,16 +110,18 @@ describe('TechRecordSummaryComponent', () => {
 
   describe('handleFormState', () => {
     it('should dispatch updateEditingTechRecord', () => {
+      jest.spyOn(component, 'checkForms').mockImplementation();
       const dispatchSpy = jest.spyOn(store, 'dispatch');
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.sections = new QueryList<DynamicFormGroupComponent>();
 
       store.overrideSelector(editableVehicleTechRecord, { vrms: [], vin: '', systemNumber: '', techRecord: [] });
 
       component.handleFormState({});
 
       expect(dispatchSpy).toHaveBeenCalledWith(
-        updateEditingTechRecord({ vehicleTechRecord: { vin: '', vrms: [], systemNumber: '', techRecord: [component.vehicleTechRecordCalculated!] } })
+        updateEditingTechRecord({ vehicleTechRecord: { vin: '', vrms: [], systemNumber: '', techRecord: [component.techRecordCalculated!] } })
       );
     });
   });
@@ -175,8 +179,8 @@ describe('TechRecordSummaryComponent', () => {
   describe('addAxle', () => {
     it('should add an axle', () => {
       component.isEditing = true;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
 
       const axleEvent = {
         axles: [
@@ -194,14 +198,14 @@ describe('TechRecordSummaryComponent', () => {
 
       component.addAxle(axleEvent);
 
-      expect(component.vehicleTechRecordCalculated.axles!.length).toBe(3);
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.length).toBe(2);
+      expect(component.techRecordCalculated.axles!.length).toBe(3);
+      expect(component.techRecordCalculated.dimensions?.axleSpacing?.length).toBe(2);
     });
 
     it('should add an axle on a psv', () => {
       component.isEditing = true;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
 
       const axleEvent = {
         axles: [
@@ -223,15 +227,15 @@ describe('TechRecordSummaryComponent', () => {
 
       component.addAxle(axleEvent);
 
-      expect(component.vehicleTechRecordCalculated.axles!.length).toBe(4);
+      expect(component.techRecordCalculated.axles!.length).toBe(4);
     });
   });
 
   describe('removeAxle', () => {
     it('should remove axle on psv', () => {
       component.isEditing = true;
-      component.vehicleTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
+      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord[0];
 
       const axleEvent = {
         axles: [
@@ -246,7 +250,7 @@ describe('TechRecordSummaryComponent', () => {
 
       component.removeAxle(axleEvent);
 
-      expect(component.vehicleTechRecordCalculated.axles!.length).toBe(2);
+      expect(component.techRecordCalculated.axles!.length).toBe(2);
     });
   });
 
@@ -285,7 +289,7 @@ describe('TechRecordSummaryComponent', () => {
 
   describe('normaliseVehicleTechRecordAxles', () => {
     it('should not change anything if the tech record is correct', () => {
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
       component.normaliseVehicleTechRecordAxles();
 
       const axleSpacingMock = jest.spyOn(component, 'generateAxleSpacing');
@@ -296,55 +300,55 @@ describe('TechRecordSummaryComponent', () => {
     });
 
     it('should call generate spacings if there are more axles', () => {
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
-      component.vehicleTechRecordCalculated.axles!.push({ axleNumber: 3 });
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated.axles!.push({ axleNumber: 3 });
 
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.length).toBe(1);
+      expect(component.techRecordCalculated.dimensions?.axleSpacing?.length).toBe(1);
 
       component.normaliseVehicleTechRecordAxles();
 
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.length).toBe(2);
+      expect(component.techRecordCalculated.dimensions?.axleSpacing?.length).toBe(2);
     });
 
     it('should call generate axles if there are more spacings', () => {
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
-      component.vehicleTechRecordCalculated.dimensions?.axleSpacing?.push({ axles: '2-3', value: 1 });
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated.dimensions?.axleSpacing?.push({ axles: '2-3', value: 1 });
 
-      expect(component.vehicleTechRecordCalculated.axles!.length).toBe(2);
+      expect(component.techRecordCalculated.axles!.length).toBe(2);
 
       component.normaliseVehicleTechRecordAxles();
 
-      expect(component.vehicleTechRecordCalculated.axles!.length).toBe(3);
+      expect(component.techRecordCalculated.axles!.length).toBe(3);
     });
 
     it('should call generate spacings if there are none but there is axles', () => {
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
-      component.vehicleTechRecordCalculated.dimensions!.axleSpacing = undefined;
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing).toBe(undefined);
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated.dimensions!.axleSpacing = undefined;
+      expect(component.techRecordCalculated.dimensions?.axleSpacing).toBe(undefined);
 
       component.normaliseVehicleTechRecordAxles();
 
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
+      expect(component.techRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
     });
 
     it('should call generate spacings if there are none but there is axles and there is an object to start with', () => {
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
-      component.vehicleTechRecordCalculated.dimensions!.axleSpacing = [];
-      expect(component.vehicleTechRecordCalculated.axles!.length).toBe(2);
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated.dimensions!.axleSpacing = [];
+      expect(component.techRecordCalculated.axles!.length).toBe(2);
 
       component.normaliseVehicleTechRecordAxles();
 
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
+      expect(component.techRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
     });
 
     it('should call generate axles if there are none but there is spacings', () => {
-      component.vehicleTechRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
-      component.vehicleTechRecordCalculated.axles = [];
-      expect(component.vehicleTechRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
+      component.techRecordCalculated = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord[0];
+      component.techRecordCalculated.axles = [];
+      expect(component.techRecordCalculated.dimensions?.axleSpacing!.length).toBe(1);
 
       component.normaliseVehicleTechRecordAxles();
 
-      expect(component.vehicleTechRecordCalculated.axles.length).toBe(2);
+      expect(component.techRecordCalculated.axles.length).toBe(2);
     });
   });
 

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -1,4 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { GlobalError } from '@core/components/global-error/global-error.interface';
+import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
 import { BodyComponent } from '@forms/custom-sections/body/body.component';
 import { DimensionsComponent } from '@forms/custom-sections/dimensions/dimensions.component';
@@ -6,7 +8,8 @@ import { PsvBrakesComponent } from '@forms/custom-sections/psv-brakes/psv-brakes
 import { TrlBrakesComponent } from '@forms/custom-sections/trl-brakes/trl-brakes.component';
 import { TyresComponent } from '@forms/custom-sections/tyres/tyres.component';
 import { WeightsComponent } from '@forms/custom-sections/weights/weights.component';
-import { FormNode } from '@forms/services/dynamic-form.types';
+import { DynamicFormService } from '@forms/services/dynamic-form.service';
+import { FormNode, CustomFormArray, CustomFormGroup } from '@forms/services/dynamic-form.types';
 import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
 import { BodyTypeCode, vehicleBodyTypeCodeMap } from '@models/body-type-enum';
 import { PsvMake, ReferenceDataResourceType } from '@models/reference-data.model';
@@ -16,8 +19,7 @@ import { ReferenceDataService } from '@services/reference-data/reference-data.se
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { State } from '@store/index';
 import { ReferenceDataState, selectReferenceDataByResourceKey } from '@store/reference-data';
-import cloneDeep from 'lodash.clonedeep';
-import merge from 'lodash.merge';
+import { cloneDeep, merge } from 'lodash';
 import { map, Observable, take } from 'rxjs';
 
 @Component({
@@ -35,21 +37,24 @@ export class TechRecordSummaryComponent implements OnInit {
   @ViewChild(TyresComponent) tyres!: TyresComponent;
   @ViewChild(WeightsComponent) weights!: WeightsComponent;
 
-  @Input() vehicleTechRecord!: TechRecordModel;
+  @Input() techRecord!: TechRecordModel;
   @Input() refDataState!: ReferenceDataState;
-  @Input()
-  set isEditing(value: boolean) {
+
+  private _isEditing: boolean = false;
+  @Input() set isEditing(value: boolean) {
     this._isEditing = value;
     this.calculateVehicleModel();
   }
-  @Output() formChange = new EventEmitter();
 
-  private _isEditing: boolean = false;
-  vehicleTechRecordCalculated!: TechRecordModel;
+  @Output() isFormDirty = new EventEmitter<boolean>();
+  @Output() isFormInvalid = new EventEmitter<boolean>();
+
+  techRecordCalculated!: TechRecordModel;
   sectionTemplates: Array<FormNode> = [];
   middleIndex = 0;
 
   constructor(
+    private errorService: GlobalErrorService,
     private technicalRecordService: TechnicalRecordService,
     private store: Store<State>,
     private referenceDataService: ReferenceDataService
@@ -68,14 +73,35 @@ export class TechRecordSummaryComponent implements OnInit {
 
   get psvFromDtp$(): Observable<PsvMake> {
     return this.store.select(
-      selectReferenceDataByResourceKey(ReferenceDataResourceType.PsvMake, this.vehicleTechRecordCalculated.brakes?.dtpNumber as string)
+      selectReferenceDataByResourceKey(ReferenceDataResourceType.PsvMake, this.techRecordCalculated.brakes?.dtpNumber as string)
     ) as Observable<PsvMake>;
   }
 
   get vehicleTemplates(): Array<FormNode> {
-    const vehicleTemplates = vehicleTemplateMap.get(this.vehicleTechRecordCalculated.vehicleType);
+    const vehicleTemplates = vehicleTemplateMap.get(this.techRecordCalculated.vehicleType);
     if (vehicleTemplates) return this.isEditing ? vehicleTemplates : vehicleTemplates.filter(t => t.name !== 'reasonForCreationSection');
     else return [] as Array<FormNode>;
+  }
+
+  get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {
+    const commonCustomSections = [this.body.form, this.dimensions.form, this.tyres.form, this.weights.form];
+
+    switch (this.techRecord.vehicleType) {
+      case VehicleTypes.PSV:
+        return [...commonCustomSections, this.psvBrakes!.form];
+      case VehicleTypes.HGV:
+        return commonCustomSections;
+      case VehicleTypes.TRL:
+        return [...commonCustomSections, this.trlBrakes!.form];
+      default:
+        return [];
+    }
+  }
+
+  get brakeCodePrefix(): string {
+    const prefix = `${Math.round(this.techRecordCalculated!.grossLadenWeight! / 100)}`;
+
+    return prefix.length <= 2 ? '0' + prefix : prefix;
   }
 
   calculateVehicleModel(): void {
@@ -83,71 +109,103 @@ export class TechRecordSummaryComponent implements OnInit {
       ? this.technicalRecordService.editableTechRecord$
           .pipe(
             //Need to check that the editing tech record has more than just reason for creation on and is the full object.
-            map(data => (data && Object.keys(data).length > 1 ? cloneDeep(data) : { ...cloneDeep(this.vehicleTechRecord), reasonForCreation: '' })),
+            map(data => (data && Object.keys(data).length > 1 ? cloneDeep(data) : { ...cloneDeep(this.techRecord), reasonForCreation: '' })),
             take(1)
           )
           .subscribe(data => {
-            this.vehicleTechRecordCalculated = data;
+            this.techRecordCalculated = data;
             this.normaliseVehicleTechRecordAxles();
           })
-      : (this.vehicleTechRecordCalculated = { ...this.vehicleTechRecord });
+      : (this.techRecordCalculated = { ...this.techRecord });
 
-    this.technicalRecordService.updateEditingTechRecord(this.vehicleTechRecordCalculated, true);
+    this.technicalRecordService.updateEditingTechRecord(this.techRecordCalculated, true);
   }
 
   handleFormState(event: any): void {
-    this.vehicleTechRecordCalculated = cloneDeep(this.vehicleTechRecordCalculated);
+    this.techRecordCalculated = cloneDeep(this.techRecordCalculated);
 
-    if (event.axles && event.axles.length < this.vehicleTechRecordCalculated.axles!.length) {
+    if (event.axles && event.axles.length < this.techRecordCalculated.axles!.length) {
       this.removeAxle(event);
-    } else if (event.axles && this.vehicleTechRecordCalculated.axles!.length < event.axles.length) {
+    } else if (event.axles && this.techRecordCalculated.axles!.length < event.axles.length) {
       this.addAxle(event);
     } else {
-      this.vehicleTechRecordCalculated = merge(this.vehicleTechRecordCalculated, event);
+      this.techRecordCalculated = merge(this.techRecordCalculated, event);
     }
 
-    if (event.brakes?.dtpNumber && event.brakes.dtpNumber.length >= 4 && this.vehicleTechRecordCalculated.vehicleType === VehicleTypes.PSV) {
-      this.setBodyFields(this.vehicleTechRecordCalculated.vehicleType);
+    if (event.brakes?.dtpNumber && event.brakes.dtpNumber.length >= 4 && this.techRecordCalculated.vehicleType === VehicleTypes.PSV) {
+      this.setBodyFields(this.techRecordCalculated.vehicleType);
     }
 
-    if (this.vehicleTechRecordCalculated.vehicleType === VehicleTypes.PSV && (event.grossKerbWeight || event.grossLadenWeight || event.brakes)) {
+    if (this.techRecordCalculated.vehicleType === VehicleTypes.PSV && (event.grossKerbWeight || event.grossLadenWeight || event.brakes)) {
       this.setBrakesForces();
     }
 
     if (
-      this.vehicleTechRecord.vehicleType === VehicleTypes.PSV ||
-      this.vehicleTechRecord.vehicleType === VehicleTypes.HGV ||
-      this.vehicleTechRecord.vehicleType === VehicleTypes.TRL
+      this.techRecord.vehicleType === VehicleTypes.PSV ||
+      this.techRecord.vehicleType === VehicleTypes.HGV ||
+      this.techRecord.vehicleType === VehicleTypes.TRL
     ) {
-      this.vehicleTechRecordCalculated.noOfAxles = this.vehicleTechRecordCalculated.axles?.length ?? 0;
+      this.techRecordCalculated.noOfAxles = this.techRecordCalculated.axles?.length ?? 0;
     }
 
-    this.technicalRecordService.updateEditingTechRecord(this.vehicleTechRecordCalculated);
-    this.formChange.emit();
+    this.technicalRecordService.updateEditingTechRecord(this.techRecordCalculated);
+
+    this.checkForms();
   }
 
-  generateAxleSpacing(numberOfAxles: number, setOriginalValues: boolean = false, axleSpacingOriginal?: AxleSpacing[]): AxleSpacing[] {
-    let axleSpacing: AxleSpacing[] = [];
+  checkForms(): void {
+    const forms = this.sections?.map(section => section.form).concat(this.customSectionForms);
 
-    let axleNumber = 1;
-    while (axleNumber < numberOfAxles) {
-      axleSpacing.push({
-        axles: `${axleNumber}-${axleNumber + 1}`,
-        value: setOriginalValues && axleSpacingOriginal![axleNumber - 1] ? axleSpacingOriginal![axleNumber - 1].value : null
-      });
-      axleNumber++;
-    }
+    this.isFormDirty.emit(forms.some(form => form.dirty));
 
-    return axleSpacing;
+    this.setErrors(forms);
+
+    this.isFormInvalid.emit(forms.some(form => form.invalid));
+  }
+
+  setErrors(forms: Array<CustomFormGroup | CustomFormArray>): void {
+    const errors: GlobalError[] = [];
+
+    forms.forEach(form => DynamicFormService.updateValidity(form, errors));
+
+    errors.length ? this.errorService.setErrors(errors) : this.errorService.clearErrors();
+  }
+
+  setBodyFields(vehicleType: VehicleTypes): void {
+    this.psvFromDtp$.pipe(take(1)).subscribe(payload => {
+      const code = payload?.psvBodyType.toLowerCase() as BodyTypeCode;
+
+      this.techRecordCalculated.bodyType = { code, description: vehicleBodyTypeCodeMap.get(vehicleType)?.get(code) };
+      this.techRecordCalculated.bodyMake = payload?.psvBodyMake;
+      this.techRecordCalculated.chassisMake = payload?.psvChassisMake;
+      this.techRecordCalculated.chassisModel = payload?.psvChassisModel;
+    });
+  }
+
+  setBrakesForces(): void {
+    this.techRecordCalculated.brakes = {
+      ...this.techRecordCalculated.brakes,
+      brakeCode: this.brakeCodePrefix + this.techRecordCalculated.brakes?.brakeCodeOriginal,
+      brakeForceWheelsNotLocked: {
+        serviceBrakeForceA: Math.round(((this.techRecordCalculated.grossLadenWeight || 0) * 16) / 100),
+        secondaryBrakeForceA: Math.round(((this.techRecordCalculated.grossLadenWeight || 0) * 22.5) / 100),
+        parkingBrakeForceA: Math.round(((this.techRecordCalculated.grossLadenWeight || 0) * 45) / 100)
+      },
+      brakeForceWheelsUpToHalfLocked: {
+        serviceBrakeForceB: Math.round(((this.techRecordCalculated.grossKerbWeight || 0) * 16) / 100),
+        secondaryBrakeForceB: Math.round(((this.techRecordCalculated.grossKerbWeight || 0) * 25) / 100),
+        parkingBrakeForceB: Math.round(((this.techRecordCalculated.grossKerbWeight || 0) * 50) / 100)
+      }
+    };
   }
 
   addAxle(event: any): void {
-    this.vehicleTechRecordCalculated = merge(this.vehicleTechRecordCalculated, event);
-    if (this.vehicleTechRecord.vehicleType !== VehicleTypes.PSV && this.vehicleTechRecordCalculated.dimensions) {
-      this.vehicleTechRecordCalculated.dimensions.axleSpacing = this.generateAxleSpacing(
-        this.vehicleTechRecordCalculated.axles!.length,
+    this.techRecordCalculated = merge(this.techRecordCalculated, event);
+    if (this.techRecord.vehicleType !== VehicleTypes.PSV && this.techRecordCalculated.dimensions) {
+      this.techRecordCalculated.dimensions.axleSpacing = this.generateAxleSpacing(
+        this.techRecordCalculated.axles!.length,
         true,
-        this.vehicleTechRecordCalculated.dimensions.axleSpacing
+        this.techRecordCalculated.dimensions.axleSpacing
       );
     }
   }
@@ -155,7 +213,7 @@ export class TechRecordSummaryComponent implements OnInit {
   removeAxle(axleEvent: any): void {
     const axleToRemove = this.findAxleToRemove(axleEvent.axles);
 
-    this.vehicleTechRecordCalculated.axles = this.vehicleTechRecordCalculated.axles!.filter(ax => {
+    this.techRecordCalculated.axles = this.techRecordCalculated.axles!.filter(ax => {
       if (ax.axleNumber !== axleToRemove) {
         if (ax.axleNumber! > axleToRemove) {
           ax.axleNumber! -= 1;
@@ -165,8 +223,8 @@ export class TechRecordSummaryComponent implements OnInit {
       return false;
     });
 
-    if (this.vehicleTechRecord.vehicleType !== VehicleTypes.PSV && this.vehicleTechRecordCalculated.dimensions) {
-      this.vehicleTechRecordCalculated.dimensions.axleSpacing = this.generateAxleSpacing(this.vehicleTechRecordCalculated.axles.length);
+    if (this.techRecord.vehicleType !== VehicleTypes.PSV && this.techRecordCalculated.dimensions) {
+      this.techRecordCalculated.dimensions.axleSpacing = this.generateAxleSpacing(this.techRecordCalculated.axles.length);
     }
   }
 
@@ -184,30 +242,42 @@ export class TechRecordSummaryComponent implements OnInit {
   }
 
   normaliseVehicleTechRecordAxles() {
-    if (this.vehicleTechRecordCalculated.vehicleType !== VehicleTypes.PSV) {
-      const vehicleAxles = this.vehicleTechRecordCalculated.axles;
-      const vehicleAxleSpacings = this.vehicleTechRecordCalculated.dimensions?.axleSpacing;
+    if (this.techRecordCalculated.vehicleType !== VehicleTypes.PSV) {
+      const vehicleAxles = this.techRecordCalculated.axles;
+      const vehicleAxleSpacings = this.techRecordCalculated.dimensions?.axleSpacing;
 
       //axles = axlespacings + 1
       if (vehicleAxles && vehicleAxleSpacings) {
         if (vehicleAxles.length > vehicleAxleSpacings.length + 1) {
-          this.vehicleTechRecordCalculated.dimensions!.axleSpacing = this.generateAxleSpacing(vehicleAxles.length, true, vehicleAxleSpacings);
+          this.techRecordCalculated.dimensions!.axleSpacing = this.generateAxleSpacing(vehicleAxles.length, true, vehicleAxleSpacings);
         } else if (vehicleAxles.length < vehicleAxleSpacings.length + 1 && vehicleAxleSpacings.length) {
-          this.vehicleTechRecordCalculated.axles = this.generateAxlesFromAxleSpacings(
-            this.vehicleTechRecordCalculated.vehicleType,
+          this.techRecordCalculated.axles = this.generateAxlesFromAxleSpacings(
+            this.techRecordCalculated.vehicleType,
             vehicleAxleSpacings.length,
             vehicleAxles
           );
         }
       } else if (vehicleAxles && !vehicleAxleSpacings) {
-        this.vehicleTechRecordCalculated.dimensions!.axleSpacing = this.generateAxleSpacing(vehicleAxles.length);
+        this.techRecordCalculated.dimensions!.axleSpacing = this.generateAxleSpacing(vehicleAxles.length);
       } else if (!vehicleAxles && vehicleAxleSpacings && vehicleAxleSpacings.length) {
-        this.vehicleTechRecordCalculated.axles = this.generateAxlesFromAxleSpacings(
-          this.vehicleTechRecordCalculated.vehicleType,
-          vehicleAxleSpacings.length
-        );
+        this.techRecordCalculated.axles = this.generateAxlesFromAxleSpacings(this.techRecordCalculated.vehicleType, vehicleAxleSpacings.length);
       }
     }
+  }
+
+  generateAxleSpacing(numberOfAxles: number, setOriginalValues: boolean = false, axleSpacingOriginal?: AxleSpacing[]): AxleSpacing[] {
+    let axleSpacing: AxleSpacing[] = [];
+
+    let axleNumber = 1;
+    while (axleNumber < numberOfAxles) {
+      axleSpacing.push({
+        axles: `${axleNumber}-${axleNumber + 1}`,
+        value: setOriginalValues && axleSpacingOriginal![axleNumber - 1] ? axleSpacingOriginal![axleNumber - 1].value : null
+      });
+      axleNumber++;
+    }
+
+    return axleSpacing;
   }
 
   generateAxlesFromAxleSpacings(vehicleType: VehicleTypes, vehicleAxleSpacingsLength: number, previousAxles?: Axle[]): Axle[] {
@@ -231,39 +301,5 @@ export class TechRecordSummaryComponent implements OnInit {
     const tyres = { tyreSize: null, speedCategorySymbol: null, fitmentCode: null, dataTrAxles: null, plyRating: null, tyreCode: null };
 
     return { axleNumber, weights, tyres };
-  }
-
-  setBodyFields(vehicleType: VehicleTypes): void {
-    this.psvFromDtp$.pipe(take(1)).subscribe(payload => {
-      const code = payload?.psvBodyType.toLowerCase() as BodyTypeCode;
-
-      this.vehicleTechRecordCalculated.bodyType = { code, description: vehicleBodyTypeCodeMap.get(vehicleType)?.get(code) };
-      this.vehicleTechRecordCalculated.bodyMake = payload?.psvBodyMake;
-      this.vehicleTechRecordCalculated.chassisMake = payload?.psvChassisMake;
-      this.vehicleTechRecordCalculated.chassisModel = payload?.psvChassisModel;
-    });
-  }
-
-  get brakeCodePrefix(): string {
-    const prefix = `${Math.round(this.vehicleTechRecordCalculated!.grossLadenWeight! / 100)}`;
-
-    return prefix.length <= 2 ? '0' + prefix : prefix;
-  }
-
-  setBrakesForces(): void {
-    this.vehicleTechRecordCalculated.brakes = {
-      ...this.vehicleTechRecordCalculated.brakes,
-      brakeCode: this.brakeCodePrefix + this.vehicleTechRecordCalculated.brakes?.brakeCodeOriginal,
-      brakeForceWheelsNotLocked: {
-        serviceBrakeForceA: Math.round(((this.vehicleTechRecordCalculated.grossLadenWeight || 0) * 16) / 100),
-        secondaryBrakeForceA: Math.round(((this.vehicleTechRecordCalculated.grossLadenWeight || 0) * 22.5) / 100),
-        parkingBrakeForceA: Math.round(((this.vehicleTechRecordCalculated.grossLadenWeight || 0) * 45) / 100)
-      },
-      brakeForceWheelsUpToHalfLocked: {
-        serviceBrakeForceB: Math.round(((this.vehicleTechRecordCalculated.grossKerbWeight || 0) * 16) / 100),
-        secondaryBrakeForceB: Math.round(((this.vehicleTechRecordCalculated.grossKerbWeight || 0) * 25) / 100),
-        parkingBrakeForceB: Math.round(((this.vehicleTechRecordCalculated.grossKerbWeight || 0) * 50) / 100)
-      }
-    };
   }
 }

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
@@ -1,49 +1,24 @@
-<div class="vehicle_heading">
-  <h1 class="govuk-heading-l">
-    <span>{{ vehicleMakeAndModel }}</span>
-    <app-icon [icon]="(editableTechRecord$ | async)?.vehicleType || ''"></app-icon>
-  </h1>
-</div>
-
-<dl *ngIf="currentTechRecord$ | async as currentTechRecord" class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Vehicle type</dt>
-    <dd id="vehicleType" class="govuk-summary-list__value">
-      {{ (editableTechRecord$ | async)?.vehicleType ?? '' | uppercase | defaultNullOrEmpty }}
-    </dd>
-    <dd *ngIf="!hideActions" class="govuk-summary-list__actions">
-      <div class="govuk-summary-list__actions--flex">
-        <app-button
-          *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === (editableTechRecord$ | async)?.vehicleType"
-          design="link"
-          id="change-vehicle-type-link"
-          (clicked)="navigateTo('change-vehicle-type')"
-          >Change</app-button
-        >
-      </div>
-    </dd>
+<ng-container *ngIf="editableTechRecord$ | async as editableTechRecord">
+  <div class="vehicle_heading">
+    <h1 class="govuk-heading-l">
+      <span>{{ vehicleMakeAndModel }}</span>
+      <app-icon [icon]="editableTechRecord.vehicleType || ''"></app-icon>
+    </h1>
   </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Vehicle identification number (VIN)</dt>
-    <dd id="vin" class="govuk-summary-list__value">
-      {{ currentTechRecord.historicVin ?? vehicleTechRecord?.vin | defaultNullOrEmpty }}
-    </dd>
-  </div>
-
-  <ng-container *ngIf="currentTechRecord.vehicleType !== vehicleTypes.TRL; else trailerHeader">
+  <dl *ngIf="currentTechRecord$ | async as currentTechRecord" class="govuk-summary-list">
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Vehicle registration mark (VRM)</dt>
-      <dd id="current-vrm" class="govuk-summary-list__value">
-        <app-number-plate *ngIf="currentVrm" [vrm]="currentVrm"></app-number-plate>
+      <dt class="govuk-summary-list__key">Vehicle type</dt>
+      <dd id="vehicleType" class="govuk-summary-list__value">
+        {{ editableTechRecord.vehicleType | uppercase | defaultNullOrEmpty }}
       </dd>
-      <dd *appRoleRequired="roles.TechRecordArchive" class="govuk-summary-list__actions">
+      <dd *ngIf="!hideActions" class="govuk-summary-list__actions">
         <div class="govuk-summary-list__actions--flex">
           <app-button
-            *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === (editableTechRecord$ | async)?.vehicleType"
+            *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === editableTechRecord.vehicleType"
             design="link"
-            id="change-vrm-link"
-            (clicked)="navigateTo('change-vrm')"
+            id="change-vehicle-type-link"
+            (clicked)="navigateTo('change-vehicle-type')"
             >Change</app-button
           >
         </div>
@@ -51,78 +26,105 @@
     </div>
 
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Previous VRM</dt>
-      <dd id="previous-vrm" class="govuk-summary-list__value">
-        <app-number-plate
-          *ngFor="let secondaryVrm of otherVrms"
-          class="govuk-body govuk-!-margin-bottom-0"
-          [vrm]="secondaryVrm.vrm"
-          [isSecondary]="true"
-        ></app-number-plate>
+      <dt class="govuk-summary-list__key">Vehicle identification number (VIN)</dt>
+      <dd id="vin" class="govuk-summary-list__value">
+        {{ currentTechRecord.historicVin ?? vehicle?.vin | defaultNullOrEmpty }}
       </dd>
     </div>
-  </ng-container>
 
-  <ng-template #trailerHeader>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Trailer ID</dt>
-      <dd id="trailer-id" class="govuk-summary-list__value">
-        {{ vehicleTechRecord?.trailerId | defaultNullOrEmpty }}
-      </dd>
-    </div>
-  </ng-template>
+    <ng-container *ngIf="currentTechRecord.vehicleType !== vehicleTypes.TRL; else trailerHeader">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Vehicle registration mark (VRM)</dt>
+        <dd id="current-vrm" class="govuk-summary-list__value">
+          <app-number-plate *ngIf="currentVrm" [vrm]="currentVrm"></app-number-plate>
+        </dd>
+        <dd *appRoleRequired="roles.TechRecordArchive" class="govuk-summary-list__actions">
+          <div class="govuk-summary-list__actions--flex">
+            <app-button
+              *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === editableTechRecord.vehicleType"
+              design="link"
+              id="change-vrm-link"
+              (clicked)="navigateTo('change-vrm')"
+              >Change</app-button
+            >
+          </div>
+        </dd>
+      </div>
 
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Record type</dt>
-    <dd id="status-code" class="govuk-summary-list__value">
-      <strong class="govuk-tag govuk-phase-banner__content__tag">{{ currentTechRecord.statusCode | defaultNullOrEmpty }}</strong>
-    </dd>
-    <ng-container *ngIf="!hideActions">
-      <dd *appRoleRequired="roles.TechRecordArchive" class="govuk-summary-list__actions">
-        <div class="govuk-summary-list__actions--flex">
-          <app-button
-            *ngIf="queryableRecordActions.includes('archive')"
-            design="link"
-            id="change-status-to-archive-link"
-            (clicked)="navigateTo('change-status', { to: 'archived' })"
-            >Archive</app-button
-          >
-          <app-button
-            *ngIf="queryableRecordActions.includes('promote')"
-            design="link"
-            id="promote-link"
-            (clicked)="navigateTo('change-status', { to: 'current' })"
-            >Promote</app-button
-          >
-        </div>
-      </dd>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Previous VRM</dt>
+        <dd id="previous-vrm" class="govuk-summary-list__value">
+          <app-number-plate
+            *ngFor="let secondaryVrm of otherVrms"
+            class="govuk-body govuk-!-margin-bottom-0"
+            [vrm]="secondaryVrm.vrm"
+            [isSecondary]="true"
+          ></app-number-plate>
+        </dd>
+      </div>
     </ng-container>
-  </div>
 
-  <ng-container *ngIf="currentTechRecord.statusCode !== statuses.ARCHIVED">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Record status</dt>
-      <dd id="record-completeness" class="govuk-summary-list__value">
-        <app-tag [type]="getCompletenessColor(currentTechRecord.recordCompleteness)">
-          {{ currentTechRecord.recordCompleteness | uppercase }}
-        </app-tag>
-      </dd>
-    </div>
+    <ng-template #trailerHeader>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Trailer ID</dt>
+        <dd id="trailer-id" class="govuk-summary-list__value">
+          {{ vehicle?.trailerId | defaultNullOrEmpty }}
+        </dd>
+      </div>
+    </ng-template>
 
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Record visibility in VTA</dt>
-      <dd id="record-visibility" class="govuk-summary-list__value">
-        <app-tag [type]="currentTechRecord.hiddenInVta ? 'red' : 'green'">
-          {{ currentTechRecord.hiddenInVta ? 'HIDDEN' : 'VISIBLE' }}
-        </app-tag>
+      <dt class="govuk-summary-list__key">Record type</dt>
+      <dd id="status-code" class="govuk-summary-list__value">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">{{ currentTechRecord.statusCode | defaultNullOrEmpty }}</strong>
       </dd>
       <ng-container *ngIf="!hideActions">
-        <dd class="govuk-summary-list__actions">
+        <dd *appRoleRequired="roles.TechRecordArchive" class="govuk-summary-list__actions">
           <div class="govuk-summary-list__actions--flex">
-            <app-button design="link" id="change-record-visibility-in-vta-link" (clicked)="navigateTo('change-vta-visibility')">Change</app-button>
+            <app-button
+              *ngIf="queryableActions.includes('archive')"
+              design="link"
+              id="change-status-to-archive-link"
+              (clicked)="navigateTo('change-status', { to: 'archived' })"
+              >Archive</app-button
+            >
+            <app-button
+              *ngIf="queryableActions.includes('promote')"
+              design="link"
+              id="promote-link"
+              (clicked)="navigateTo('change-status', { to: 'current' })"
+              >Promote</app-button
+            >
           </div>
         </dd>
       </ng-container>
     </div>
-  </ng-container>
-</dl>
+
+    <ng-container *ngIf="currentTechRecord.statusCode !== statuses.ARCHIVED">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Record status</dt>
+        <dd id="record-completeness" class="govuk-summary-list__value">
+          <app-tag [type]="getCompletenessColor(currentTechRecord.recordCompleteness)">
+            {{ currentTechRecord.recordCompleteness | uppercase }}
+          </app-tag>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Record visibility in VTA</dt>
+        <dd id="record-visibility" class="govuk-summary-list__value">
+          <app-tag [type]="currentTechRecord.hiddenInVta ? 'red' : 'green'">
+            {{ currentTechRecord.hiddenInVta ? 'HIDDEN' : 'VISIBLE' }}
+          </app-tag>
+        </dd>
+        <ng-container *ngIf="!hideActions">
+          <dd class="govuk-summary-list__actions">
+            <div class="govuk-summary-list__actions--flex">
+              <app-button design="link" id="change-record-visibility-in-vta-link" (clicked)="navigateTo('change-vta-visibility')">Change</app-button>
+            </div>
+          </dd>
+        </ng-container>
+      </div>
+    </ng-container>
+  </dl>
+</ng-container>

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
@@ -9,25 +9,25 @@ import { editableTechRecord } from '@store/technical-records';
 import { Observable, take } from 'rxjs';
 
 @Component({
-  selector: 'app-tech-record-title',
+  selector: 'app-tech-record-title[vehicle]',
   templateUrl: './tech-record-title.component.html',
   styleUrls: ['./tech-record-title.component.scss']
 })
 export class TechRecordTitleComponent implements OnInit {
-  @Input() vehicleTechRecord?: VehicleTechRecordModel;
-  @Input() recordActions: TechRecordActions = TechRecordActions.NONE;
+  @Input() vehicle?: VehicleTechRecordModel;
+  @Input() actions: TechRecordActions = TechRecordActions.NONE;
   @Input() hideActions: boolean = false;
 
   currentTechRecord$!: Observable<TechRecordModel | undefined>;
-  queryableRecordActions: string[] = [];
-  vehicleMakeAndModel?: string;
+  queryableActions: string[] = [];
+  vehicleMakeAndModel = '';
 
-  constructor(private route: ActivatedRoute, private router: Router, private technicalRecordService: TechnicalRecordService, private store: Store) {}
+  constructor(private route: ActivatedRoute, private router: Router, private store: Store, private technicalRecordService: TechnicalRecordService) {}
 
   ngOnInit(): void {
-    this.queryableRecordActions = this.recordActions.split(',');
+    this.queryableActions = this.actions.split(',');
 
-    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$(this.vehicleTechRecord!);
+    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$(this.vehicle!);
 
     this.currentTechRecord$
       .pipe(take(1))
@@ -43,7 +43,7 @@ export class TechRecordTitleComponent implements OnInit {
   }
 
   get currentVrm(): string | undefined {
-    return this.vehicleTechRecord?.vrms.find(vrm => vrm.isPrimary === true)?.vrm;
+    return this.vehicle?.vrms.find(vrm => vrm.isPrimary === true)?.vrm;
   }
 
   get editableTechRecord$() {
@@ -51,7 +51,7 @@ export class TechRecordTitleComponent implements OnInit {
   }
 
   get otherVrms(): Vrm[] | undefined {
-    return this.vehicleTechRecord?.vrms.filter(vrm => vrm.isPrimary === false);
+    return this.vehicle?.vrms.filter(vrm => vrm.isPrimary === false);
   }
 
   get vehicleTypes(): typeof VehicleTypes {

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.html
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.html
@@ -1,8 +1,4 @@
-<div *ngIf="!testRecords || !testRecords.length">
-  <h2 class="govuk-heading-m">Test Records</h2>
-  <h3 class="govuk-heading-s">No test records found.</h3>
-</div>
-<ng-container *ngIf="testRecords && testRecords.length">
+<ng-container *ngIf="testResults?.length; else noTestResults">
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">
       Test Records
@@ -30,3 +26,8 @@
   </table>
   <app-pagination tableName="test-history" [numberOfItems]="numberOfRecords" (paginationOptions)="handlePaginationChange($event)"></app-pagination>
 </ng-container>
+
+<ng-template #noTestResults>
+  <h2 class="govuk-heading-m">Test Records</h2>
+  <h3 class="govuk-heading-s">No test records found.</h3>
+</ng-template>

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.spec.ts
@@ -28,7 +28,7 @@ describe('TestRecordSummaryComponent', () => {
   });
 
   it('should not show table if no records found', () => {
-    component.testRecords = [];
+    component.testResults = [];
     fixture.detectChanges();
 
     const heading = fixture.debugElement.query(By.css('.govuk-heading-s'));
@@ -40,7 +40,7 @@ describe('TestRecordSummaryComponent', () => {
   });
 
   it('should show table if records found', () => {
-    component.testRecords = [createMock<TestResultModel>()];
+    component.testResults = [createMock<TestResultModel>()];
     fixture.detectChanges();
 
     const heading = fixture.debugElement.query(By.css('.govuk-heading-s'));
@@ -107,7 +107,7 @@ describe('TestRecordSummaryComponent', () => {
         ]
       }
     ] as TestResultModel[];
-    component.testRecords = mockRecords;
+    component.testResults = mockRecords;
     const testFieldResults = component.sortedTestTypeFields;
 
     expect(testFieldResults).toHaveLength(3);

--- a/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
+++ b/src/app/features/tech-record/components/test-record-summary/test-record-summary.component.ts
@@ -17,35 +17,29 @@ interface TestField {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TestRecordSummaryComponent {
-  @Input() testRecords: TestResultModel[] = [];
-
-  public get roles() {
-    return Roles;
-  }
+  @Input() testResults: TestResultModel[] = [];
 
   pageStart?: number;
   pageEnd?: number;
 
   constructor(private cdr: ChangeDetectorRef) {}
 
-  handlePaginationChange({ start, end }: { start: number; end: number }) {
-    this.pageStart = start;
-    this.pageEnd = end;
-    this.cdr.detectChanges();
+  public get roles() {
+    return Roles;
   }
 
-  getTestTypeName(testResult: TestResultModel) {
-    return testResult.testTypes.map(t => t.testTypeName).join(',');
+  get numberOfRecords(): number {
+    return this.testResults.length;
   }
 
-  getTestTypeResults(testResult: TestResultModel) {
-    return testResult.testTypes.map(t => t.testResult).join(',');
+  get paginatedTestFields() {
+    return this.sortedTestTypeFields.slice(this.pageStart, this.pageEnd);
   }
 
   get sortedTestTypeFields(): TestField[] {
     const byDate = (a: TestField, b: TestField) => new Date(b.testTypeStartTimestamp).getTime() - new Date(a.testTypeStartTimestamp).getTime();
 
-    return this.testRecords
+    return this.testResults
       .flatMap(record =>
         record.testTypes.map(testType => ({
           testTypeStartTimestamp: testType.testTypeStartTimestamp,
@@ -58,15 +52,21 @@ export class TestRecordSummaryComponent {
       .sort(byDate);
   }
 
-  get numberOfRecords(): number {
-    return this.testRecords.length;
+  getTestTypeName(testResult: TestResultModel) {
+    return testResult.testTypes.map(t => t.testTypeName).join(',');
   }
 
-  get paginatedTestFields() {
-    return this.sortedTestTypeFields.slice(this.pageStart, this.pageEnd);
+  getTestTypeResults(testResult: TestResultModel) {
+    return testResult.testTypes.map(t => t.testResult).join(',');
   }
 
   trackByFn(i: number, t: TestField) {
     return t.testNumber;
+  }
+
+  handlePaginationChange({ start, end }: { start: number; end: number }) {
+    this.pageStart = start;
+    this.pageEnd = end;
+    this.cdr.detectChanges();
   }
 }

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -1,21 +1,21 @@
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" *ngIf="currentTechRecord$ | async as currentTechRecord">
   <div class="govuk-grid-column-one-third">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full" *ngIf="currentTechRecord$ | async as currentTechRecord">
-        <app-tech-record-title [vehicleTechRecord]="vehicleTechRecord" [recordActions]="getActions(currentTechRecord)"></app-tech-record-title>
+      <div class="govuk-grid-column-full">
+        <app-tech-record-title [vehicle]="vehicle" [actions]="getActions(currentTechRecord)"></app-tech-record-title>
 
         <app-edit-tech-record-button
-          [vehicleTechRecord]="vehicleTechRecord"
+          *appRoleRequired="roles.TechRecordAmend"
+          [vehicle]="vehicle"
           [viewableTechRecord]="currentTechRecord"
           [(isEditing)]="isEditing"
           [isDirty]="isDirty"
           (submitChange)="handleSubmit()"
-          *appRoleRequired="roles.TechRecordAmend"
         ></app-edit-tech-record-button>
 
-        <app-tech-record-history [currentRecord]="currentTechRecord" [vehicleTechRecord]="vehicleTechRecord"></app-tech-record-history>
+        <app-tech-record-history [vehicle]="vehicle" [currentTechRecord]="currentTechRecord"></app-tech-record-history>
 
-        <app-test-record-summary *appRoleRequired="roles.TestResultView" [testRecords]="(records$ | async) || []"></app-test-record-summary>
+        <app-test-record-summary *appRoleRequired="roles.TestResultView" [testResults]="(testResults$ | async) || []"></app-test-record-summary>
 
         <ng-container *ngIf="!isArchived && !isEditing">
           <div class="govuk-button-group" *appRoleRequired="[roles.TestResultCreateContingency, roles.TestResultCreateDeskAssesment]">
@@ -27,10 +27,10 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <app-tech-record-summary
-      *ngIf="currentTechRecord$ | async as currentTechRecord"
+      [techRecord]="currentTechRecord"
       [isEditing]="isEditing"
-      [vehicleTechRecord]="currentTechRecord"
-      (formChange)="handleFormState()"
+      (isFormDirty)="isDirty = $event"
+      (isFormInvalid)="isInvalid = $event"
     ></app-tech-record-summary>
   </div>
 </div>

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -75,6 +75,7 @@ describe('VehicleTechnicalRecordComponent', () => {
     store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(VehicleTechnicalRecordComponent);
     component = fixture.componentInstance;
+    component.vehicle = mockVehicleTechnicalRecord();
   });
 
   it('should create', () => {
@@ -84,13 +85,11 @@ describe('VehicleTechnicalRecordComponent', () => {
 
   it('should get current vrm', () => {
     fixture.detectChanges();
-    component.vehicleTechRecord = mockVehicleTechnicalRecord();
     expect(component.currentVrm).toEqual('KP01ABC');
   });
 
   it('should get other Vrms', () => {
     fixture.detectChanges();
-    component.vehicleTechRecord = mockVehicleTechnicalRecord();
     expect(component.otherVrms).toEqual([
       {
         vrm: '609859Z',
@@ -104,16 +103,14 @@ describe('VehicleTechnicalRecordComponent', () => {
   });
 
   it('should get current tech record', () => {
-    component.vehicleTechRecord = mockVehicleTechnicalRecord();
-    component.vehicleTechRecord.techRecord = component.vehicleTechRecord.techRecord.filter(record => record.statusCode === StatusCodes.CURRENT);
+    component.vehicle.techRecord = component.vehicle.techRecord.filter(record => record.statusCode === StatusCodes.CURRENT);
     fixture.detectChanges();
 
     component.currentTechRecord$?.subscribe(record => expect(record).toBeTruthy());
   });
 
   it('should get archived tech record', () => {
-    component.vehicleTechRecord = mockVehicleTechnicalRecord();
-    component.vehicleTechRecord.techRecord = component.vehicleTechRecord.techRecord.filter(record => record.statusCode === StatusCodes.ARCHIVED);
+    component.vehicle.techRecord = component.vehicle.techRecord.filter(record => record.statusCode === StatusCodes.ARCHIVED);
     fixture.detectChanges();
 
     component.currentTechRecord$?.subscribe(record => expect(record).toBeTruthy());
@@ -122,58 +119,40 @@ describe('VehicleTechnicalRecordComponent', () => {
   it('should get tech record using created date', () => {
     const expectedDate = new Date();
     store.overrideSelector(selectRouteNestedParams, { techCreatedAt: expectedDate });
-    component.vehicleTechRecord = mockVehicleTechnicalRecord();
-    component.vehicleTechRecord.techRecord[0].createdAt = expectedDate;
+    component.vehicle.techRecord[0].createdAt = expectedDate;
     fixture.detectChanges();
 
     component.currentTechRecord$?.subscribe(record => expect(record).toBeTruthy());
   });
 
   describe('handleSubmit', () => {
-    it('should evaluate form validity', () => {
-      const handleFormStateSpy = jest.spyOn(component, 'handleFormState');
-      component.vehicleTechRecord = mockVehicleTechnicalRecord();
-      fixture.detectChanges();
-
-      component.isEditing = true;
-      component.handleSubmit();
-
-      expect(handleFormStateSpy).toHaveBeenCalled();
-      expect(component.isInvalid).toBeTruthy();
-      expect(component.isDirty).toBeFalsy();
-    });
-
     describe('correcting an error', () => {
       beforeEach(() => {
         component.editingReason = ReasonForEditing.CORRECTING_AN_ERROR;
-        component.handleFormState = jest.fn(() => (component.isInvalid = false));
         fixture.detectChanges();
       });
 
       it('should update the current for a valid form', fakeAsync(() => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        component.vehicleTechRecord = mockVehicleTechnicalRecord();
         tick();
         component.handleSubmit();
-        expect(dispatchSpy).toHaveBeenCalledWith(updateTechRecords({ systemNumber: component.vehicleTechRecord.systemNumber }));
+        expect(dispatchSpy).toHaveBeenCalledWith(updateTechRecords({ systemNumber: component.vehicle.systemNumber }));
       }));
     });
 
     describe('notifiable alteration', () => {
       beforeEach(() => {
         component.editingReason = ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED;
-        component.handleFormState = jest.fn(() => (component.isInvalid = false));
         fixture.detectChanges();
       });
 
       it('should dispatch updateTechRecords with oldStatusCode to archive the prosional', fakeAsync(() => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        component.vehicleTechRecord = mockVehicleTechnicalRecord();
         tick();
         component.handleSubmit();
         expect(dispatchSpy).toHaveBeenCalledWith(
           updateTechRecords({
-            systemNumber: component.vehicleTechRecord.systemNumber,
+            systemNumber: component.vehicle.systemNumber,
             recordToArchiveStatus: StatusCodes.PROVISIONAL,
             newStatus: StatusCodes.PROVISIONAL
           })
@@ -182,12 +161,11 @@ describe('VehicleTechnicalRecordComponent', () => {
 
       it('should dispatch updateTechRecords to create a new provisional when one isnt present', fakeAsync(() => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        component.vehicleTechRecord = mockVehicleTechnicalRecord();
         //remove provisional
-        component.vehicleTechRecord.techRecord.splice(0, 1);
+        component.vehicle.techRecord.splice(0, 1);
         tick();
         component.handleSubmit();
-        expect(dispatchSpy).toHaveBeenCalledWith(createProvisionalTechRecord({ systemNumber: component.vehicleTechRecord.systemNumber }));
+        expect(dispatchSpy).toHaveBeenCalledWith(createProvisionalTechRecord({ systemNumber: component.vehicle.systemNumber }));
       }));
     });
   });

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -24,11 +24,17 @@ import { createProvisionalTechRecord, updateTechRecords } from '@store/technical
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { MultiOptionsService } from '@forms/services/multi-options.service';
 import { TechRecordTitleComponent } from '../tech-record-title/tech-record-title.component';
+import { Component } from '@angular/core';
 
 describe('VehicleTechnicalRecordComponent', () => {
   let component: VehicleTechnicalRecordComponent;
   let fixture: ComponentFixture<VehicleTechnicalRecordComponent>;
   let store: MockStore<State>;
+
+  @Component({})
+  class TechRecordSummaryStubComponent {
+    checkForms() {}
+  }
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -47,7 +53,7 @@ describe('VehicleTechnicalRecordComponent', () => {
         TechRecordHistoryComponent,
         TechRecordSummaryComponent,
         TechRecordTitleComponent,
-        TestRecordSummaryComponent,
+        TechRecordSummaryStubComponent,
         VehicleTechnicalRecordComponent
       ],
       providers: [
@@ -130,6 +136,7 @@ describe('VehicleTechnicalRecordComponent', () => {
       beforeEach(() => {
         component.editingReason = ReasonForEditing.CORRECTING_AN_ERROR;
         fixture.detectChanges();
+        component.summary = TestBed.createComponent(TechRecordSummaryStubComponent).componentInstance as TechRecordSummaryComponent;
       });
 
       it('should update the current for a valid form', fakeAsync(() => {
@@ -144,6 +151,7 @@ describe('VehicleTechnicalRecordComponent', () => {
       beforeEach(() => {
         component.editingReason = ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED;
         fixture.detectChanges();
+        component.summary = TestBed.createComponent(TechRecordSummaryStubComponent).componentInstance as TechRecordSummaryComponent;
       });
 
       it('should dispatch updateTechRecords with oldStatusCode to archive the prosional', fakeAsync(() => {

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -1,9 +1,7 @@
-import { AfterViewInit, Component, Input, OnInit, ViewChild } from '@angular/core';
-import { GlobalError } from '@core/components/global-error/global-error.interface';
-import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { DynamicFormService } from '@forms/services/dynamic-form.service';
-import { CustomFormArray, CustomFormGroup } from '@forms/services/dynamic-form.types';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Roles } from '@models/roles.enum';
+import { TechRecordActions } from '@models/tech-record/tech-record-actions.enum';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { ReasonForEditing, StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes, Vrm } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
@@ -13,44 +11,41 @@ import { createProvisionalTechRecord, updateTechRecords } from '@store/technical
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
 import { Observable, tap } from 'rxjs';
 import { TechRecordSummaryComponent } from '../tech-record-summary/tech-record-summary.component';
-import { ActivatedRoute, Router } from '@angular/router';
-import { TechRecordActions } from '@models/tech-record/tech-record-actions.enum';
 
 @Component({
-  selector: 'app-vehicle-technical-record',
+  selector: 'app-vehicle-technical-record[vehicle]',
   templateUrl: './vehicle-technical-record.component.html',
   styleUrls: ['./vehicle-technical-record.component.scss']
 })
-export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
+export class VehicleTechnicalRecordComponent implements OnInit {
   @ViewChild(TechRecordSummaryComponent) summary!: TechRecordSummaryComponent;
-  @Input() vehicleTechRecord?: VehicleTechRecordModel;
+  @Input() vehicle!: VehicleTechRecordModel;
 
   currentTechRecord$!: Observable<TechRecordModel | undefined>;
-  records$: Observable<TestResultModel[]>;
+  testResults$: Observable<TestResultModel[]>;
+  editingReason?: ReasonForEditing;
 
-  isDirty = false;
   isCurrent = false;
   isArchived = false;
-  isInvalid = false;
   isEditing = false;
-  editingReason?: ReasonForEditing;
+  isDirty = false;
+  isInvalid = false;
 
   constructor(
     testRecordService: TestRecordsService,
     private activatedRoute: ActivatedRoute,
-    private errorService: GlobalErrorService,
     private route: ActivatedRoute,
     private router: Router,
     private store: Store<TechnicalRecordServiceState>,
     private technicalRecordService: TechnicalRecordService
   ) {
-    this.records$ = testRecordService.testRecords$;
+    this.testResults$ = testRecordService.testRecords$;
     this.isEditing = this.activatedRoute.snapshot.data['isEditing'] ?? false;
     this.editingReason = this.activatedRoute.snapshot.data['reason'];
   }
 
   ngOnInit(): void {
-    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$(this.vehicleTechRecord!).pipe(
+    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$(this.vehicle).pipe(
       tap(viewableTechRecord => {
         this.isCurrent = viewableTechRecord?.statusCode === StatusCodes.CURRENT;
         this.isArchived = viewableTechRecord?.statusCode === StatusCodes.ARCHIVED;
@@ -58,16 +53,12 @@ export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
     );
   }
 
-  ngAfterViewInit(): void {
-    this.handleFormState();
-  }
-
   get currentVrm(): string | undefined {
-    return this.vehicleTechRecord?.vrms.find(vrm => vrm.isPrimary === true)?.vrm;
+    return this.vehicle.vrms.find(vrm => vrm.isPrimary === true)?.vrm;
   }
 
   get otherVrms(): Vrm[] | undefined {
-    return this.vehicleTechRecord?.vrms.filter(vrm => vrm.isPrimary === false);
+    return this.vehicle.vrms.filter(vrm => vrm.isPrimary === false);
   }
 
   get roles(): typeof Roles {
@@ -80,23 +71,6 @@ export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
 
   get statusCodes(): typeof StatusCodes {
     return StatusCodes;
-  }
-
-  get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {
-    const type = this.vehicleTechRecord?.techRecord.find(record => record.statusCode === StatusCodes.CURRENT)?.vehicleType;
-
-    const commonCustomSections = [this.summary.body.form, this.summary.dimensions.form, this.summary.tyres.form, this.summary.weights.form];
-
-    switch (type) {
-      case VehicleTypes.PSV:
-        return [...commonCustomSections, this.summary.psvBrakes!.form];
-      case VehicleTypes.HGV:
-        return commonCustomSections;
-      case VehicleTypes.TRL:
-        return [...commonCustomSections, this.summary.trlBrakes!.form];
-      default:
-        return [];
-    }
   }
 
   getActions(techRecord?: TechRecordModel): TechRecordActions {
@@ -138,31 +112,10 @@ export class VehicleTechnicalRecordComponent implements OnInit, AfterViewInit {
     }
   }
 
-  isAnyFormInvalid(forms: Array<CustomFormGroup | CustomFormArray>): boolean {
-    const errors: GlobalError[] = [];
-
-    forms.forEach(form => DynamicFormService.updateValidity(form, errors));
-
-    errors.length ? this.errorService.setErrors(errors) : this.errorService.clearErrors();
-
-    return forms.some(form => form.invalid);
-  }
-
-  handleFormState(): void {
-    if (this.isEditing) {
-      const form = this.summary.sections.map(section => section.form).concat(this.customSectionForms);
-
-      this.isDirty = form.some(form => form.dirty);
-      this.isInvalid = this.isAnyFormInvalid(form);
-    }
-  }
-
   handleSubmit(): void {
-    this.handleFormState();
-
     if (!this.isInvalid) {
-      const { systemNumber } = this.vehicleTechRecord!;
-      const hasProvisional = this.vehicleTechRecord!.techRecord.some(record => record.statusCode === StatusCodes.PROVISIONAL);
+      const { systemNumber } = this.vehicle;
+      const hasProvisional = this.vehicle.techRecord.some(record => record.statusCode === StatusCodes.PROVISIONAL);
 
       if (this.editingReason == ReasonForEditing.CORRECTING_AN_ERROR) {
         this.store.dispatch(updateTechRecords({ systemNumber }));

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -113,6 +113,8 @@ export class VehicleTechnicalRecordComponent implements OnInit {
   }
 
   handleSubmit(): void {
+    this.summary.checkForms();
+
     if (!this.isInvalid) {
       const { systemNumber } = this.vehicle;
       const hasProvisional = this.vehicle.techRecord.some(record => record.statusCode === StatusCodes.PROVISIONAL);

--- a/src/app/features/tech-record/tech-record.component.html
+++ b/src/app/features/tech-record/tech-record.component.html
@@ -1,17 +1,16 @@
-<ng-container *ngIf="vehicleTechRecord$ | async as vehicleTechRecord">
-  <app-vehicle-technical-record
-    [vehicleTechRecord]="vehicleTechRecord || undefined"
-    *appRoleRequired="roles.TechRecordView"
-  ></app-vehicle-technical-record>
+<ng-container *ngIf="vehicle$ | async as vehicle; else noVehicle">
+  <app-vehicle-technical-record *appRoleRequired="roles.TechRecordView" [vehicle]="vehicle"></app-vehicle-technical-record>
+
+  <ng-template #error let-name>
+    <ng-container *ngIf="errorService.errors$ | async as errorMessages">
+      <span id="search-term-error" class="govuk-error-message" *ngIf="getErrorByName(errorMessages, name) as errorMessage">
+        <span class="govuk-visually-hidden">Error:</span>
+        <p class="white-space--normal">{{ errorMessage.error }}</p>
+      </span>
+    </ng-container>
+  </ng-template>
 </ng-container>
 
-<h1 *ngIf="(vehicleTechRecord$ | async) === undefined">This vehicle is not real, like the no vehicle page we need to create</h1>
-
-<ng-template #error let-name>
-  <ng-container *ngIf="errorService.errors$ | async as errorMessages">
-    <span id="search-term-error" class="govuk-error-message" *ngIf="getErrorByName(errorMessages, name) as errorMessage">
-      <span class="govuk-visually-hidden">Error:</span>
-      <p class="white-space--normal">{{ errorMessage.error }}</p>
-    </span>
-  </ng-container>
+<ng-template #noVehicle>
+  <h1>This vehicle is not real, like the no vehicle page we need to create</h1>
 </ng-template>

--- a/src/app/features/tech-record/tech-record.component.html
+++ b/src/app/features/tech-record/tech-record.component.html
@@ -1,16 +1,16 @@
 <ng-container *ngIf="vehicle$ | async as vehicle; else noVehicle">
   <app-vehicle-technical-record *appRoleRequired="roles.TechRecordView" [vehicle]="vehicle"></app-vehicle-technical-record>
-
-  <ng-template #error let-name>
-    <ng-container *ngIf="errorService.errors$ | async as errorMessages">
-      <span id="search-term-error" class="govuk-error-message" *ngIf="getErrorByName(errorMessages, name) as errorMessage">
-        <span class="govuk-visually-hidden">Error:</span>
-        <p class="white-space--normal">{{ errorMessage.error }}</p>
-      </span>
-    </ng-container>
-  </ng-template>
 </ng-container>
 
 <ng-template #noVehicle>
   <h1>This vehicle is not real, like the no vehicle page we need to create</h1>
+</ng-template>
+
+<ng-template #error let-name>
+  <ng-container *ngIf="errorService.errors$ | async as errorMessages">
+    <span id="search-term-error" class="govuk-error-message" *ngIf="getErrorByName(errorMessages, name) as errorMessage">
+      <span class="govuk-visually-hidden">Error:</span>
+      <p class="white-space--normal">{{ errorMessage.error }}</p>
+    </span>
+  </ng-container>
 </ng-template>

--- a/src/app/features/tech-record/tech-record.component.ts
+++ b/src/app/features/tech-record/tech-record.component.ts
@@ -1,26 +1,25 @@
 import { Component } from '@angular/core';
-import { VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
-import { Roles } from '@models/roles.enum';
-
-import { Observable } from 'rxjs';
+import { Router } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { Router } from '@angular/router';
+import { Roles } from '@models/roles.enum';
+import { VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record',
   templateUrl: './tech-record.component.html'
 })
 export class TechRecordComponent {
-  vehicleTechRecord$: Observable<VehicleTechRecordModel | undefined>;
+  vehicle$: Observable<VehicleTechRecordModel | undefined>;
 
   constructor(private techrecordService: TechnicalRecordService, private router: Router, public errorService: GlobalErrorService) {
-    this.vehicleTechRecord$ = this.techrecordService.selectedVehicleTechRecord$;
+    this.vehicle$ = this.techrecordService.selectedVehicleTechRecord$;
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
   }
 
-  public get roles() {
+  get roles() {
     return Roles;
   }
 

--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -180,9 +180,7 @@ export class TechnicalRecordServiceEffects {
             }, {}) as TechRecordModel
           );
         }),
-        tap(mergedForms => {
-          this.technicalRecordService.updateEditingTechRecord(mergedForms);
-        })
+        tap(mergedForms => this.technicalRecordService.updateEditingTechRecord(mergedForms))
       ),
     { dispatch: false }
   );


### PR DESCRIPTION
## Update the Editable Tech Record Logic

- Centralize the logic that verifies all tech record summary forms are valid which was duplicated across the Vehicle Tech Record Component and the Hydrate Component. The validation logic being outside of the summary component was causing bugs as it was using `selectedTechRecord` instead of `editableTechRecord`.
- Simplify the naming conventions in common tech record components

[CB2-7456](https://dvsa.atlassian.net/browse/CB2-7456)