### PR TITLE
fix(cb2-7610): initialise parkingBrakeMrk to false

### DIFF
--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -200,7 +200,8 @@ function handleAddAxle(state: TechnicalRecordServiceState): TechnicalRecordServi
   newState.editingTechRecord.techRecord[0].axles.push({
     axleNumber: newState.editingTechRecord.techRecord[0].axles.length + 1,
     tyres: {},
-    weights: {}
+    weights: {},
+    parkingBrakeMrk: false
   });
 
   newState.editingTechRecord.techRecord[0].noOfAxles = newState.editingTechRecord.techRecord[0].axles.length;


### PR DESCRIPTION
## Values for all parking brakes are Yes even though I selected Yes for only First two axles

_One line description_
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-7610)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
