### PR TITLE
fix(cb2-7833): preserve value type of the select element

### DIFF
--- a/src/app/forms/components/select/select.component.html
+++ b/src/app/forms/components/select/select.component.html
@@ -18,6 +18,6 @@
     (focus)="handleEvent($event)"
   >
     <option value="" selected disabled hidden></option>
-    <option *ngFor="let option of options; trackBy: trackBy" [value]="option.value" [selected]="value === option.value">{{ option.label }}</option>
+    <option *ngFor="let option of options; trackBy: trackBy" [ngValue]="option.value" [selected]="value === option.value">{{ option.label }}</option>
   </select>
 </div>

--- a/src/app/forms/components/select/select.component.spec.ts
+++ b/src/app/forms/components/select/select.component.spec.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { CustomFormControl, FormNodeOption, FormNodeTypes } from '@forms/services/dynamic-form.types';
@@ -16,6 +16,8 @@ import { SelectComponent } from './select.component';
   styles: []
 })
 class HostComponent {
+  @ViewChild(SelectComponent) select?: SelectComponent;
+
   form = new FormGroup({
     foo: new CustomFormControl({ name: 'foo', type: FormNodeTypes.CONTROL, children: [] }, null)
   });
@@ -51,14 +53,17 @@ describe('SelectComponent', () => {
 
   describe('value', () => {
     it('should be propagated from element to the form control', () => {
-      const foo = component.form.get('foo');
-      const select = fixture.debugElement.query(By.css('select'));
-      expect(select).toBeTruthy();
+      const select = fixture.debugElement.query(By.css('select')).nativeElement as HTMLSelectElement;
 
-      (select.nativeElement as HTMLSelectElement).value = '1';
-      select.nativeElement.dispatchEvent(new Event('change'));
-      expect(foo?.value).toEqual('1');
-      expect(foo?.value).not.toBeNull();
+      select.options[0].dispatchEvent(new Event('click'));
+
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+
+        const foo = component.form.get('foo');
+        expect(foo?.value).toEqual('1');
+        expect(foo?.value).not.toBeNull();
+      });
     });
 
     it('should select the right option when the form value is updated', () => {
@@ -66,7 +71,7 @@ describe('SelectComponent', () => {
       fixture.detectChanges();
       const select = fixture.debugElement.query(By.css('select'));
       expect(select).toBeTruthy();
-      expect(select.nativeElement.value).toEqual('2');
+      expect(select.nativeElement.value).toEqual('2: 2');
     });
   });
 });


### PR DESCRIPTION
## Tech records failing to NOP - INC0283462

By default, the select element converts its values to string. By using `ngValue` the type is preserved.

[CB2-7833](https://dvsa.atlassian.net/browse/CB2-7833)