### PR TITLE
CB2-7682: Amend VIN validation issue

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
@@ -87,7 +87,7 @@ export class AmendVinComponent implements OnInit, OnDestroy {
   }
 
   handleSubmit(): void {
-    if (this.form.invalid) return;
+    if (!this.isFormValid()) return;
 
     const payload = {
       newVin: this.form.value.vin,


### PR DESCRIPTION
CB2-7682:

form validation not being triggered when the input field is empty and the user clicks save. 
