### PR TITLE
fix(cb2-7470): 

### DIFF
--- a/src/app/features/create/create.component.html
+++ b/src/app/features/create/create.component.html
@@ -15,7 +15,18 @@
     label="VRM / Trailer ID"
     [width]="30"
     (ngModelChange)="ngOnChanges()"
+    *ngIf="!generateID.value"
   ></app-text-input>
+  <span class="govuk-list" *ngIf="!generateID.value">Or</span>
+
+  <app-checkbox-group
+    #generateID
+    formControlName="generateID"
+    name="generate-c-or-z-num"
+    [options]="[{ value: true, label: 'Generate a C/Z number on submission of the new record' }]"
+    (ngModelChange)="toggleVrmInput(generateID)"
+  ></app-checkbox-group>
+
   <app-select
     #selectVehicleStatus
     formControlName="vehicleStatus"

--- a/src/app/features/create/create.component.ts
+++ b/src/app/features/create/create.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnChanges } from '@angular/core';
-import { FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
@@ -16,7 +16,7 @@ import { firstValueFrom } from 'rxjs';
 })
 export class CreateComponent implements OnChanges {
   vehicle: Partial<VehicleTechRecordModel> = {};
-  isDuplicateVinAlllowed: boolean = false;
+  isDuplicateVinAllowed: boolean = false;
   isVinUniqueCheckComplete: boolean = false;
 
   vinUnique: boolean = false;
@@ -38,13 +38,24 @@ export class CreateComponent implements OnChanges {
       Validators.maxLength(9),
       Validators.required
     ]),
-    vehicleStatus: new CustomFormControl({ name: 'change-vehicle-status-select', label: 'Vehicle status', type: FormNodeTypes.CONTROL }, '', [
-      Validators.required
-    ]),
+    vehicleStatus: new CustomFormControl(
+      { name: 'change-vehicle-status-select', label: 'Vehicle status', type: FormNodeTypes.CONTROL },
+      StatusCodes.PROVISIONAL,
+      [Validators.required]
+    ),
     vehicleType: new CustomFormControl({ name: 'change-vehicle-type-select', label: 'Vehicle type', type: FormNodeTypes.CONTROL }, '', [
       Validators.required
-    ])
+    ]),
+    generateID: new CustomFormControl({ name: 'generate-c-or-z-num', type: FormNodeTypes.CONTROL }, null)
   });
+
+  public vehicleTypeOptions: MultiOptions = [
+    { label: 'Heavy goods vehicle (HGV)', value: VehicleTypes.HGV },
+    { label: 'Public service vehicle (PSV)', value: VehicleTypes.PSV },
+    { label: 'Trailer (TRL)', value: VehicleTypes.TRL }
+  ];
+
+  public vehicleStatusOptions: MultiOptions = [{ label: 'Provisional', value: StatusCodes.PROVISIONAL }];
 
   constructor(
     private globalErrorService: GlobalErrorService,
@@ -55,18 +66,25 @@ export class CreateComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.globalErrorService.clearErrors();
+    console.log(this.vehicleForm.value);
   }
 
-  public vehicleTypeOptions: MultiOptions = [
-    { label: 'Heavy goods vehicle (HGV)', value: VehicleTypes.HGV },
-    { label: 'Public service vehicle (PSV)', value: VehicleTypes.PSV },
-    { label: 'Trailer (TRL)', value: VehicleTypes.TRL }
-  ];
+  toggleVrmInput(checked: any) {
+    const vrmTrm = this.vehicleForm.controls['vrmTrm'];
+    checked.value ? this.generateID(vrmTrm) : this.vrmTrm(vrmTrm);
+  }
 
