### PR TITLE
fix(cb2-7819): Unable to add axles when axles property is undefined

### DIFF
--- a/src/app/forms/custom-sections/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.ts
@@ -127,6 +127,8 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
       const currentAxles = vehicleTechRecord.currentValue.axles;
       const previousAxles = vehicleTechRecord.previousValue.axles;
 
+      if (!previousAxles) return false;
+
       for (let [index, axle] of currentAxles.entries()) {
         if (
           axle?.tyres !== undefined &&
@@ -183,7 +185,7 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   addAxle(): void {
-    if (this.vehicleTechRecord.axles!.length < 10) {
+    if (!this.vehicleTechRecord.axles || this.vehicleTechRecord.axles!.length < 10) {
       this.isError = false;
       this.store.dispatch(addAxle());
     } else {

--- a/src/app/forms/custom-sections/weights/weights.component.ts
+++ b/src/app/forms/custom-sections/weights/weights.component.ts
@@ -93,7 +93,7 @@ export class WeightsComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   addAxle(): void {
-    if (this.vehicleTechRecord.axles!.length < 10) {
+    if (!this.vehicleTechRecord.axles || this.vehicleTechRecord.axles!.length < 10) {
       this.isError = false;
       this.store.dispatch(addAxle());
     } else {

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -545,20 +545,39 @@ describe('Vehicle Technical Record Reducer', () => {
     });
 
     describe('addAxle', () => {
-      it('should add an axle', () => {
-        const techRecord = initialState.editingTechRecord?.techRecord[0];
-        expect(techRecord?.noOfAxles).toBe(2);
-        expect(techRecord?.axles?.length).toBe(3);
+      describe('it should add an axle', () => {
+        it('with the axles property defined', () => {
+          const techRecord = initialState.editingTechRecord?.techRecord[0];
+          expect(techRecord?.noOfAxles).toBe(2);
+          expect(techRecord?.axles?.length).toBe(3);
 
-        const newState = vehicleTechRecordReducer(initialState, addAxle());
+          const newState = vehicleTechRecordReducer(initialState, addAxle());
 
-        expect(newState).not.toBe(initialState);
-        expect(newState).not.toEqual(initialState);
+          expect(newState).not.toBe(initialState);
+          expect(newState).not.toEqual(initialState);
 
-        const updatedTechRecord = newState.editingTechRecord?.techRecord[0];
-        expect(updatedTechRecord?.noOfAxles).toBe(4);
-        expect(updatedTechRecord?.axles?.length).toBe(4);
-        expect(updatedTechRecord?.axles?.pop()?.axleNumber).toBe(4);
+          const updatedTechRecord = newState.editingTechRecord?.techRecord[0];
+          expect(updatedTechRecord?.noOfAxles).toBe(4);
+          expect(updatedTechRecord?.axles?.length).toBe(4);
+          expect(updatedTechRecord?.axles?.pop()?.axleNumber).toBe(4);
+        });
+
+        it('without the axles property defined', () => {
+          const techRecord = initialState.editingTechRecord?.techRecord[0];
+          delete techRecord?.axles;
+          techRecord!.noOfAxles = 0;
+          expect(techRecord?.noOfAxles).toBe(0);
+
+          const newState = vehicleTechRecordReducer(initialState, addAxle());
+
+          expect(newState).not.toBe(initialState);
+          expect(newState).not.toEqual(initialState);
+
+          const updatedTechRecord = newState.editingTechRecord?.techRecord[0];
+          expect(updatedTechRecord?.noOfAxles).toBe(1);
+          expect(updatedTechRecord?.axles?.length).toBe(1);
+          expect(updatedTechRecord?.axles?.pop()?.axleNumber).toBe(1);
+        });
       });
     });
 

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -203,7 +203,8 @@ function handleAddAxle(state: TechnicalRecordServiceState): TechnicalRecordServi
   const newState = cloneDeep(state);
   const vehicleType = newState.editingTechRecord?.techRecord[0].vehicleType;
 
-  if (!newState.editingTechRecord?.techRecord[0].axles) return newState;
+  if (!newState.editingTechRecord) return newState;
+  if (!newState.editingTechRecord?.techRecord[0].axles) newState.editingTechRecord.techRecord[0].axles = [];
 
   const newAxle: Axle = {
     axleNumber: newState.editingTechRecord.techRecord[0].axles.length + 1,


### PR DESCRIPTION
## CB2-7819: Unable to add axles when axles property is undefined

_PR to allow users to add axles to a record when said record does not have the axles property defined_
[CB2-7819](https://dvsa.atlassian.net/browse/CB2-7819)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
