### PR TITLE
fix(cb2-7738): vehicle class map

### DIFF
--- a/src/app/api/test-results/model/completeTestResultsVehicleClass.ts
+++ b/src/app/api/test-results/model/completeTestResultsVehicleClass.ts
@@ -33,14 +33,14 @@ export namespace CompleteTestResultsVehicleClass {
         P: 'p' as CodeEnum,
         U: 'u' as CodeEnum
     };
-    export type DescriptionEnum = 'motorbikes over 200cc or with a sidecar' | 'not applicable' | 'small psv (ie: less than or equal to 22 seats)' | 'motorbikes up to 200cc' | 'trailer' | 'large psv(ie: greater than 23 seats)' | '3 wheelers' | 'heavy goods vehicle' | 'MOT class 4' | 'MOT class 7' | 'MOT class 5' | 'PSV of unknown or unspecified size' | 'Not Known';
+    export type DescriptionEnum = 'motorbikes over 200cc or with a sidecar' | 'not applicable' | 'small psv (ie: less than or equal to 22 seats)' | 'motorbikes up to 200cc' | 'trailer' | 'large psv (ie: greater than 23 seats)' | '3 wheelers' | 'heavy goods vehicle' | 'MOT class 4' | 'MOT class 7' | 'MOT class 5' | 'PSV of unknown or unspecified size' | 'Not Known';
     export const DescriptionEnum = {
         MotorbikesOver200ccOrWithASidecar: 'motorbikes over 200cc or with a sidecar' as DescriptionEnum,
         NotApplicable: 'not applicable' as DescriptionEnum,
         SmallPsvIeLessThanOrEqualTo22Seats: 'small psv (ie: less than or equal to 22 seats)' as DescriptionEnum,
         MotorbikesUpTo200cc: 'motorbikes up to 200cc' as DescriptionEnum,
         Trailer: 'trailer' as DescriptionEnum,
-        LargePsvIeGreaterThan23Seats: 'large psv(ie: greater than 23 seats)' as DescriptionEnum,
+        LargePsvIeGreaterThan23Seats: 'large psv (ie: greater than 23 seats)' as DescriptionEnum,
         _3Wheelers: '3 wheelers' as DescriptionEnum,
         HeavyGoodsVehicle: 'heavy goods vehicle' as DescriptionEnum,
         MOTClass4: 'MOT class 4' as DescriptionEnum,

--- a/src/app/api/vehicle/model/techRecordVehicleClass.ts
+++ b/src/app/api/vehicle/model/techRecordVehicleClass.ts
@@ -31,14 +31,14 @@ export namespace TechRecordVehicleClass {
         _7: '7' as CodeEnum,
         _5: '5' as CodeEnum
     };
-    export type DescriptionEnum = 'motorbikes over 200cc or with a sidecar' | 'not applicable' | 'small psv (ie: less than or equal to 22 seats)' | 'motorbikes up to 200cc' | 'trailer' | 'large psv(ie: greater than 23 seats)' | '3 wheelers' | 'heavy goods vehicle' | 'MOT class 4' | 'MOT class 7' | 'MOT class 5' | 'PSV of unknown or unspecified size' | 'Not Known';
+    export type DescriptionEnum = 'motorbikes over 200cc or with a sidecar' | 'not applicable' | 'small psv (ie: less than or equal to 22 seats)' | 'motorbikes up to 200cc' | 'trailer' | 'large psv (ie: greater than 23 seats)' | '3 wheelers' | 'heavy goods vehicle' | 'MOT class 4' | 'MOT class 7' | 'MOT class 5' | 'PSV of unknown or unspecified size' | 'Not Known';
     export const DescriptionEnum = {
         MotorbikesOver200ccOrWithASidecar: 'motorbikes over 200cc or with a sidecar' as DescriptionEnum,
         NotApplicable: 'not applicable' as DescriptionEnum,
         SmallPsvIeLessThanOrEqualTo22Seats: 'small psv (ie: less than or equal to 22 seats)' as DescriptionEnum,
         MotorbikesUpTo200cc: 'motorbikes up to 200cc' as DescriptionEnum,
         Trailer: 'trailer' as DescriptionEnum,
-        LargePsvIeGreaterThan23Seats: 'large psv(ie: greater than 23 seats)' as DescriptionEnum,
+        LargePsvIeGreaterThan23Seats: 'large psv (ie: greater than 23 seats)' as DescriptionEnum,
         _3Wheelers: '3 wheelers' as DescriptionEnum,
         HeavyGoodsVehicle: 'heavy goods vehicle' as DescriptionEnum,
         MOTClass4: 'MOT class 4' as DescriptionEnum,

--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -142,7 +142,7 @@ export const HgvTechRecord: FormNode = {
           customId: 'vehicleClassDescription',
           type: FormNodeTypes.CONTROL,
           editType: FormNodeEditTypes.SELECT,
-          options: getOptionsFromEnum(VehicleClass.DescriptionEnum),
+          options: getOptionsFromEnum(VehicleClass.retrieveVehicleClassesByType('hgv')),
           validators: [{ name: ValidatorNames.Required }]
         }
       ]

--- a/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
+++ b/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
@@ -70,7 +70,7 @@ export const MotorcycleTechRecord: FormNode = {
           type: FormNodeTypes.CONTROL,
           viewType: FormNodeViewTypes.STRING,
           editType: FormNodeEditTypes.SELECT,
-          options: getOptionsFromEnum(VehicleClass.DescriptionEnum),
+          options: getOptionsFromEnum(VehicleClass.retrieveVehicleClassesByType('motorcycle')),
           class: '.govuk-input--width-10',
           validators: [{ name: ValidatorNames.Required }]
         }

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -123,7 +123,7 @@ export const PsvTechRecord: FormNode = {
           type: FormNodeTypes.CONTROL,
           viewType: FormNodeViewTypes.STRING,
           editType: FormNodeEditTypes.SELECT,
-          options: getOptionsFromEnum(VehicleClass.DescriptionEnum),
+          options: getOptionsFromEnum(VehicleClass.retrieveVehicleClassesByType('psv')),
           class: '.govuk-input--width-10',
           validators: [{ name: ValidatorNames.Required }]
         }

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -57,7 +57,7 @@ export const SmallTrailerTechRecord: FormNode = {
           value: '',
           type: FormNodeTypes.CONTROL,
           editType: FormNodeEditTypes.SELECT,
-          options: getOptionsFromEnum(VehicleClass.DescriptionEnum),
+          options: getOptionsFromEnum(VehicleClass.retrieveVehicleClassesByType('small trl')),
           validators: [{ name: ValidatorNames.Required }]
         }
       ]

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -110,7 +110,7 @@ export const TrlTechRecordTemplate: FormNode = {
           type: FormNodeTypes.CONTROL,
           viewType: FormNodeViewTypes.STRING,
           editType: FormNodeEditTypes.SELECT,
-          options: getOptionsFromEnum(VehicleClass.DescriptionEnum),
+          options: getOptionsFromEnum(VehicleClass.retrieveVehicleClassesByType('trl')),
           validators: [{ name: ValidatorNames.Required }]
         }
       ]

