### PR TITLE
fix(cb2-7522): fix the vrm and z number validation

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.html
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.html
@@ -5,13 +5,15 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Vehicle type</dt>
       <dd id="vehicleType" class="govuk-summary-list__value">
-        {{ currentTechRecord?.vehicleType | defaultNullOrEmpty | uppercase }}
+        {{ techRecord?.vehicleType | defaultNullOrEmpty | uppercase }}
       </dd>
     </div>
+
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">VRM</dt>
       <app-number-plate *ngIf="vrm" [vrm]="vrm"></app-number-plate>
     </div>
+
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">VIN/chassis number</dt>
       <dd id="vehicleType" class="govuk-summary-list__value">{{ vehicle.vin | defaultNullOrEmpty }}</dd>
@@ -19,22 +21,9 @@
   </dl>
 
   <form [formGroup]="form">
-    <app-text-input
-      #newVrm
-      [label]="form.meta.children![0].label"
-      [formControlName]="form.meta.children![0].name"
-      [width]="width"
-      name="amend-vrm-text"
-      (ngModelChange)="ngOnChanges(); newVrm.value = newVrm.value.toUpperCase()"
-    ></app-text-input>
+    <app-text-input #newVrm formControlName="newVrm" [width]="width"></app-text-input>
 
-    <app-radio-group
-      #cherishedTransfer
-      name="cherishedTransfer"
-      label="Why do you want to amend this VRM?"
-      formControlName="amend-vrm-reason"
-      [options]="reasons"
-    ></app-radio-group>
+    <app-radio-group formControlName="isCherishedTransfer" [options]="reasons"></app-radio-group>
 
     <div *ngIf="newVrm.value.toUpperCase() !== vrm && newVrm.value.length">
       <p class="govuk-heading-l">Are you sure you want to change this VRM?</p>
@@ -42,7 +31,7 @@
     </div>
 
     <app-button-group>
-      <app-button id="submit-vrm" (clicked)="handleSubmit(newVrm.value, cherishedTransfer.value)">Save</app-button>
+      <app-button id="submit-vrm" (clicked)="handleSubmit()">Save</app-button>
       <app-button design="link" data-module="govuk-button" (clicked)="navigateBack()">Back</app-button>
     </app-button-group>
   </form>

