### PR TITLE
fix(cb2-7640): default eec weight to null on hgv and trl

### DIFF
--- a/src/app/forms/validators/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validators.ts
@@ -1,17 +1,16 @@
 import { AbstractControl, AsyncValidatorFn, ValidationErrors } from '@angular/forms';
-import { TestType } from '@api/test-types';
 import { Condition, operatorEnum } from '@forms/models/condition.model';
 import { CustomFormControl } from '@forms/services/dynamic-form.types';
 import { User } from '@models/reference-data.model';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { TestStation } from '@models/test-stations/test-station.model';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
-import { select, Store } from '@ngrx/store';
+import { Store, select } from '@ngrx/store';
 import { State } from '@store/.';
 import { selectUserByResourceKey } from '@store/reference-data';
 import { testResultInEdit } from '@store/test-records';
 import { getTestStationFromProperty } from '@store/test-stations';
-import { catchError, map, Observable, of, take, tap } from 'rxjs';
+import { Observable, catchError, map, of, take, tap } from 'rxjs';
 
 export class CustomAsyncValidators {
   static resultDependantOnCustomDefects(store: Store<State>): AsyncValidatorFn {

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -1,6 +1,6 @@
 import { BodyTypeCode, vehicleBodyTypeCodeMap } from '@models/body-type-enum';
 import { PsvMake } from '@models/reference-data.model';
-import { VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { Axle, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { createFeatureSelector, createReducer, on } from '@ngrx/store';
 import { AxlesService } from '@services/axles/axles.service';
 import { cloneDeep } from 'lodash';
@@ -15,6 +15,12 @@ import {
   createVehicleRecord,
   createVehicleRecordFailure,
   createVehicleRecordSuccess,
+  generateLetter,
+  generateLetterFailure,
+  generateLetterSuccess,
+  generatePlate,
+  generatePlateFailure,
+  generatePlateSuccess,
   getByAll,
   getByAllFailure,
   getByAllSuccess,
@@ -40,13 +46,7 @@ import {
   updateEditingTechRecordCancel,
   updateTechRecords,
   updateTechRecordsFailure,
-  updateTechRecordsSuccess,
-  generatePlate,
-  generatePlateSuccess,
-  generatePlateFailure,
-  generateLetter,
-  generateLetterSuccess,
-  generateLetterFailure
+  updateTechRecordsSuccess
 } from '../actions/technical-record-service.actions';
 
 export const STORE_FEATURE_TECHNICAL_RECORDS_KEY = 'TechnicalRecords';
@@ -194,21 +194,27 @@ function handleUpdateBody(state: TechnicalRecordServiceState, action: { psvMake:
 
 function handleAddAxle(state: TechnicalRecordServiceState): TechnicalRecordServiceState {
   const newState = cloneDeep(state);
+  const vehicleType = newState.editingTechRecord?.techRecord[0].vehicleType;
 
   if (!newState.editingTechRecord?.techRecord[0].axles) return newState;
 
-  newState.editingTechRecord.techRecord[0].axles.push({
+  const newAxle: Axle = {
     axleNumber: newState.editingTechRecord.techRecord[0].axles.length + 1,
     tyres: {},
     weights: {},
     parkingBrakeMrk: false
-  });
+  };
+
+  if (vehicleType === VehicleTypes.HGV || vehicleType === VehicleTypes.TRL) {
+    newAxle.weights!.eecWeight = null;
+  }
+
+  newState.editingTechRecord.techRecord[0].axles.push(newAxle);
 
   newState.editingTechRecord.techRecord[0].noOfAxles = newState.editingTechRecord.techRecord[0].axles.length;
 
   newState.editingTechRecord.techRecord[0].dimensions ??= {};
 
-  const vehicleType = newState.editingTechRecord?.techRecord[0].vehicleType;
   if (vehicleType === VehicleTypes.HGV || vehicleType === VehicleTypes.TRL) {
     newState.editingTechRecord.techRecord[0].dimensions.axleSpacing = new AxlesService().generateAxleSpacing(
       newState.editingTechRecord?.techRecord[0].axles.length,

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -200,7 +200,7 @@ function handleAddAxle(state: TechnicalRecordServiceState): TechnicalRecordServi
 
   const newAxle: Axle = {
     axleNumber: newState.editingTechRecord.techRecord[0].axles.length + 1,
-    tyres: {},
+    tyres: { dataTrAxles: null },
     weights: {},
     parkingBrakeMrk: false
   };


### PR DESCRIPTION
## Axle weights validation when creating a skeleton tech record

_One line description_
[link to ticket number](https://dvsa.atlassian.net/browse/CB2-7640)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