--- a/src/app/forms/utils/enum-map.ts
+++ b/src/app/forms/utils/enum-map.ts
@@ -1,4 +1,5 @@
 import { MultiOptions } from '@forms/models/options.model';
+import { VehicleClass } from '@models/vehicle-class.model';
 
 export function getOptionsFromEnum(object: object): MultiOptions {
   return Object.values(object).map(value => ({ value, label: value.charAt(0).toUpperCase() + value.slice(1) }));

--- a/src/app/models/vehicle-class.model.spec.ts
+++ b/src/app/models/vehicle-class.model.spec.ts
@@ -1,0 +1,48 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { DynamicFormsModule } from '@forms/dynamic-forms.module';
+import { StoreModule } from '@ngrx/store';
+import { VehicleClass } from './vehicle-class.model';
+
+describe('VehicleClass', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, HttpClientTestingModule, DynamicFormsModule, StoreModule.forRoot({})],
+      declarations: [VehicleClass]
+    }).compileComponents();
+  });
+
+  describe('retrieveVehicleClassesByType', () => {
+    describe('should return the correct classes by vehicle type', () => {
+      it('where the vehicle type has specific classes', () => {
+        const vehicleType = 'psv';
+        const vehicleClasses = VehicleClass.retrieveVehicleClassesByType(vehicleType);
+        expect(vehicleClasses).toHaveLength(7);
+        expect(vehicleClasses).toEqual([
+          VehicleClass.DescriptionEnum.SmallPsvIeLessThanOrEqualTo22Seats,
+          VehicleClass.DescriptionEnum.LargePsvIeGreaterThan23Seats,
+          VehicleClass.DescriptionEnum.MOTClass4,
+          VehicleClass.DescriptionEnum.MOTClass5,
+          VehicleClass.DescriptionEnum.MOTClass7,
+          VehicleClass.DescriptionEnum.NotApplicable,
+          VehicleClass.DescriptionEnum._3Wheelers
+        ]);
+      });
+
+      it('where the vehicle type does not have specific classes', () => {
+        const vehicleType = 'lgv';
+        const vehicleClasses = VehicleClass.retrieveVehicleClassesByType(vehicleType);
+        expect(vehicleClasses).toHaveLength(2);
+        expect(vehicleClasses).toEqual([VehicleClass.DescriptionEnum.NotApplicable, VehicleClass.DescriptionEnum._3Wheelers]);
+      });
+    });
+
+    it('should return the common classes if not given a vehicle type', () => {
+      const vehicleType = '';
+      const vehicleClasses = VehicleClass.retrieveVehicleClassesByType(vehicleType);
+      expect(vehicleClasses).toHaveLength(2);
+      expect(vehicleClasses).toEqual([VehicleClass.DescriptionEnum.NotApplicable, VehicleClass.DescriptionEnum._3Wheelers]);
+    });
+  });
+});

