### PR TITLE
fix(cb2-7727): allow creating small trailers

### DIFF
--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -54,6 +54,7 @@ export class CreateTechRecordComponent implements OnChanges {
     { label: 'Light goods vehicle (LGV)', value: VehicleTypes.LGV },
     { label: 'Public service vehicle (PSV)', value: VehicleTypes.PSV },
     { label: 'Trailer (TRL)', value: VehicleTypes.TRL },
+    { label: 'Small Trailer (Small TRL)', value: VehicleTypes.SMALL_TRL },
     { label: 'Car', value: VehicleTypes.CAR },
     { label: 'Motorcycle', value: VehicleTypes.MOTORCYCLE }
   ];

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -2,6 +2,7 @@ import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleClass } from '@models/vehicle-class.model';
+import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
 
 export const SmallTrailerTechRecord: FormNode = {
@@ -68,6 +69,14 @@ export const SmallTrailerTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CHECKBOXGROUP,
       options: getOptionsFromEnum(VehicleSubclass)
+    },
+    {
+      name: 'vehicleConfiguration',
+      label: 'Vehicle configuration',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(VehicleConfiguration)
     },
     {
       name: 'euVehicleCategory',


### PR DESCRIPTION
## Manage small trailers in VTM

- Add the small trailer type to the creation page dropdown.
- Add vehicle configuration to small trailers' template as it is required by the record completeness.

[CB2-7727](https://dvsa.atlassian.net/browse/CB2-7727)
