### PR TITLE
fix(cb2 7812): adds TestCode to the test result header

### DIFF
--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -4,7 +4,10 @@
       <div class="govuk-grid-column-two-thirds">
         <div class="vehicle_heading">
           <h1 class="govuk-heading-l">
-            <span>{{ test?.testTypeId ?? '' | testTypeName: (selectAllTestTypes$ | async) | defaultNullOrEmpty }}</span>
+            <span>
+              {{ test?.testTypeId ?? '' | testTypeName: (selectAllTestTypes$ | async) | defaultNullOrEmpty }}
+              {{ testCode | uppercase }}
+            </span>
             <app-icon [icon]="(techRecord$ | async)?.vehicleType || ''"></app-icon>
           </h1>
         </div>
@@ -46,7 +49,9 @@
   <ng-container *ngSwitchCase="false">
     <div class="test_result_header">
       <div class="test_name_and_date">
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ test?.testTypeId || '' | testTypeName: (selectAllTestTypes$ | async) }}</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+          <span>{{ test?.testTypeId || '' | testTypeName: (selectAllTestTypes$ | async) }} {{ testCode | uppercase }}</span>
+        </h1>
         <div class="date_and_result">
           <span class="govuk-caption-l">{{ testResult?.createdAt | date: 'dd MMM yyyy' }}</span>
           <app-result-of-test [resultOfTest]="resultOfTest"></app-result-of-test>

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
@@ -50,6 +50,11 @@ export class VehicleHeaderComponent {
     return this.testResult?.testTypes[0].testResult;
   }
 
