### PR TITLE
fix(cb2-7489): bug fix for changing vehicle type

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -90,7 +90,7 @@ export class TechRecordSummaryComponent implements OnInit {
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {
     const commonCustomSections = [this.body.form, this.dimensions.form, this.tyres.form, this.weights.form];
 
-    switch (this.techRecord.vehicleType) {
+    switch (this.techRecordCalculated.vehicleType) {
       case VehicleTypes.PSV:
         return [...commonCustomSections, this.psvBrakes!.form];
       case VehicleTypes.HGV:

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -88,7 +88,7 @@ export class TechRecordSummaryComponent implements OnInit {
   }
 
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {
-    const commonCustomSections = [this.body.form, this.dimensions.form, this.tyres.form, this.weights.form];
+    const commonCustomSections = [this.body?.form, this.dimensions?.form, this.tyres?.form, this.weights?.form];
 
     switch (this.techRecordCalculated.vehicleType) {
       case VehicleTypes.PSV:

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -12,7 +12,7 @@ export const SmallTrailerTechRecord: FormNode = {
       name: 'vehicleType',
       label: 'Vehicle type',
       value: '',
-      width: FormNodeWidth.XS,
+      width: FormNodeWidth.S,
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.VEHICLETYPE,
       disabled: true,


### PR DESCRIPTION
## Not able to amend PSV vehicle type to HGV

- Use `techRecordCalculated` when calculating custom sections.
- Make custom sections optional for vehicles with type LGV, CAR, SMALL TRL & MOTORCYCLE do not break.
- Extend the vehicle type field just enough to house "small trailer".

[CB2-7489](https://dvsa.atlassian.net/browse/CB2-7489)