### PR TITLE
fix(cb2-7489): get the vehicle type from the calculated tech record

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -90,7 +90,7 @@ export class TechRecordSummaryComponent implements OnInit {
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {
     const commonCustomSections = [this.body.form, this.dimensions.form, this.tyres.form, this.weights.form];
 
-    switch (this.techRecord.vehicleType) {
+    switch (this.techRecordCalculated.vehicleType) {
       case VehicleTypes.PSV:
         return [...commonCustomSections, this.psvBrakes!.form];
       case VehicleTypes.HGV:


### PR DESCRIPTION
## Not able to amend PSV vehicle type to HGV

[CB2-7489](https://dvsa.atlassian.net/browse/CB2-7489)