### PR TITLE
fix(cb2-7626): fix letters breaking templates

### DIFF
--- a/src/app/forms/custom-sections/letters/letters.component.html
+++ b/src/app/forms/custom-sections/letters/letters.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="form">
+<form [formGroup]="form" *ngIf="!isEditing">
   <dl class="govuk-summary-list">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Letter type</dt>


### PR DESCRIPTION
## Formatting on Create Tech Record sometimes breaks

_Fix for letters section attempting to render and fetch values that don't exist_
[CB2-7626](https://dvsa.atlassian.net/browse/CB2-7626)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
