### PR TITLE
fix(cb2-7666): Cannot amend Tech Record with frontVehicleTo5thWheelCouplingMax or Min

### DIFF
--- a/src/app/api/vehicle/model/techRecord.ts
+++ b/src/app/api/vehicle/model/techRecord.ts
@@ -281,11 +281,11 @@ export interface TechRecord {
     /**
      * Used only for HGV. Optional for HGV
      */
-    frontAxleTo5thWheelCouplingMin?: number;
+    frontVehicleTo5thWheelCouplingMin?: number;
     /**
      * Used only for HGV. Optional for HGV
      */
-    frontAxleTo5thWheelCouplingMax?: number;
+    frontVehicleTo5thWheelCouplingMax?: number;
     /**
      * Used for all vehicle types. Optional for PSV
      */

--- a/src/app/forms/custom-sections/dimensions/dimensions.component.html
+++ b/src/app/forms/custom-sections/dimensions/dimensions.component.html
@@ -95,7 +95,7 @@
       <app-switchable-input
         [form]="form"
         [type]="types.NUMBER"
-        name="frontAxleTo5thWheelCouplingMin"
+        name="frontVehicleTo5thWheelCouplingMin"
         label="Minimum"
         [isEditing]="isEditing"
         [width]="widths.XS"
@@ -105,7 +105,7 @@
       <app-switchable-input
         [form]="form"
         [type]="types.NUMBER"
-        name="frontAxleTo5thWheelCouplingMax"
+        name="frontVehicleTo5thWheelCouplingMax"
         label="Maximum"
         [isEditing]="isEditing"
         [width]="widths.XS"

--- a/src/app/forms/templates/hgv/hgv-dimensions.template.ts
+++ b/src/app/forms/templates/hgv/hgv-dimensions.template.ts
@@ -55,14 +55,14 @@ export const HgvDimensionsTemplate: FormNode = {
       validators: [{ name: ValidatorNames.Max, args: 99999 }]
     },
     {
-      name: 'frontAxleTo5thWheelCouplingMin',
+      name: 'frontVehicleTo5thWheelCouplingMin',
       label: 'Minimum',
       value: null,
       type: FormNodeTypes.CONTROL,
       validators: [{ name: ValidatorNames.Max, args: 99999 }]
     },
     {
-      name: 'frontAxleTo5thWheelCouplingMax',
+      name: 'frontVehicleTo5thWheelCouplingMax',
       label: 'Maximum',
       value: null,
       type: FormNodeTypes.CONTROL,

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -353,8 +353,8 @@ export interface TechRecordModel {
   rearAxleToRearTrl?: number;
 
   // Front of vehicle to 5th wheel coupling
-  frontAxleTo5thWheelCouplingMin?: number;
-  frontAxleTo5thWheelCouplingMax?: number;
+  frontVehicleTo5thWheelCouplingMin?: number;
+  frontVehicleTo5thWheelCouplingMax?: number;
 
   // Front axle to 5th wheel
   frontAxleTo5thWheelMin?: number;

--- a/src/mocks/hgv-record.mock.ts
+++ b/src/mocks/hgv-record.mock.ts
@@ -82,8 +82,8 @@ const currentTechRecord = {
     ]
   },
   frontAxleToRearAxle: 3,
-  frontAxleTo5thWheelCouplingMin: 5,
-  frontAxleTo5thWheelCouplingMax: 6,
+  frontVehicleTo5thWheelCouplingMin: 5,
+  frontVehicleTo5thWheelCouplingMax: 6,
   frontAxleTo5thWheelMin: 7,
   frontAxleTo5thWheelMax: 8,
   plates: [


### PR DESCRIPTION
Cannot amend Tech Record with frontVehicleTo5thWheelCouplingMax or Min

Global find and replace of AxleTo5thWheelCoupling -> VehicleTo5thWheelCoupling

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-7666)

## Checklist
- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number