+  get testCode(): string | undefined {
+    const testCode = this.testResult?.testTypes[0].testCode;
+    return testCode ? `(${testCode})` : '';
+  }
+
   getVehicleDescription(techRecord: TechRecordModel, vehicleType: VehicleTypes | undefined) {
     switch (vehicleType) {
       case VehicleTypes.TRL:

--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -33,11 +33,9 @@ import { ContingencyTestSectionSpecialistGroup3And4 } from './section-templates/
 import { ContingencyTestSectionSpecialistGroup5 } from './section-templates/test/contingency/contingency-test-section-specialist-group5.template';
 import { DeskBasedTestSectionGroup1Psv } from './section-templates/test/desk-based/desk-based-test-section-group1-PSV.template';
 import { DeskBasedTestSectionGroup1And4HgvTrl as DeskBasedTestSectionGroup1And4And5HgvTrl } from './section-templates/test/desk-based/desk-based-test-section-group1And4-HGV-TRL.template';
-import {
-  AmendDeskBasedTestSectionGroup2And5,
-  DeskBasedTestSectionGroup2And5
-} from './section-templates/test/desk-based/desk-based-test-section-group2.template';
+import { DeskBasedTestSectionGroup2And5 } from './section-templates/test/desk-based/desk-based-test-section-group2.template';
 import { DeskBasedTestSectionGroup3 } from './section-templates/test/desk-based/desk-based-test-section-group3.template';
+import { DeskBasedTestSectionGroup4LgvCarMotorcycle } from './section-templates/test/desk-based/desk-based-test-section-group4-lgv-template';
 import { DeskBasedTestSectionGroup4Psv } from './section-templates/test/desk-based/desk-based-test-section-group4-PSV.template';
 import { DeskBasedTestSectionLgvGroup5 } from './section-templates/test/desk-based/desk-based-test-section-group5-LGV';
 import { SpecialistTestSectionGroup3 } from './section-templates/test/specialist/specialist-test-section-group3.template';
@@ -508,7 +506,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     testTypesDeskBasedGroup4: {
       required: DeskBasedRequiredHiddenSectionGroup4Lgv,
       vehicle: DeskBasedVehicleSectionGroup4LGV,
-      test: AmendDeskBasedTestSectionGroup2And5,
+      test: DeskBasedTestSectionGroup4LgvCarMotorcycle,
       visit: VisitSection,
       notes: NotesSection,
       customDefects: CustomDefectsHiddenSection,
@@ -557,7 +555,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     testTypesDeskBasedGroup4: {
       required: DeskBasedRequiredHiddenSectionGroup4Lgv,
       vehicle: DeskBasedVehicleSectionGroup4LGV,
-      test: AmendDeskBasedTestSectionGroup2And5,
+      test: DeskBasedTestSectionGroup4LgvCarMotorcycle,
       visit: VisitSection,
       notes: NotesSection,
       customDefects: CustomDefectsHiddenSection,
@@ -615,7 +613,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     testTypesDeskBasedGroup4: {
       required: DeskBasedRequiredHiddenSectionGroup4Motorcyle,
       vehicle: DeskBasedVehicleSectionGroup4LGV,
-      test: AmendDeskBasedTestSectionGroup2And5,
+      test: DeskBasedTestSectionGroup4LgvCarMotorcycle,
       visit: VisitSection,
       notes: NotesSection,
       customDefects: CustomDefectsHiddenSection,

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group1-PSV.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group1-PSV.template.ts
@@ -141,6 +141,14 @@ export const AmendDeskBasedTestSectionGroup1Psv: FormNode = {
           type: FormNodeTypes.GROUP,
           children: [
             {
+              name: 'testCode',
+              label: 'Test Code',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL,
+              width: FormNodeWidth.XS
+            },
+            {
               name: 'testResult',
               label: 'Result',
               type: FormNodeTypes.CONTROL,

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group2.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group2.template.ts
@@ -143,6 +143,14 @@ export const AmendDeskBasedTestSectionGroup2And5: FormNode = {
           type: FormNodeTypes.GROUP,
           children: [
             {
+              name: 'testCode',
+              label: 'Test Code',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL,
+              width: FormNodeWidth.XS
+            },
+            {
               name: 'testResult',
               label: 'Result',
               type: FormNodeTypes.CONTROL,

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group3.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group3.template.ts
@@ -132,6 +132,14 @@ export const AmendDeskBasedTestSectionGroup3: FormNode = {
           type: FormNodeTypes.GROUP,
           children: [
             {
+              name: 'testCode',
+              label: 'Test Code',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL,
+              width: FormNodeWidth.XS
+            },
+            {
               name: 'testResult',
               label: 'Result',
               type: FormNodeTypes.CONTROL,

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group4-PSV.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group4-PSV.template.ts
@@ -144,6 +144,14 @@ export const amendDeskBasedTestSectionGroup4Psv: FormNode = {
           type: FormNodeTypes.GROUP,
           children: [
             {
+              name: 'testCode',
+              label: 'Test Code',
+              value: '',
+              disabled: true,
+              type: FormNodeTypes.CONTROL,
+              width: FormNodeWidth.XS
+            },
+            {
               name: 'testResult',
               label: 'Result',
               type: FormNodeTypes.CONTROL,

--- a/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group4-lgv-template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/desk-based/desk-based-test-section-group4-lgv-template.ts
@@ -1,0 +1,103 @@
+import { ValidatorNames } from '@forms/models/validators.enum';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+
+export const DeskBasedTestSectionGroup4LgvCarMotorcycle: FormNode = {
+  name: 'testSection',
+  label: 'Test',
+  type: FormNodeTypes.GROUP,
+  children: [
+    {
+      name: 'testStartTimestamp',
+      label: 'Test start date',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'testEndTimestamp',
+      type: FormNodeTypes.CONTROL,
+      label: 'Test end date',
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN
+    },
+    {
+      name: 'testTypes',
+      label: 'Test Types',
+      type: FormNodeTypes.ARRAY,
+      children: [
+        {
+          name: '0', // it is important here that the name of the node for an ARRAY type should be an index value
+          type: FormNodeTypes.GROUP,
+          children: [
+            {
+              name: 'testResult',
+              label: 'Result',
+              type: FormNodeTypes.CONTROL,
+              viewType: FormNodeViewTypes.HIDDEN,
+              editType: FormNodeEditTypes.RADIO,
+              options: [
+                { value: 'pass', label: 'Pass' },
+                { value: 'fail', label: 'Fail' }
+              ]
+            },
+            {
+              name: 'certificateNumber',
+              label: 'Certificate number',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.TEXT,
+              width: FormNodeWidth.L,
+              validators: [{ name: ValidatorNames.Alphanumeric }],
+              value: null
+            },
+            {
+              name: 'secondaryCertificateNumber',
+              label: 'Secondary Certificate number',
+              type: FormNodeTypes.CONTROL,
+              editType: FormNodeEditTypes.TEXT,
+              width: FormNodeWidth.L,
+              validators: [{ name: ValidatorNames.Alphanumeric }],
+              value: null
+            },
+            {
+              name: 'testTypeStartTimestamp',
+              type: FormNodeTypes.CONTROL,
+              value: null,
+              label: 'Test start date and time',
+              viewType: FormNodeViewTypes.HIDDEN,
+              editType: FormNodeEditTypes.HIDDEN
+            },
+            {
+              name: 'testTypeEndTimestamp',
+              type: FormNodeTypes.CONTROL,
+              value: null,
+              label: 'Test end date and time',
+              viewType: FormNodeViewTypes.HIDDEN,
+              editType: FormNodeEditTypes.HIDDEN
+            },
+            {
+              name: 'testExpiryDate',
+              label: 'Expiry Date',
+              value: null,
+              type: FormNodeTypes.CONTROL,
+              viewType: FormNodeViewTypes.DATE,
+              editType: FormNodeEditTypes.DATE,
+              validators: [{ name: ValidatorNames.HideIfEmpty, args: 'testAnniversaryDate' }]
+            },
+            {
+              name: 'testAnniversaryDate',
+              label: 'Anniversary date',
+              value: '',
+              type: FormNodeTypes.CONTROL,
+              viewType: FormNodeViewTypes.DATE,
+              editType: FormNodeEditTypes.DATE,
+              validators: [
+                { name: ValidatorNames.AheadOfDate, args: 'testTypeStartTimestamp' },
+                { name: ValidatorNames.DateNotExceed, args: { sibling: 'testExpiryDate', months: 14 } }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
## Bug: All LGV Test Results View Headers should include the TestCode (e.g. YDT)

test codes now appear in the header along with the name when viewing or amending a test.

[CB2-7812](https://dvsa.atlassian.net/browse/CB2-7812)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
