### PR TITLE
feat(*): add create auto labelling and assignee action

### DIFF
--- a/.github/workflows/pr-label-and-assign.yml
+++ b/.github/workflows/pr-label-and-assign.yml
@@ -16,6 +16,7 @@ jobs:
             ["fix", ["bug"]],
             ["test", ["coverage"]],
             ["refactor", ["refactor"]],
+            ["chore", ["task"]],
             ]);
             const labels = labelMap.get(context.payload.pull_request.title.split("(")[0])
             if (labels) {

--- a/.github/workflows/pr-label-and-assign.yml
+++ b/.github/workflows/pr-label-and-assign.yml
@@ -1,4 +1,4 @@
-name: Label PRs
+name: Label and assign PRs
 on:
   pull_request:
     branches: ['develop']
@@ -28,3 +28,9 @@ jobs:
             } else {
               console.log("No label found. Please format PR title.")
             }
+            github.rest.issues.addAssignees({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: [context.payload.pull_request.user.login]
+            })

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,30 @@
+name: Label PRs
+on:
+  pull_request:
+    branches: ['develop']
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const labelMap = new Map([
+            ["feat", ["enhancement"]],
+            ["fix", ["bug"]],
+            ["test", ["coverage"]],
+            ["refactor", ["refactor"]],
+            ]);
+            const labels = labelMap.get(context.payload.pull_request.title.split("(")[0])
+            if (labels) {
+              github.rest.issues.addLabels({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels,
+              });
+            } else {
+              console.log("No label found. Please format PR title.")
+            }


### PR DESCRIPTION
## Auto-add labels to PRs accoring to the PR title
Because adding labels manually can be tedious. Also means people are more inclined to format their PR titles. And adding the assignee as well

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
