### PR TITLE
feat(cb2-7479): create a directive to handle document downloads

### DIFF
--- a/src/app/api/document-retrieval/api/document-retrieval.service.ts
+++ b/src/app/api/document-retrieval/api/document-retrieval.service.ts
@@ -165,7 +165,7 @@ export class DocumentRetrievalService {
 
     let params = new HttpParams({ encoder: new CustomHttpUrlEncodingCodec() });
 
-    paramMap.forEach(([value, key]) => params = params.set(key, value))
+    paramMap.forEach((value, key) => params = params.set(key, value));
 
     return this.httpClient.get(
       `${this.basePath}/v1/document-retrieval`,

--- a/src/app/api/document-retrieval/api/document-retrieval.service.ts
+++ b/src/app/api/document-retrieval/api/document-retrieval.service.ts
@@ -143,4 +143,40 @@ export class DocumentRetrievalService {
       withCredentials: this.configuration.withCredentials
     });
   }
+
+  getDocument(paramMap: Map<string, string>): Observable<HttpEvent<string>> {
+    let headers = this.defaultHeaders;
+
+    if (this.configuration.accessToken) {
+      const accessToken = typeof this.configuration.accessToken === 'function' ? this.configuration.accessToken() : this.configuration.accessToken;
+      headers = headers.set('Authorization', 'Bearer ' + accessToken);
+    }
+
+    if (this.configuration.apiKeys) {
+      for (const key in this.configuration.apiKeys) {
+        headers = headers.set(key, this.configuration.apiKeys[key]);
+      }
+    }
+
+    const httpContentTypeSelected = this.configuration.selectHeaderContentType(['application/pdf; charset=utf-8']);
+    if (httpContentTypeSelected) {
+      headers = headers.set('Content-Type', httpContentTypeSelected);
+    }
+
+    let params = new HttpParams({ encoder: new CustomHttpUrlEncodingCodec() });
+
+    paramMap.forEach(([value, key]) => params = params.set(key, value))
+
+    return this.httpClient.get(
+      `${this.basePath}/v1/document-retrieval`,
+      {
+        headers,
+        observe: 'events',
+        params,
+        reportProgress: true,
+        responseType: 'text',
+        withCredentials: this.configuration.withCredentials
+      }
+    );
+  }
 }

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.html
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="form">
-  <app-radio-group formControlName="reason" [options]="reasons"></app-radio-group>
+  <app-radio-group id="reason" formControlName="reason" [options]="reasons"></app-radio-group>
 
   <app-button-group>
     <app-button id="submit-plate-form" (clicked)="handleSubmit()">Save</app-button>

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.spec.ts
@@ -109,7 +109,7 @@ describe('TechRecordGeneratePlateComponent', () => {
 
       component.handleSubmit();
 
-      expect(addErrorSpy).toHaveBeenCalledWith({ error: 'Reason for generating plate is required', anchorLink: 'plateReasonForGenerating' });
+      expect(addErrorSpy).toHaveBeenCalledWith({ error: 'Reason for generating plate is required', anchorLink: 'reason' });
     });
 
     it('should dispatch the generatePlate action', () => {

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
@@ -55,7 +55,7 @@ export class GeneratePlateComponent {
   handleSubmit(): void {
     this.globalErrorService.clearErrors();
     if (!this.form.value.reason) {
-      return this.globalErrorService.addError({ error: 'Reason for generating plate is required', anchorLink: 'plateReasonForGenerating' });
+      return this.globalErrorService.addError({ error: 'Reason for generating plate is required', anchorLink: 'reason' });
     }
 
     this.actions$.pipe(ofType(generatePlateSuccess), take(1)).subscribe(() => this.navigateBack());

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -63,14 +63,14 @@
 
     <app-letters
       *ngSwitchCase="'lettersSection'"
-      [vehicleTechRecord]="techRecordCalculated"
+      [techRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-letters>
 
     <app-plates
       *ngSwitchCase="'platesSection'"
-      [vehicleTechRecord]="techRecordCalculated"
+      [techRecord]="techRecordCalculated"
       [isEditing]="isEditing"
       (formChange)="handleFormState($event)"
     ></app-plates>

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -1,21 +1,22 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { QueryList } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
-import { DynamicFormsModule } from '@forms/dynamic-forms.module';
-import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
-import { Axle, VehicleTypes } from '@models/vehicle-tech-record.model';
-import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { initialAppState, State } from '@store/.';
-import { TechRecordSummaryComponent } from './tech-record-summary.component';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { editableVehicleTechRecord, updateEditingTechRecord } from '@store/technical-records';
-import { SharedModule } from '@shared/shared.module';
-import { MultiOptionsService } from '@forms/services/multi-options.service';
-import { QueryList } from '@angular/core';
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
-import { UserService } from '@services/user-service/user-service';
-import { of } from 'rxjs';
+import { DynamicFormsModule } from '@forms/dynamic-forms.module';
+import { MultiOptionsService } from '@forms/services/multi-options.service';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
+import { createMockTrl } from '@mocks/trl-record.mock';
 import { Roles } from '@models/roles.enum';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { UserService } from '@services/user-service/user-service';
+import { SharedModule } from '@shared/shared.module';
+import { initialAppState, State } from '@store/index';
+import { editableVehicleTechRecord, updateEditingTechRecord } from '@store/technical-records';
+import { of } from 'rxjs';
+import { TechRecordSummaryComponent } from './tech-record-summary.component';
 
 describe('TechRecordSummaryComponent', () => {
   let component: TechRecordSummaryComponent;
@@ -94,7 +95,10 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show TRL record found', () => {
       component.isEditing = false;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
+      component.techRecord = {
+        ...createMockTrl(12345).techRecord[0],
+        lettersOfAuth: [{ letterContents: 'test' }]
+      };
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -102,7 +106,10 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show TRL record found without dimensions', () => {
       component.isEditing = false;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.TRL).techRecord.pop()!;
+      component.techRecord = {
+        ...createMockTrl(12345).techRecord[0],
+        lettersOfAuth: [{ letterContents: 'test' }]
+      };
       component.techRecord!.dimensions = undefined;
       fixture.detectChanges();
 

--- a/src/app/forms/custom-sections/letters/letters.component.html
+++ b/src/app/forms/custom-sections/letters/letters.component.html
@@ -11,15 +11,15 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Letter:</dt>
       <dd id="test-certificate" class="govuk-summary-list__value">
-        <button id="test-certificate-link" class="link" (click)="download()">TEST LETTER</button>
+        <button id="test-certificate-link" class="link" appRetrieveDocument [params]="documentParams" [fileName]="fileName">TEST LETTER</button>
       </dd>
     </div>
     <div class="govuk-grid-row">
       <br />
       <div class="govuk-grid-column-full">
-        <app-button id="generate-letters-link" type="link" routerLink="generate-letter" *appRoleRequired="roles.TechRecordAmend"
-          >Generate letter</app-button
-        >
+        <app-button id="generate-letters-link" type="link" routerLink="generate-letter" *appRoleRequired="roles.TechRecordAmend">
+          Generate letter
+        </app-button>
       </div>
     </div>
   </dl>

--- a/src/app/forms/custom-sections/letters/letters.component.spec.ts
+++ b/src/app/forms/custom-sections/letters/letters.component.spec.ts
@@ -1,10 +1,8 @@
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MsalBroadcastService } from '@azure/msal-angular';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { createMockPsv } from '@mocks/psv-record.mock';
 import { Roles } from '@models/roles.enum';
@@ -51,7 +49,10 @@ describe('LettersComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LettersComponent);
     component = fixture.componentInstance;
-    component.vehicleTechRecord = createMockPsv(12345).techRecord[0];
+    component.techRecord = {
+      ...createMockPsv(12345).techRecord[0],
+      lettersOfAuth: [{ letterContents: 'test' }]
+    };
     fixture.detectChanges();
   });
 

--- a/src/app/forms/custom-sections/plates/plates.component.html
+++ b/src/app/forms/custom-sections/plates/plates.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form">
   <dl class="govuk-summary-list">
-    <ng-container *ngIf="hasPlates()">
+    <ng-container *ngIf="hasPlates">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Plate serial number</dt>
         <dd id="test-cor" class="govuk-summary-list__value">{{ mostRecentPlate?.plateSerialNumber | defaultNullOrEmpty }}</dd>
@@ -16,16 +16,18 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Plate:</dt>
         <dd id="test-certificate" class="govuk-summary-list__value">
-          <button id="test-certificate-link" class="link" (click)="download()">{{ 'plate_' + mostRecentPlate?.plateSerialNumber + '.pdf' }}</button>
+          <button id="test-certificate-link" class="link" appRetrieveDocument [params]="documentParams" [fileName]="fileName">
+            {{ 'plate_' + mostRecentPlate?.plateSerialNumber + '.pdf' }}
+          </button>
         </dd>
       </div>
     </ng-container>
-    <ng-container *ngIf="!hasPlates()">
+    <ng-container *ngIf="!hasPlates">
       <div>
         <dt class="govuk-summary-list__key">This vehicle does not have a plate.</dt>
       </div>
     </ng-container>
-    <div class="govuk-grid-row" *ngIf="vehicleTechRecord.statusCode === 'current' && !isEditing">
+    <div class="govuk-grid-row" *ngIf="techRecord.statusCode === 'current' && !isEditing">
       <br />
       <div class="govuk-grid-column-full">
         <app-button id="generate-plate-link" type="link" routerLink="generate-plate" *appRoleRequired="roles.TechRecordAmend"

--- a/src/app/forms/custom-sections/plates/plates.component.spec.ts
+++ b/src/app/forms/custom-sections/plates/plates.component.spec.ts
@@ -1,10 +1,8 @@
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MsalBroadcastService } from '@azure/msal-angular';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { createMockPsv } from '@mocks/psv-record.mock';
 import { Roles } from '@models/roles.enum';
@@ -54,7 +52,7 @@ describe('PlatesComponent', () => {
     component = fixture.componentInstance;
     route = TestBed.inject(ActivatedRoute);
     router = TestBed.inject(Router);
-    component.vehicleTechRecord = createMockPsv(12345).techRecord[0];
+    component.techRecord = createMockPsv(12345).techRecord[0];
     fixture.detectChanges();
   });
 
@@ -64,7 +62,7 @@ describe('PlatesComponent', () => {
 
   describe('mostRecentPlate', () => {
     it('should fetch the plate if only 1 exists', () => {
-      component.vehicleTechRecord = {
+      component.techRecord = {
         plates: [
           {
             plateIssueDate: new Date(),
@@ -82,7 +80,7 @@ describe('PlatesComponent', () => {
     });
 
     it('should fetch the latest plate if more than 1 exists', () => {
-      component.vehicleTechRecord = {
+      component.techRecord = {
         plates: [
           {
             plateIssueDate: new Date(new Date().getTime()),
@@ -112,7 +110,7 @@ describe('PlatesComponent', () => {
     });
 
     it('should return null if plates are empty', () => {
-      component.vehicleTechRecord = {
+      component.techRecord = {
         plates: [] as Plates[]
       } as TechRecordModel;
 

--- a/src/app/forms/custom-sections/plates/plates.component.ts
+++ b/src/app/forms/custom-sections/plates/plates.component.ts
@@ -1,4 +1,3 @@
-import { HttpEventType } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
 import { DocumentRetrievalService } from '@api/document-retrieval';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
@@ -6,85 +5,66 @@ import { CustomFormGroup, FormNodeEditTypes } from '@forms/services/dynamic-form
 import { PlatesTemplate } from '@forms/templates/general/plates.template';
 import { Roles } from '@models/roles.enum';
 import { Plates, TechRecordModel } from '@models/vehicle-tech-record.model';
-import { DocumentsService } from '@services/documents/documents.service';
-import cloneDeep from 'lodash.clonedeep';
-import { debounceTime, Subscription, takeWhile } from 'rxjs';
+import { cloneDeep } from 'lodash';
+import { debounceTime, Subscription } from 'rxjs';
 
 @Component({
-  selector: 'app-plates[vehicleTechRecord]',
+  selector: 'app-plates[techRecord]',
   templateUrl: './plates.component.html',
   styleUrls: ['./plates.component.scss']
 })
 export class PlatesComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() vehicleTechRecord!: TechRecordModel;
+  @Input() techRecord!: TechRecordModel;
   @Input() isEditing = false;
 
   @Output() formChange = new EventEmitter();
-  @Output() isSuccess = new EventEmitter<boolean>();
 
   form!: CustomFormGroup;
 
   private _formSubscription = new Subscription();
 
-  constructor(
-    private documentRetrievalService: DocumentRetrievalService,
-    private documentsService: DocumentsService,
-    private dynamicFormService: DynamicFormService
-  ) {}
+  constructor(private dynamicFormService: DynamicFormService) {}
 
   ngOnInit(): void {
-    this.form = this.dynamicFormService.createForm(PlatesTemplate, this.vehicleTechRecord) as CustomFormGroup;
+    this.form = this.dynamicFormService.createForm(PlatesTemplate, this.techRecord) as CustomFormGroup;
     this._formSubscription = this.form.cleanValueChanges.pipe(debounceTime(400)).subscribe(event => this.formChange.emit(event));
   }
 
   ngOnChanges(): void {
-    this.form?.patchValue(this.vehicleTechRecord, { emitEvent: false });
+    this.form?.patchValue(this.techRecord, { emitEvent: false });
   }
 
   ngOnDestroy(): void {
     this._formSubscription.unsubscribe();
   }
 
-  hasPlates(): boolean {
-    return this.vehicleTechRecord.plates !== undefined && this.vehicleTechRecord.plates.length > 0;
+  get roles(): typeof Roles {
+    return Roles;
   }
 
   get types(): typeof FormNodeEditTypes {
     return FormNodeEditTypes;
   }
 
-  get roles(): typeof Roles {
-    return Roles;
+  get hasPlates(): boolean {
+    return this.techRecord.plates !== undefined && this.techRecord.plates.length > 0;
   }
 
   get mostRecentPlate(): Plates | undefined {
-    return cloneDeep(this.vehicleTechRecord.plates)
+    return cloneDeep(this.techRecord.plates)
       ?.sort((a, b) => (a.plateIssueDate && b.plateIssueDate ? new Date(a.plateIssueDate).getTime() - new Date(b.plateIssueDate).getTime() : 0))
       ?.pop();
   }
 
-  download() {
-    const mostRecentPlate = this.mostRecentPlate;
-    if (!mostRecentPlate) {
+  get documentParams(): Map<string, string> {
+    return new Map([['plateSerialNumber', this.fileName]]);
+  }
+
+  get fileName(): string {
+    if (this.mostRecentPlate) {
+      return `plate_${this.mostRecentPlate.plateSerialNumber}`;
+    } else {
       throw new Error('Could not find plate.');
     }
-
-    return this.documentRetrievalService
-      .testPlateGet(`plate_${mostRecentPlate.plateSerialNumber}`, 'events', true)
-      .pipe(takeWhile(event => event.type !== HttpEventType.Response, true))
-      .subscribe({
-        next: res => {
-          switch (res.type) {
-            case HttpEventType.DownloadProgress:
-              console.log(res);
-              break;
-            case HttpEventType.Response:
-              this.documentsService.openDocumentFromResponse(`plate_${mostRecentPlate.plateSerialNumber}`, res.body);
-              this.isSuccess.emit(true);
-              break;
-          }
-        },
-        error: () => this.isSuccess.emit(false)
-      });
   }
 }

--- a/src/app/forms/templates/psv/psv-brakes.template.ts
+++ b/src/app/forms/templates/psv/psv-brakes.template.ts
@@ -78,6 +78,7 @@ export const PsvBrakesTemplate: FormNode = {
             {
               name: 'parkingBrakeMrk',
               label: 'Parking Brake',
+              value: false,
               type: FormNodeTypes.CONTROL
             }
           ]

--- a/src/app/services/documents/documents.service.spec.ts
+++ b/src/app/services/documents/documents.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DocumentsService } from './documents.service';
+
+describe('DocumentsService', () => {
+  let service: DocumentsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DocumentsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/documents/documents.service.ts
+++ b/src/app/services/documents/documents.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class DocumentsService {
+  openDocumentFromResponse(fileName: string, responseBody: any): void {
+    const blob = this.convertToBlob(responseBody);
+
+    const link = this.createFileLink(fileName, blob);
+
+    this.simmulateClick(link);
+  }
+
+  convertToBlob(data: any): Blob {
+    if (typeof data !== 'string') throw new Error('Cannot convert to a blob. Data needs to be of type string');
+
+    const byteArray = new Uint8Array(
+      window
+        .atob(data)
+        .split('')
+        .map(char => char.charCodeAt(0))
+    );
+
+    return new Blob([byteArray], { type: 'application/pdf; charset=utf-8' });
+  }
+
+  createFileLink(fileName: string, blob: Blob): HTMLAnchorElement {
+    const url = window.URL.createObjectURL(blob);
+
+    const link: HTMLAnchorElement = document.createElement('a');
+
+    link.href = url;
+    link.target = '_blank';
+    link.download = `${fileName}.pdf`;
+
+    return link;
+  }
+
+  simmulateClick(link: HTMLAnchorElement): void {
+    document.body.appendChild(link);
+
+    link.click();
+
+    document.body.removeChild(link);
+  }
+}

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -309,7 +309,7 @@ export class TechnicalRecordService {
       vtmUsername: user.name
     };
 
-    return this.http.post<VehicleTechRecordModel>(url, body, { responseType: 'json' });
+    return this.http.post(url, body, { responseType: 'json' });
   }
 
   generateLetter(techRecord: TechRecordModel, letterType: string) {

--- a/src/app/shared/components/test-certificate/test-certificate.component.html
+++ b/src/app/shared/components/test-certificate/test-certificate.component.html
@@ -1,3 +1,3 @@
-<button id="test-certificate-link" class="link" (click)="download()">
+<button id="test-certificate-link" class="link" appRetrieveDocument [params]="documentParams" [fileName]="fileName">
   <ng-content></ng-content>
 </button>

--- a/src/app/shared/components/test-certificate/test-certificate.component.ts
+++ b/src/app/shared/components/test-certificate/test-certificate.component.ts
@@ -1,7 +1,4 @@
-import { HttpEventType } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
-import { DocumentRetrievalService } from '@api/document-retrieval';
-import { takeWhile } from 'rxjs';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-test-certificate[testNumber][vin]',
@@ -12,44 +9,15 @@ import { takeWhile } from 'rxjs';
 export class TestCertificateComponent {
   @Input() testNumber!: string;
   @Input() vin!: string;
-  @Output() isSuccess = new EventEmitter<boolean>();
 
-  constructor(private documentRetrievalService: DocumentRetrievalService) {}
+  get documentParams(): Map<string, string> {
+    return new Map([
+      ['testNumber', this.testNumber],
+      ['vinNumber', this.vin]
+    ]);
+  }
 
-  download() {
-    return this.documentRetrievalService
-      .testCertificateGet(this.testNumber, this.vin, 'events', true)
-      .pipe(takeWhile(event => event.type !== HttpEventType.Response, true))
-      .subscribe({
-        next: res => {
-          switch (res.type) {
-            case HttpEventType.DownloadProgress:
-              console.log(res);
-              break;
-            case HttpEventType.Response:
-              const byteArray = new Uint8Array(
-                window
-                  .atob(res.body)
-                  .split('')
-                  .map(char => char.charCodeAt(0))
-              );
-
-              const file = new Blob([byteArray], { type: 'application/pdf; charset=utf-8' });
-              const url = window.URL.createObjectURL(file);
-              const link: HTMLAnchorElement | undefined = document.createElement('a');
-              link.href = url;
-              link.target = '_blank';
-              link.download = `${this.testNumber}_${this.vin}.pdf`;
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
-
-              this.isSuccess.emit(true);
-          }
-        },
-        error: () => {
-          this.isSuccess.emit(false);
-        }
-      });
+  get fileName(): string {
+    return `${this.testNumber}_${this.vin}`;
   }
 }

--- a/src/app/shared/directives/retrieve-document/retrieve-document.directive.spec.ts
+++ b/src/app/shared/directives/retrieve-document/retrieve-document.directive.spec.ts
@@ -1,0 +1,11 @@
+import { HttpClient } from '@angular/common/http';
+import { Configuration, DocumentRetrievalService } from '@api/document-retrieval';
+import { DocumentsService } from '@services/documents/documents.service';
+import { RetrieveDocumentDirective } from './retrieve-document.directive';
+
+describe('RetrieveDocumentDirective', () => {
+  it('should create an instance', () => {
+    const directive = new RetrieveDocumentDirective(new DocumentRetrievalService({} as HttpClient, '', new Configuration()), new DocumentsService());
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/shared/directives/retrieve-document/retrieve-document.directive.ts
+++ b/src/app/shared/directives/retrieve-document/retrieve-document.directive.ts
@@ -1,0 +1,32 @@
+import { HttpEventType } from '@angular/common/http';
+import { Directive, HostListener, Input } from '@angular/core';
+import { DocumentRetrievalService } from '@api/document-retrieval';
+import { DocumentsService } from '@services/documents/documents.service';
+import { takeWhile } from 'rxjs';
+
+@Directive({ selector: '[appRetrieveDocument][params][fileName]' })
+export class RetrieveDocumentDirective {
+  @Input() params: Map<string, string> = new Map();
+  @Input() fileName: string = '';
+
+  constructor(private documentRetrievalService: DocumentRetrievalService, private documentsService: DocumentsService) {}
+
+  @HostListener('click', ['$event']) clickEvent(event: PointerEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.documentRetrievalService
+      .getDocument(this.params)
+      .pipe(takeWhile(event => event.type !== HttpEventType.Response, true))
+      .subscribe(response => {
+        switch (response.type) {
+          case HttpEventType.DownloadProgress:
+            console.log(response);
+            break;
+          case HttpEventType.Response:
+            this.documentsService.openDocumentFromResponse(this.fileName, response.body);
+            break;
+        }
+      });
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,24 +1,25 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { RoleRequiredDirective } from '../directives/app-role-required.directive';
+import { RouterModule } from '@angular/router';
+import { DocumentRetrievalService } from '@api/document-retrieval';
+import { RoleRequiredDirective } from '@directives/app-role-required.directive';
+import { AccordionControlComponent } from './components/accordion-control/accordion-control.component';
+import { AccordionComponent } from './components/accordion/accordion.component';
 import { BannerComponent } from './components/banner/banner.component';
+import { BaseDialogComponent } from './components/base-dialog/base-dialog.component';
 import { ButtonGroupComponent } from './components/button-group/button-group.component';
 import { ButtonComponent } from './components/button/button.component';
-import { DefaultNullOrEmpty } from './pipes/default-null-or-empty/default-null-or-empty.pipe';
-import { TagComponent } from './components/tag/tag.component';
-import { NumberPlateComponent } from './components/number-plate/number-plate.component';
 import { IconComponent } from './components/icon/icon.component';
-import { TestTypeNamePipe } from './pipes/test-type-name/test-type-name.pipe';
-import { AccordionComponent } from './components/accordion/accordion.component';
-import { AccordionControlComponent } from './components/accordion-control/accordion-control.component';
+import { NumberPlateComponent } from './components/number-plate/number-plate.component';
 import { PaginationComponent } from './components/pagination/pagination.component';
-import { RouterModule } from '@angular/router';
+import { TagComponent } from './components/tag/tag.component';
 import { TestCertificateComponent } from './components/test-certificate/test-certificate.component';
+import { RetrieveDocumentDirective } from './directives/retrieve-document/retrieve-document.directive';
 import { PreventDoubleClickDirective } from './directives/prevent-double-click/prevent-double-click.directive';
-import { BaseDialogComponent } from './components/base-dialog/base-dialog.component';
+import { DefaultNullOrEmpty } from './pipes/default-null-or-empty/default-null-or-empty.pipe';
 import { DigitGroupSeparatorPipe } from './pipes/digit-group-separator/digit-group-separator.pipe';
-import { DocumentRetrievalService } from '@api/document-retrieval';
 import { RefDataDecodePipe } from './pipes/ref-data-decode/ref-data-decode.pipe';
+import { TestTypeNamePipe } from './pipes/test-type-name/test-type-name.pipe';
 
 @NgModule({
   declarations: [
@@ -38,7 +39,8 @@ import { RefDataDecodePipe } from './pipes/ref-data-decode/ref-data-decode.pipe'
     PreventDoubleClickDirective,
     BaseDialogComponent,
     DigitGroupSeparatorPipe,
-    RefDataDecodePipe
+    RefDataDecodePipe,
+    RetrieveDocumentDirective
   ],
   imports: [CommonModule, RouterModule],
   exports: [
@@ -57,7 +59,8 @@ import { RefDataDecodePipe } from './pipes/ref-data-decode/ref-data-decode.pipe'
     TestCertificateComponent,
     BaseDialogComponent,
     DigitGroupSeparatorPipe,
-    RefDataDecodePipe
+    RefDataDecodePipe,
+    RetrieveDocumentDirective
   ],
   providers: [DocumentRetrievalService]
 })

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -109,7 +109,7 @@ export const vehicleTechRecordReducer = createReducer(
   on(archiveTechRecordFailure, updateFailureArgs),
 
   on(generatePlate, defaultArgs),
-  on(generatePlateSuccess, state => ({ ...state, editingTechRecord: undefined })),
+  on(generatePlateSuccess, state => ({ ...state, editingTechRecord: undefined, loading: false })),
   on(generatePlateFailure, failureArgs),
 
   on(generateLetter, defaultArgs),


### PR DESCRIPTION
## View Trailer into Service Letter

- Create a directive that handles document downloads.
- Encapsulate blob generation logic inside a service.
- Update the certificates, plates and letters components to use this new directive.
- Add a new generic method into the document retrieval service that will be used by the directive.
- Correct the anchor link on generate plate component.
- Fix the `generatePlateSuccess` action to set `loading` to ` false`.
- Set the default for parking brakes to `false`.

Important note:
There is a last TODO that depends on [CB2-7471](https://dvsa.atlassian.net/browse/CB2-7471) and [CB2-7048](https://dvsa.atlassian.net/browse/CB2-7048). The TODO is to verify that letters can be retrieved from the `document-retrieval` endpoint and update the letters component if required.

[CB2-7479](https://dvsa.atlassian.net/browse/CB2-7479)