### PR TITLE
fix(cb2-7021): fix on tech record create summary

### DIFF
--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -59,26 +59,30 @@ export class HydrateNewVehicleRecordComponent {
 
     this.technicalRecordService.editableVehicleTechRecord$
       .pipe(
-        withLatestFrom(this.technicalRecordService.batchVehicles$),
+        withLatestFrom(this.technicalRecordService.batchVehicles$, this.isBatch$),
         take(1),
-        map(([record, batch]) =>
-          (record ? [record] : []).concat(
-            batch.map(
-              v =>
-                ({
-                  ...record!,
-                  vin: v.vin,
-                  vrms: v.trailerId ? [{ vrm: v.trailerId, isPrimary: true }] : null,
-                  trailerId: v.trailerId ?? null
-                } as VehicleTechRecordModel)
-            )
-          )
-        )
+        map(([record, batch, isBatch]) => {
+          const recordArray = record ? [record] : [];
+          return {
+            vehicleList: recordArray.concat(
+              batch.map(
+                v =>
+                  ({
+                    ...record!,
+                    vin: v.vin,
+                    vrms: v.trailerId ? [{ vrm: v.trailerId, isPrimary: true }] : null,
+                    trailerId: v.trailerId ?? null
+                  } as VehicleTechRecordModel)
+              )
+            ),
+            isBatch
+          };
+        })
       )
-      .subscribe(vehicleList => {
+      .subscribe(({ vehicleList, isBatch }) => {
         vehicleList.forEach(vehicle => this.store.dispatch(createVehicleRecord({ vehicle })));
 
-        this.navigateTo('batch-results');
+        this.navigateTo(isBatch ? 'batch-results' : '..');
       });
   }
 }

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -59,27 +59,24 @@ export class HydrateNewVehicleRecordComponent {
 
     this.technicalRecordService.editableVehicleTechRecord$
       .pipe(
-        withLatestFrom(this.technicalRecordService.batchVehicles$, this.isBatch$),
+        withLatestFrom(this.technicalRecordService.batchVehicles$),
         take(1),
-        map(([record, batch, isBatch]) => {
-          const recordArray = record ? [record] : [];
-          return {
-            vehicleList: recordArray.concat(
-              batch.map(
-                v =>
-                  ({
-                    ...record!,
-                    vin: v.vin,
-                    vrms: v.trailerId ? [{ vrm: v.trailerId, isPrimary: true }] : null,
-                    trailerId: v.trailerId ?? null
-                  } as VehicleTechRecordModel)
-              )
-            ),
-            isBatch
-          };
-        })
+        map(([record, batch]) =>
+          (record ? [record] : []).concat(
+            batch.map(
+              v =>
+                ({
+                  ...record!,
+                  vin: v.vin,
+                  vrms: v.trailerId ? [{ vrm: v.trailerId, isPrimary: true }] : null,
+                  trailerId: v.trailerId ?? null
+                } as VehicleTechRecordModel)
+            )
+          )
+        ),
+        withLatestFrom(this.isBatch$)
       )
-      .subscribe(({ vehicleList, isBatch }) => {
+      .subscribe(([vehicleList, isBatch]) => {
         vehicleList.forEach(vehicle => this.store.dispatch(createVehicleRecord({ vehicle })));
 
         this.navigateTo(isBatch ? 'batch-results' : '..');


### PR DESCRIPTION
## Ticket title

Currently after doing a single tech record create, it navigates to the batch results page, not the single result page as it has been
[link to ticket number]()

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
