### PR TITLE
fix(cb2-7893): visual error when creating provisional

### DIFF
--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -16,6 +16,7 @@ import { AmendVrmComponent } from './components/tech-record-amend-vrm/tech-recor
 import { GeneratePlateComponent } from './components/tech-record-generate-plate/tech-record-generate-plate.component';
 import { GenerateLetterComponent } from './components/tech-record-generate-letter/tech-record-generate-letter.component';
 import { AmendVinComponent } from './components/tech-record-amend-vin/tech-record-amend-vin.component';
+import { CancelEditTechGuard } from '@guards/cancel-edit-tech/cancel-edit-tech.guard';
 
 const routes: Routes = [
   {
@@ -23,6 +24,7 @@ const routes: Routes = [
     component: TechRecordComponent,
     data: { roles: Roles.TechRecordView, isCustomLayout: true },
     canActivateChild: [MsalGuard, RoleGuard],
+    canActivate: [CancelEditTechGuard],
     resolve: { load: TechRecordViewResolver }
   },
   {
@@ -78,7 +80,7 @@ const routes: Routes = [
         path: '',
         component: TechRecordComponent,
         data: { title: 'Provisional tech record', isCustomLayout: true },
-        canActivate: [MsalGuard],
+        canActivate: [MsalGuard, CancelEditTechGuard],
         resolve: { load: TechRecordViewResolver }
       },
       {

--- a/src/app/guards/cancel-edit-tech/cancel-edit-tech.guard.ts
+++ b/src/app/guards/cancel-edit-tech/cancel-edit-tech.guard.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, CanDeactivate, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { CanActivate, CanDeactivate } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { State } from '@store/index';
 import { updateEditingTechRecordCancel } from '@store/technical-records';
-import { Observable } from 'rxjs';
 import { TechRecordComponent } from 'src/app/features/tech-record/tech-record.component';
 
 @Injectable({

--- a/src/app/guards/cancel-edit-tech/cancel-edit-tech.guard.ts
+++ b/src/app/guards/cancel-edit-tech/cancel-edit-tech.guard.ts
@@ -1,15 +1,21 @@
 import { Injectable } from '@angular/core';
-import { CanDeactivate } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanDeactivate, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { State } from '@store/index';
 import { updateEditingTechRecordCancel } from '@store/technical-records';
+import { Observable } from 'rxjs';
 import { TechRecordComponent } from 'src/app/features/tech-record/tech-record.component';
 
 @Injectable({
   providedIn: 'root'
 })
-export class CancelEditTechGuard implements CanDeactivate<TechRecordComponent> {
+export class CancelEditTechGuard implements CanDeactivate<TechRecordComponent>, CanActivate {
   constructor(private store: Store<State>) {}
+
+  canActivate(): boolean {
+    this.store.dispatch(updateEditingTechRecordCancel());
+    return true;
+  }
 
   canDeactivate(): boolean {
     this.store.dispatch(updateEditingTechRecordCancel());

--- a/src/app/services/technical-record/technical-record.service.spec.ts
+++ b/src/app/services/technical-record/technical-record.service.spec.ts
@@ -1,13 +1,11 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TechRecord } from '@api/vehicle';
 import { mockVehicleTechnicalRecord, mockVehicleTechnicalRecordList } from '@mocks/mock-vehicle-technical-record.mock';
 import { StatusCodes, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { initialAppState, State } from '@store/index';
 import { editableVehicleTechRecord, selectVehicleTechnicalRecordsBySystemNumber, updateEditingTechRecord } from '@store/technical-records';
-import { assert } from 'console';
 import { lastValueFrom } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { SEARCH_TYPES, TechnicalRecordService } from './technical-record.service';


### PR DESCRIPTION
## Visual error when creating provisional

_After creating a provisional, there is a bug where the current record uses information entered in the provisional. State is polluted with previously entered information_
[CB2-7893](https://dvsa.atlassian.net/browse/CB2-7893)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
