### PR TITLE
fix(cb2-6641): do not display the audit section when editing tech records

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -106,13 +106,11 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
   }
 
   get vehicleTemplates(): Array<FormNode> {
-    const vehicleTemplates = vehicleTemplateMap.get(this.techRecordCalculated.vehicleType);
-
-    return vehicleTemplates
-      ? this.isEditing
-        ? vehicleTemplates
-        : vehicleTemplates.filter(t => t.name !== 'reasonForCreationSection')
-      : ([] as Array<FormNode>);
+    return (
+      vehicleTemplateMap
+        .get(this.techRecordCalculated.vehicleType)
+        ?.filter(template => template.name !== (this.isEditing ? 'audit' : 'reasonForCreationSection')) ?? []
+    );
   }
 
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {


### PR DESCRIPTION
## Amend a light vehicle Tech Record

- Hide the audit section when `isEditing` is toggled on.

[CB2-6641](https://dvsa.atlassian.net/browse/CB2-6641)