--- a/src/app/models/vehicle-class.model.ts
+++ b/src/app/models/vehicle-class.model.ts
@@ -51,7 +51,7 @@ export namespace VehicleClass {
 
   export const DescriptionEnumCommon = [DescriptionEnum.NotApplicable, DescriptionEnum._3Wheelers];
 
-  export const DescriptionByVehicleTypeMap = new Map<string, Array<DescriptionEnum>>([
+  export const DescriptionEnumByVehicleTypeMap = new Map<string, Array<DescriptionEnum>>([
     [
       'psv',
       [
@@ -71,6 +71,6 @@ export namespace VehicleClass {
   ]);
 
   export function retrieveVehicleClassesByType(vehicleType: string) {
-    return [...(DescriptionByVehicleTypeMap.get(vehicleType) ?? []), ...DescriptionEnumCommon];
+    return [...(DescriptionEnumByVehicleTypeMap.get(vehicleType) ?? []), ...DescriptionEnumCommon];
   }
 }

--- a/src/app/models/vehicle-class.model.ts
+++ b/src/app/models/vehicle-class.model.ts
@@ -25,7 +25,7 @@ export namespace VehicleClass {
     | 'small psv (ie: less than or equal to 22 seats)'
     | 'motorbikes up to 200cc'
     | 'trailer'
-    | 'large psv(ie: greater than 23 seats)'
+    | 'large psv (ie: greater than 23 seats)'
     | '3 wheelers'
     | 'heavy goods vehicle'
     | 'MOT class 4'
@@ -39,7 +39,7 @@ export namespace VehicleClass {
     SmallPsvIeLessThanOrEqualTo22Seats: 'small psv (ie: less than or equal to 22 seats)' as DescriptionEnum,
     MotorbikesUpTo200cc: 'motorbikes up to 200cc' as DescriptionEnum,
     Trailer: 'trailer' as DescriptionEnum,
-    LargePsvIeGreaterThan23Seats: 'large psv(ie: greater than 23 seats)' as DescriptionEnum,
+    LargePsvIeGreaterThan23Seats: 'large psv (ie: greater than 23 seats)' as DescriptionEnum,
     _3Wheelers: '3 wheelers' as DescriptionEnum,
     HeavyGoodsVehicle: 'heavy goods vehicle' as DescriptionEnum,
     MOTClass4: 'MOT class 4' as DescriptionEnum,
@@ -48,4 +48,29 @@ export namespace VehicleClass {
     PSVOfUnknownOrUnspecifiedSize: 'PSV of unknown or unspecified size' as DescriptionEnum,
     NotKnown: 'Not Known' as DescriptionEnum
   };
+
+  export const DescriptionEnumCommon = [DescriptionEnum.NotApplicable, DescriptionEnum._3Wheelers];
+
+  export const DescriptionByVehicleTypeMap = new Map<string, Array<DescriptionEnum>>([
+    [
+      'psv',
+      [
+        DescriptionEnum.SmallPsvIeLessThanOrEqualTo22Seats,
+        DescriptionEnum.LargePsvIeGreaterThan23Seats,
+        DescriptionEnum.MOTClass4,
+        DescriptionEnum.MOTClass5,
+        DescriptionEnum.MOTClass7
+      ]
+    ],
+    ['hgv', [DescriptionEnum.HeavyGoodsVehicle, DescriptionEnum.MOTClass4, DescriptionEnum.MOTClass5, DescriptionEnum.MOTClass7]],
+    ['trl', [DescriptionEnum.Trailer]],
+    ['small trl', [DescriptionEnum.Trailer]],
+    ['lgv', []],
+    ['car', []],
+    ['motorcycle', [DescriptionEnum.MotorbikesOver200ccOrWithASidecar, DescriptionEnum.MotorbikesUpTo200cc]]
+  ]);
+
+  export function retrieveVehicleClassesByType(vehicleType: string) {
+    return [...(DescriptionByVehicleTypeMap.get(vehicleType) ?? []), ...DescriptionEnumCommon];
+  }
 }

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -62,7 +62,7 @@ export enum VehicleClassDescriptions {
   SMALL_PSV = 'small psv (ie: less than or equal to 22 seats)',
   MOTORBIKE_UPTO_200CC = 'motorbikes up to 200cc',
   TRAILER = 'trailer',
-  LARGE_PSV = 'large psv(ie: greater than 23 seats)',
+  LARGE_PSV = 'large psv (ie: greater than 23 seats)',
   THREE_WHEELER = '3 wheelers',
   HGV = 'heavy goods vehicle',
   MOT_CLASS_4 = 'MOT class 4',


### PR DESCRIPTION
## CB2-7738: Bike 'Vehicle Class' drop down list contains incorrect values

_PR to allow vehicle class to be mapped to specific vehicle types, preventing vehicles from having illegal types_
[CB2-7738](https://dvsa.atlassian.net/browse/CB2-7738)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
