### PR TITLE
fix(cb2-7565): display skeleton TRLs and HGVs

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -20,7 +20,7 @@ import { TrlBrakesComponent } from '@forms/custom-sections/trl-brakes/trl-brakes
 import { TyresComponent } from '@forms/custom-sections/tyres/tyres.component';
 import { WeightsComponent } from '@forms/custom-sections/weights/weights.component';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
-import { FormNode, CustomFormArray, CustomFormGroup } from '@forms/services/dynamic-form.types';
+import { CustomFormArray, CustomFormGroup, FormNode } from '@forms/services/dynamic-form.types';
 import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
 import { TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { select, Store } from '@ngrx/store';
@@ -97,11 +97,12 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
         }),
         takeUntil(this.destroy$)
       )
-      .subscribe(techRecord => (this.techRecordCalculated = techRecord));
-
-    this.referenceDataService.removeTyreSearch();
-    this.sectionTemplates = this.vehicleTemplates;
-    this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
+      .subscribe(techRecord => {
+        this.techRecordCalculated = techRecord;
+        this.referenceDataService.removeTyreSearch();
+        this.sectionTemplates = this.vehicleTemplates;
+        this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -11,9 +11,9 @@ export class AxlesService {
     let newAxleSpacings = cloneDeep(axleSpacings ?? []);
 
     if (newAxles.length > newAxleSpacings.length + 1) {
-      newAxleSpacings = this.generateAxleSpacing(newAxles.length, axleSpacings);
+      newAxleSpacings = this.generateAxleSpacing(newAxles.length, newAxleSpacings);
     } else if (newAxles.length < newAxleSpacings.length + 1) {
-      newAxles = this.generateAxlesFromAxleSpacings(newAxleSpacings.length, axles);
+      newAxles = this.generateAxlesFromAxleSpacings(newAxleSpacings.length, newAxles);
     }
 
     return [newAxles, newAxleSpacings];


### PR DESCRIPTION
## Creating a Skeleton TRL/HGV and loading it returns an almost blank page

_As listed in the title, creating a skeleton record for a TRL or HGV, sometimes results in the Technical Record page appearing empty like this:_
![image](https://user-images.githubusercontent.com/102959178/218705307-bb1b59dd-b7ad-4bca-ba24-585acf7282be.png)

[CB2-7565](https://dvsa.atlassian.net/browse/CB2-7565)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
