### PR TITLE
fix(cb2-7027): enable adding test type group 3 for small trailers

### DIFF
--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
@@ -32,7 +32,19 @@
       </dd>
     </div>
 
-    <ng-container *ngIf="currentTechRecord.vehicleType !== vehicleTypes.TRL; else trailerHeader">
+    <ng-container *ngSwitch="currentTechRecord.vehicleType">
+      <!-- Small Trailer -->
+      <ng-container *ngSwitchCase="vehicleTypes.SMALL_TRL"></ng-container>
+
+      <!-- Trailer -->
+      <div *ngSwitchCase="vehicleTypes.TRL" class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Trailer ID</dt>
+        <dd id="trailer-id" class="govuk-summary-list__value">
+          {{ vehicle?.trailerId | defaultNullOrEmpty }}
+        </dd>
+      </div>
+
+      <!-- Default -->
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Vehicle registration mark (VRM)</dt>
         <dd id="current-vrm" class="govuk-summary-list__value">
@@ -63,15 +75,6 @@
         </dd>
       </div>
     </ng-container>
-
-    <ng-template #trailerHeader>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Trailer ID</dt>
-        <dd id="trailer-id" class="govuk-summary-list__value">
-          {{ vehicle?.trailerId | defaultNullOrEmpty }}
-        </dd>
-      </div>
-    </ng-template>
 
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Record type</dt>

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -15,13 +15,23 @@
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">Vehicle details</h2>
         <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">{{ testResult?.vehicleType === vehicleTypes.TRL ? 'Trailer ID' : 'VRM' }}</dt>
-            <dd id="test-testTypeId" class="govuk-summary-list__value">
-              <app-number-plate *ngIf="testResult?.vehicleType !== vehicleTypes.TRL; else trailerId" [vrm]="testResult?.vrm"></app-number-plate>
-              <ng-template #trailerId>{{ testResult?.trailerId | defaultNullOrEmpty }}</ng-template>
-            </dd>
-          </div>
+          <ng-container *ngSwitch="testResult?.vehicleType">
+            <ng-container *ngSwitchCase="vehicleTypes.SMALL_TRL"></ng-container>
+
+            <div *ngSwitchCase="vehicleTypes.TRL" class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Trailer ID</dt>
+              <dd id="test-testTypeId" class="govuk-summary-list__value">
+                {{ testResult?.trailerId | defaultNullOrEmpty }}
+              </dd>
+            </div>
+
+            <div *ngSwitchDefault class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">VRM</dt>
+              <dd id="test-testTypeId" class="govuk-summary-list__value">
+                <app-number-plate [vrm]="testResult?.vrm"></app-number-plate>
+              </dd>
+            </div>
+          </ng-container>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">VIN</dt>
             <dd class="govuk-summary-list__value">
@@ -70,13 +80,21 @@
     </div>
     <h3 class="govuk-heading-m">Vehicle overview</h3>
     <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">{{ testResult?.vehicleType === vehicleTypes.TRL ? 'Trailer ID' : 'VRM' }}</dt>
-        <dd id="test-testTypeId" class="govuk-summary-list__value">
-          <app-number-plate *ngIf="testResult?.vehicleType !== vehicleTypes.TRL; else trailerId" [vrm]="testResult?.vrm"></app-number-plate>
-          <ng-template #trailerId>{{ testResult?.trailerId | defaultNullOrEmpty }}</ng-template>
-        </dd>
-      </div>
+      <ng-container *ngSwitch="testResult?.vehicleType">
+        <ng-container *ngSwitchCase="vehicleTypes.SMALL_TRL"></ng-container>
+
+        <div *ngSwitchCase="vehicleTypes.TRL" class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Trailer ID</dt>
+          <dd id="test-testTypeId" class="govuk-summary-list__value">{{ testResult?.trailerId | defaultNullOrEmpty }}</dd>
+        </div>
+
+        <div *ngSwitchDefault class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">VRM</dt>
+          <dd id="test-testTypeId" class="govuk-summary-list__value">
+            <app-number-plate [vrm]="testResult?.vrm"></app-number-plate>
+          </dd>
+        </div>
+      </ng-container>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">VIN</dt>
         <dd id="test-vin" class="govuk-summary-list__value">

--- a/src/app/forms/models/testTypeId.enum.ts
+++ b/src/app/forms/models/testTypeId.enum.ts
@@ -190,7 +190,7 @@ export const SPECIALIST_TEST_TYPE_IDS: string[] = [
 
 export const TEST_TYPES_GROUP1_DESK_BASED_TEST: string[] = ['417', '418'];
 export const TEST_TYPES_GROUP2_DESK_BASED_TEST: string[] = ['403', '404', '415'];
-export const TEST_TYPES_GROUP3_DESK_BASED_TEST: string[] = ['407', '408', '414', '420', '426'];
+export const TEST_TYPES_GROUP3_DESK_BASED_TEST: string[] = ['407', '408', '414', '420', '426', '431'];
 export const TEST_TYPES_GROUP4_DESK_BASED_TEST: string[] = ['409', '411', '412', '423', '424', '425'];
 
 export const TEST_TYPES = {

--- a/src/app/forms/templates/test-records/section-templates/test/specialist/specialist-test-section-group3.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/specialist/specialist-test-section-group3.template.ts
@@ -52,10 +52,6 @@ export const SpecialistTestSectionGroup3: FormNode = {
                 { value: 'fail', label: 'Fail' },
                 { value: 'abandoned', label: 'Abandoned' }
               ],
-              validators: [
-                { name: ValidatorNames.HideIfNotEqual, args: { sibling: 'reasonForAbandoning', value: 'abandoned' } },
-                { name: ValidatorNames.HideIfNotEqual, args: { sibling: 'additionalCommentsForAbandon', value: 'abandoned' } }
-              ],
               asyncValidators: [
                 { name: AsyncValidatorNames.ResultDependantOnCustomDefects },
                 {

--- a/src/app/models/body-type-enum.ts
+++ b/src/app/models/body-type-enum.ts
@@ -103,8 +103,8 @@ const trlBodyTypeCodeMap = new Map<BodyTypeCode, BodyTypeDescription>([
   [BodyTypeCode.A, BodyTypeDescription.ARTICULATED],
   [BodyTypeCode.Y, BodyTypeDescription.CAR_TRANSPORTER],
   [BodyTypeCode.E, BodyTypeDescription.CURTAINSIDER],
-  [BodyTypeCode.L, BodyTypeDescription.LIVESTOCK_CARRIER],
-  [BodyTypeCode.I, BodyTypeDescription.LOW_LOADER],
+  [BodyTypeCode.I, BodyTypeDescription.LIVESTOCK_CARRIER],
+  [BodyTypeCode.L, BodyTypeDescription.LOW_LOADER],
   [BodyTypeCode.M, BodyTypeDescription.PETROL_OR_OIL_TANKER]
 ]);
 


### PR DESCRIPTION
## Create a Light Vehicle Test Group 3

- Add new test type code.
- Remove breaking form validators.
- Correct body type codes.
- Update the vehicle header to support small trailers.

[CB2-7027](https://dvsa.atlassian.net/browse/CB2-7027)