-  public vehicleStatusOptions: MultiOptions = [
-    { label: 'Current', value: StatusCodes.CURRENT },
-    { label: 'Provisional', value: StatusCodes.PROVISIONAL }
-  ];
+  vrmTrm(vrmTrm: AbstractControl) {
+    vrmTrm.addValidators(Validators.required);
+    vrmTrm.setValue('');
+    vrmTrm.enable();
+  }
+
+  generateID(vrmTrm: AbstractControl) {
+    vrmTrm.removeValidators(Validators.required);
+    vrmTrm.setValue(null);
+    vrmTrm.disable();
+  }
 
   get primaryVrm(): string {
     return this.vehicle.vrms?.find(vrm => vrm.isPrimary)?.vrm ?? '';
@@ -93,7 +111,7 @@ export class CreateComponent implements OnChanges {
     }
 
     if (!(await this.isFormValueUnique())) {
-      this.isDuplicateVinAlllowed = true;
+      this.isDuplicateVinAllowed = true;
       return;
     }
 
@@ -112,12 +130,16 @@ export class CreateComponent implements OnChanges {
       this.vinUnique = await this.isVinUnique();
     }
 
+    if (this.vehicleForm.controls['generateID'].value) {
+      return this.vinUnique || this.isDuplicateVinAllowed;
+    }
+
     if (isTrailer) {
       this.trlUnique = await this.isTrailerIdUnique();
-      return (this.vinUnique || this.isDuplicateVinAlllowed) && this.trlUnique;
+      return (this.vinUnique || this.isDuplicateVinAllowed) && this.trlUnique;
     } else {
       this.vrmUnique = await this.isVrmUnique();
-      return (this.vinUnique || this.isDuplicateVinAlllowed) && this.vrmUnique;
+      return (this.vinUnique || this.isDuplicateVinAllowed) && this.vrmUnique;
     }
   }
 

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
@@ -41,7 +41,7 @@
         <dd *appRoleRequired="roles.TechRecordArchive" class="govuk-summary-list__actions">
           <div class="govuk-summary-list__actions--flex">
             <app-button
-              *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === editableTechRecord.vehicleType"
+              *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === editableTechRecord.vehicleType && !hideActions"
               design="link"
               id="change-vrm-link"
               (clicked)="navigateTo('change-vrm')"

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
@@ -43,7 +43,7 @@ export class TechRecordTitleComponent implements OnInit {
   }
 
   get currentVrm(): string | undefined {
-    return this.vehicle?.vrms.find(vrm => vrm.isPrimary === true)?.vrm;
+    return this.vehicle?.vrms?.find(vrm => vrm.isPrimary)?.vrm;
   }
 
   get editableTechRecord$() {
@@ -51,7 +51,7 @@ export class TechRecordTitleComponent implements OnInit {
   }
 
   get otherVrms(): Vrm[] | undefined {
-    return this.vehicle?.vrms.filter(vrm => vrm.isPrimary === false);
+    return this.vehicle?.vrms?.filter(vrm => !vrm.isPrimary);
   }
 
   get vehicleTypes(): typeof VehicleTypes {

--- a/src/app/services/technical-record/technical-record.service.spec.ts
+++ b/src/app/services/technical-record/technical-record.service.spec.ts
@@ -181,8 +181,8 @@ describe('TechnicalRecordService', () => {
         const expectedBody = {
           msUserDetails: { msOid: expectedUser.id, msUser: expectedUser.name },
           vin: expectedVehicle.vin,
-          primaryVrm: expectedVehicle.vrms ? expectedVehicle.vrms[0].vrm : '',
-          trailerId: expectedVehicle.trailerId ?? '',
+          primaryVrm: expectedVehicle.vrms ? expectedVehicle.vrms[0].vrm : null,
+          trailerId: expectedVehicle.trailerId ?? null,
           techRecord: expectedVehicle.techRecord
         };
 
@@ -199,8 +199,8 @@ describe('TechnicalRecordService', () => {
 
         const expectedResult = {
           vin: expectedVehicle.vin,
-          primaryVrm: expectedVehicle.vrms ? expectedVehicle.vrms[0].vrm : '',
-          trailerId: expectedVehicle.trailerId ?? '',
+          primaryVrm: expectedVehicle.vrms ? expectedVehicle.vrms[0].vrm : null,
+          trailerId: expectedVehicle.trailerId ?? null,
           techRecord: expectedVehicle.techRecord
         };
 

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -98,8 +98,8 @@ export class TechnicalRecordService {
     const body = {
       msUserDetails: { msOid: user.id, msUser: user.name },
       vin: recordCopy.vin,
-      primaryVrm: recordCopy.vrms ? recordCopy.vrms[0].vrm : '',
-      trailerId: recordCopy.trailerId ?? '',
+      primaryVrm: recordCopy.vrms ? recordCopy.vrms[0].vrm : null,
+      trailerId: recordCopy.trailerId ?? null,
       techRecord: recordCopy.techRecord
     };
 


### PR DESCRIPTION
Add UI / UX logic to choose temporary numbers ( C or Z ) in the user flow for create tech record

Bypass is unique if the user has no Vrm or Trm then post value null which will be used trigger the generation
[Link](https://dvsa.atlassian.net/browse/CB2-7470)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
