### PR TITLE
fix(cb2-7632): added check for if trailer has letter

### DIFF
--- a/src/app/forms/custom-sections/letters/letters.component.html
+++ b/src/app/forms/custom-sections/letters/letters.component.html
@@ -1,26 +1,35 @@
+<!-- This section is going to be redone as part of the changes in VTMDEV-2 -->
 <form [formGroup]="form" *ngIf="!isEditing">
   <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Letter type</dt>
-      <dd id="test-cor" class="govuk-summary-list__value">{{ mostRecentLetter?.letterType | defaultNullOrEmpty }}</dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Date requested</dt>
-      <dd id="test-cor" class="govuk-summary-list__value">{{ mostRecentLetter?.letterDateRequested | date: 'dd/MM/yyyy HH:mm' }}</dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Letter:</dt>
-      <dd id="test-certificate" class="govuk-summary-list__value">
-        <button id="test-certificate-link" class="link" appRetrieveDocument [params]="documentParams" [fileName]="fileName">TEST LETTER</button>
-      </dd>
-    </div>
-    <div class="govuk-grid-row">
-      <br />
-      <div class="govuk-grid-column-full">
-        <app-button id="generate-letters-link" type="link" routerLink="generate-letter" *appRoleRequired="roles.TechRecordAmend">
-          Generate letter
-        </app-button>
+    <ng-container *ngIf="mostRecentLetter">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Letter type</dt>
+        <dd id="test-cor" class="govuk-summary-list__value">{{ mostRecentLetter?.letterType | defaultNullOrEmpty }}</dd>
       </div>
-    </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Date requested</dt>
+        <dd id="test-cor" class="govuk-summary-list__value">{{ mostRecentLetter?.letterDateRequested | date: 'dd/MM/yyyy HH:mm' }}</dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Letter:</dt>
+        <dd id="test-certificate" class="govuk-summary-list__value">
+          <button id="test-certificate-link" class="link" appRetrieveDocument [params]="documentParams" [fileName]="fileName">TEST LETTER</button>
+        </dd>
+      </div>
+      <div class="govuk-grid-row">
+        <br />
+        <div class="govuk-grid-column-full">
+          <app-button id="generate-letters-link" type="link" routerLink="generate-letter" *appRoleRequired="roles.TechRecordAmend">
+            Generate letter
+          </app-button>
+        </div>
+      </div>
+    </ng-container>
+
+    <ng-container *ngIf="!mostRecentLetter">
+      <div>
+        <dt class="govuk-summary-list__key">This vehicle does not have a letter.</dt>
+      </div>
+    </ng-container>
   </dl>
 </form>


### PR DESCRIPTION
## Can not view detailed tech record for TRL after search and select tech record to view

_PR to add a fallback for if a trailer does not have a letter, preventing VTM from throwing errors and hanging_
![image](https://user-images.githubusercontent.com/114917018/220372035-f53f9ee6-4405-425c-997e-46e72b1c8eb4.png)

[CB2-7632](https://dvsa.atlassian.net/browse/CB2-7632)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