--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.ts
@@ -1,53 +1,42 @@
-import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnChanges, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
-import { CustomFormGroup, FormNode, FormNodeOption, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
-import { TechRecordModel, VehicleTechRecordModel, Vrm } from '@models/vehicle-tech-record.model';
+import { CustomFormControl, FormNodeOption, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { CustomValidators } from '@forms/validators/custom-validators';
+import { TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { SEARCH_TYPES, TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { updateTechRecords, updateTechRecordsSuccess } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
-import cloneDeep from 'lodash.clonedeep';
-import { catchError, filter, map, of, switchMap, take, tap, throwError } from 'rxjs';
-import { ValidatorNames } from '@forms/models/validators.enum';
-import { Actions, ofType } from '@ngrx/effects';
+import { cloneDeep } from 'lodash';
+import { catchError, filter, of, switchMap, take, throwError } from 'rxjs';
 
 @Component({
   selector: 'app-change-amend-vrm',
   templateUrl: './tech-record-amend-vrm.component.html',
   styleUrls: ['./tech-record-amend-vrm.component.scss']
 })
-export class AmendVrmComponent implements OnInit, OnChanges {
-  reasons: Array<FormNodeOption<string>> = [
-    { label: 'Cherished transfer', value: 'true', hint: 'Current VRM will be archived' },
-    { label: 'Correcting an error', value: 'false', hint: 'Current VRM will not be archived' }
-  ];
-
+export class AmendVrmComponent implements OnInit {
   vehicle?: VehicleTechRecordModel;
-  currentTechRecord?: TechRecordModel;
-  form: CustomFormGroup;
-  width: FormNodeWidth = FormNodeWidth.L;
+  techRecord?: TechRecordModel;
 
-  template: FormNode = {
-    name: 'criteria',
-    type: FormNodeTypes.GROUP,
-    children: [
-      {
-        name: 'newVrm',
-        label: 'Input a new VRM',
-        value: '',
-        type: FormNodeTypes.CONTROL,
-        validators: [
-          { name: ValidatorNames.Alphanumeric },
-          { name: ValidatorNames.MaxLength, args: 9 },
-          { name: ValidatorNames.MinLength, args: 1 },
-          { name: ValidatorNames.NotZNumber }
-        ]
-      }
-    ]
-  };
+  form = new FormGroup({
+    newVrm: new CustomFormControl({ name: 'new-vrm', label: 'Input a new VRM', type: FormNodeTypes.CONTROL }, '', [
+      CustomValidators.alphanumeric(),
+      CustomValidators.notZNumber,
+      Validators.minLength(3),
+      Validators.maxLength(9)
+    ]),
+    isCherishedTransfer: new CustomFormControl(
+      { name: 'is-cherished-transfer', label: 'Why do you want to amend this VRM?', type: FormNodeTypes.CONTROL },
+      '',
+      [Validators.required]
+    )
+  });
 
   constructor(
     private actions$: Actions,
@@ -60,27 +49,30 @@ export class AmendVrmComponent implements OnInit, OnChanges {
   ) {
     this.technicalRecordService.selectedVehicleTechRecord$.pipe(take(1)).subscribe(vehicle => (this.vehicle = vehicle));
 
-    this.technicalRecordService.editableTechRecord$.pipe(take(1)).subscribe(techRecord => (this.currentTechRecord = techRecord));
+    this.technicalRecordService.editableTechRecord$.pipe(take(1)).subscribe(techRecord => (this.techRecord = techRecord));
+  }
 
-    this.form = this.dfs.createForm(this.template) as CustomFormGroup;
+  get reasons(): Array<FormNodeOption<string>> {
+    return [
+      { label: 'Cherished transfer', value: 'true', hint: 'Current VRM will be archived' },
+      { label: 'Correcting an error', value: 'false', hint: 'Current VRM will not be archived' }
+    ];
+  }
+
+  get width(): FormNodeWidth {
+    return FormNodeWidth.L;
   }
 
   ngOnInit(): void {
-    if (!this.currentTechRecord) {
+    if (!this.techRecord) {
       this.navigateBack();
     }
 
-    this.actions$.pipe(ofType(updateTechRecordsSuccess), take(1)).subscribe(() => {
-      this.navigateBack();
-    });
-  }
-
-  ngOnChanges(): void {
-    this.globalErrorService.clearErrors();
+    this.actions$.pipe(ofType(updateTechRecordsSuccess), take(1)).subscribe(() => this.navigateBack());
   }
 
   get makeAndModel(): string {
-    const c = this.currentTechRecord;
+    const c = this.techRecord;
     if (!c?.make && !c?.chassisMake) return '';
 
     return `${c.vehicleType === 'psv' ? c.chassisMake : c.make} - ${c.vehicleType === 'psv' ? c.chassisModel : c.model}`;
@@ -95,20 +87,14 @@ export class AmendVrmComponent implements OnInit, OnChanges {
     this.router.navigate(['..'], { relativeTo: this.route });
   }
 
-  handleSubmit(newVrm: string, cherishedTransfer: string): void {
-    this.globalErrorService.clearErrors();
-    if (newVrm === '' || (newVrm === this.vrm ?? '')) {
-      this.globalErrorService.addError({ error: 'You must provide a new VRM', anchorLink: 'newVrm' });
-    }
-    if (cherishedTransfer === '' || cherishedTransfer === undefined) {
-      this.globalErrorService.addError({ error: 'You must provide a reason for amending', anchorLink: 'cherishedTransfer' });
-    }
+  handleSubmit(): void {
+    if (!this.isFormValid()) return;
 
     this.globalErrorService.errors$
       .pipe(
         take(1),
         filter(errors => !errors.length),
-        switchMap(() => this.technicalRecordService.isUnique(newVrm, SEARCH_TYPES.VRM)),
+        switchMap(() => this.technicalRecordService.isUnique(this.form.value.newVrm, SEARCH_TYPES.VRM)),
         take(1),
         catchError(error => (error.status == 404 ? of(true) : throwError(() => new Error('Error'))))
       )
@@ -116,9 +102,12 @@ export class AmendVrmComponent implements OnInit, OnChanges {
         next: res => {
           if (!res) return this.globalErrorService.addError({ error: 'VRM already exists', anchorLink: 'newVrm' });
 
-          const newVehicleRecord = this.amendVrm(this.vehicle!, newVrm, cherishedTransfer === 'true');
+          const newVehicleRecord = this.amendVrm(this.vehicle!, this.form.value.newVrm, this.form.value.isCherishedTransfer === 'true');
 
-          this.setReasonForCreation(newVehicleRecord);
+          if (newVehicleRecord.techRecord) {
+            newVehicleRecord.techRecord.forEach(record => (record.reasonForCreation = `Amending VRM.`));
+          }
+
           this.technicalRecordService.updateEditingTechRecord({ ...newVehicleRecord });
           this.store.dispatch(updateTechRecords({ systemNumber: this.vehicle!.systemNumber }));
         },
@@ -126,20 +115,46 @@ export class AmendVrmComponent implements OnInit, OnChanges {
       });
   }
 
+  isFormValid(): boolean {
+    this.globalErrorService.clearErrors();
+
+    const errors: GlobalError[] = [];
+
+    DynamicFormService.updateValidity(this.form, errors);
+
+    if (errors?.length) {
+      this.globalErrorService.setErrors(errors);
+    }
+
+    if (this.form.value.newVrm === '' || (this.form.value.newVrm === this.vrm ?? '')) {
+      this.globalErrorService.addError({ error: 'You must provide a new VRM', anchorLink: 'newVrm' });
+      return false;
+    }
+    if (this.form.value.isCherishedTransfer === '' || this.form.value.isCherishedTransfer === undefined) {
+      this.globalErrorService.addError({ error: 'You must provide a reason for amending', anchorLink: 'cherishedTransfer' });
+      return false;
+    }
+
+    return this.form.valid;
+  }
+
   amendVrm(record: VehicleTechRecordModel, newVrm: string, cherishedTransfer: boolean) {
     const newModel: VehicleTechRecordModel = cloneDeep(record);
+
     if (!cherishedTransfer) {
-      const primaryVrm = newModel.vrms.find(vrm => vrm.isPrimary);
-      newModel.vrms.splice(newModel.vrms.indexOf(primaryVrm!), 1);
+      const primaryVrm = newModel.vrms.find(vrm => vrm.isPrimary)!;
+      newModel.vrms.splice(newModel.vrms.indexOf(primaryVrm), 1);
     }
 
     newModel.vrms.forEach(x => (x.isPrimary = false));
 
     const existingVrmObject = newModel.vrms.find(vrm => vrm.vrm == newVrm);
-    if (existingVrmObject == null) {
-      const vrmObject: Vrm = { vrm: newVrm.toUpperCase(), isPrimary: true };
-      newModel.vrms.push(vrmObject);
-    } else existingVrmObject.isPrimary = true;
+
+    if (!existingVrmObject) {
+      newModel.vrms.push({ vrm: newVrm.toUpperCase(), isPrimary: true });
+    } else {
+      existingVrmObject.isPrimary = true;
+    }
 
     return newModel;
   }
@@ -154,9 +169,5 @@ export class AmendVrmComponent implements OnInit, OnChanges {
       vrm.isPrimary ? (newTechModel.historicPrimaryVrm = vrm.vrm) : newTechModel.historicSecondaryVrms!.push(vrm.vrm)
     );
     return newTechModel;
-  }
-
-  setReasonForCreation(vehicleRecord: VehicleTechRecordModel) {
-    if (vehicleRecord.techRecord !== undefined) vehicleRecord.techRecord.forEach(record => (record.reasonForCreation = `Amending VRM.`));
   }
 }

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
@@ -19,7 +19,7 @@
               *ngIf="currentTechRecord.statusCode !== 'archived' && currentTechRecord.vehicleType === (editableTechRecord$ | async)?.vehicleType"
               design="link"
               id="change-vrm-link"
-              (clicked)="navigateTo('change-vrm')"
+              (clicked)="navigateTo('change-vehicle-type')"
               >Change</app-button
             >
           </div>

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -35,10 +35,11 @@ export class CreateTechRecordComponent implements OnChanges {
       [Validators.minLength(3), Validators.maxLength(21), Validators.required]
     ),
     vrmTrm: new CustomFormControl({ name: 'input-vrm-or-trailer-id', label: 'VRM/TRM', type: FormNodeTypes.CONTROL }, '', [
-      Validators.minLength(1),
+      CustomValidators.alphanumeric(),
+      CustomValidators.notZNumber,
       Validators.maxLength(9),
-      Validators.required,
-      CustomValidators.notZNumber
+      Validators.minLength(1),
+      Validators.required
     ]),
     vehicleStatus: new CustomFormControl(
       { name: 'change-vehicle-status-select', label: 'Vehicle status', type: FormNodeTypes.CONTROL },

--- a/src/app/forms/utils/error-message-map.ts
+++ b/src/app/forms/utils/error-message-map.ts
@@ -22,7 +22,7 @@ export const ErrorMessageMap: Record<string, (...args: any) => string> = {
   [ValidatorNames.Min]: (err: { min: number }, label?: string) => `${label || DEFAULT_LABEL} must be greater than or equal to ${err.min}`,
   [ValidatorNames.MinLength]: (err: { requiredLength: number }, label?: string) =>
     `${label || DEFAULT_LABEL} must be greater than or equal to ${err.requiredLength} characters`,
-  [ValidatorNames.NotZNumber]: () => "The VRM/Trailer ID cannot be in a format that is 6 digits followed by the character 'Z'",
+  [ValidatorNames.NotZNumber]: () => "The VRM/Trailer ID cannot be in a format that is 7 digits followed by the character 'Z'",
   [ValidatorNames.PastDate]: (err: boolean, label?: string) => `${label || 'This date'} must be in the past`,
   [ValidatorNames.Pattern]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} must match a pattern`,
   [ValidatorNames.Required]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is required`,


### PR DESCRIPTION
## Tech Record 'Z Number' updateable and able to be changed to a value assigned to another record

- When creating a tech record, the user could input a manual Z number as a VRM by including a space. This is now fixed.
- When amending existing Z numbers, the submit logic would trigger even though there were validation errors on the page. This is now fixed.

[CB2-7522](https://dvsa.atlassian.net/browse/CB2-7522)