### PR TITLE
fix(cb2-7857): persist values across on batch create pages

### DIFF
--- a/src/app/features/tech-record/create-batch-trl/components/batch-trl-results/batch-trl-results.component.ts
+++ b/src/app/features/tech-record/create-batch-trl/components/batch-trl-results/batch-trl-results.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { StatusCodes } from '@models/vehicle-tech-record.model';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
-import { filter, first, map, race, Subject, take, takeUntil, withLatestFrom } from 'rxjs';
+import { filter, race, Subject, take, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-batch-trl-results',

--- a/src/app/features/tech-record/create-batch-trl/resolvers/create-batch-trl.resolver.ts
+++ b/src/app/features/tech-record/create-batch-trl/resolvers/create-batch-trl.resolver.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
 import { StatusCodes, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
-import { Observable, of } from 'rxjs';
+import { Observable, of, take } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -10,9 +10,13 @@ import { Observable, of } from 'rxjs';
 export class CreateBatchTrlResolver implements Resolve<boolean> {
   constructor(private trs: TechnicalRecordService) {}
   resolve(_route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<boolean> {
-    this.trs.initialBatchTechRecord({
-      techRecord: [{ vehicleType: VehicleTypes.TRL, statusCode: StatusCodes.PROVISIONAL }]
-    } as VehicleTechRecordModel);
+    this.trs.editableVehicleTechRecord$.pipe(take(1)).subscribe(
+      vehicle =>
+        !vehicle &&
+        this.trs.updateEditingTechRecord({
+          techRecord: [{ vehicleType: VehicleTypes.TRL, statusCode: StatusCodes.PROVISIONAL }]
+        } as VehicleTechRecordModel)
+    );
 
     this.trs.generateEditingVehicleTechnicalRecordFromVehicleType(VehicleTypes.TRL);
 

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -246,8 +246,7 @@ export class TechnicalRecordService {
    * @returns void
    */
   updateEditingTechRecord(record: TechRecordModel | VehicleTechRecordModel, resetVehicleAttributes = false): void {
-    const isVehicleRecord = (rec: TechRecordModel | VehicleTechRecordModel): rec is VehicleTechRecordModel =>
-      rec.hasOwnProperty('vin') && rec.hasOwnProperty('techRecord');
+    const isVehicleRecord = (rec: TechRecordModel | VehicleTechRecordModel): rec is VehicleTechRecordModel => rec.hasOwnProperty('techRecord');
 
     const vehicleTechRecord$: Observable<VehicleTechRecordModel | undefined> = isVehicleRecord(record)
       ? of(record)
@@ -262,10 +261,6 @@ export class TechnicalRecordService {
         this.store.dispatch(updateEditingTechRecord({ vehicleTechRecord: vehicleRecord }));
       }
     });
-  }
-
-  initialBatchTechRecord(vehicleRecord: VehicleTechRecordModel) {
-    this.store.dispatch(updateEditingTechRecord({ vehicleTechRecord: vehicleRecord }));
   }
 
   /**

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -100,7 +100,7 @@ export const vehicleTechRecordReducer = createReducer(
   on(getByAllFailure, failureArgs),
 
   on(createVehicleRecord, defaultArgs),
-  on(createVehicleRecordSuccess, (state, action) => ({ ...state, editingTechRecord: action.vehicleTechRecords[0], loading: false })),
+  on(createVehicleRecordSuccess, successArgs),
   on(createVehicleRecordFailure, state => ({ ...state, loading: false })),
 
   on(createProvisionalTechRecord, defaultArgs),


### PR DESCRIPTION
## Values entered in tech record create do not persist across the manage batch page

_Values entered in tech record create do not persist across the manage batch page_
- The resolver was resetting the record when navigating to the batch create page. It now only does this if there is no editing tech record
- Removed a semi-redundant method in the tech record service
- The batch results component deletes the editing tech record when the results are all success, or on destroy of the component to avoid polluting state
- Reverts a change introduced in #941 to the createVehicleRecord action. The create vehicle success reducer was re-populating editing tech record unnecessarily.
[CB2-7857](https://dvsa.atlassian.net/browse/CB2-7857)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
