### PR TITLE
fix(cb2-7858): open batch results summary in new tab

### DIFF
--- a/src/app/features/tech-record/create-batch-trl/components/batch-trl-results/batch-trl-results.component.html
+++ b/src/app/features/tech-record/create-batch-trl/components/batch-trl-results/batch-trl-results.component.html
@@ -34,7 +34,14 @@
       </td>
       <td class="govuk-table__cell"></td>
       <td class="govuk-table__cell">
-        <app-button id="view-{{ i + 1 }}" type="link" design="link" [routerLink]="['/', 'tech-records', vehicle.systemNumber]">View</app-button>
+        <a
+          id="view-{{ i + 1 }}"
+          [routerLink]="['/', 'tech-records', vehicle.systemNumber]"
+          class="govuk-link"
+          rel="noreferrer noopener"
+          target="_blank"
+          >View (opens in a new tab)</a
+        >
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Open batch results in a new tab

_the view link on the batch results page should open in a new tab_

[CB2-7021](https://dvsa.atlassian.net/browse/CB2-7021)
[CB2-7858](https://dvsa.atlassian.net/browse/CB2-7858)
## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
