### PR TITLE
fix(cb2-7839): added custom id tags for dynamic-form-field and select…

### DIFF
--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
@@ -11,6 +11,7 @@
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
     [width]="control.value.meta.width"
+    [customId]="control.value.meta.customId"
   ></app-autocomplete>
 
   <app-date
@@ -20,6 +21,7 @@
     [formControlName]="control.key"
     [isoDate]="control.value.meta.isoDate ?? true"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   ></app-date>
 
   <app-date
@@ -29,6 +31,7 @@
     [formControlName]="control.key"
     [displayTime]="true"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   ></app-date>
 
   <app-number-input
@@ -38,6 +41,7 @@
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
     [width]="control.value.meta.width"
+    [customId]="control.value.meta.customId"
   >
     <ng-template *ngIf="control.value.meta.suffix" appSuffix> {{ control.value.meta.suffix }} </ng-template>
   </app-number-input>
@@ -49,6 +53,7 @@
     [options]="(options$ | async) || []"
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   ></app-radio-group>
 
   <app-select
@@ -59,6 +64,7 @@
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
     [width]="control.value.meta.width"
+    [customId]="control.value.meta.customId"
   ></app-select>
 
   <app-text-area
@@ -67,6 +73,7 @@
     [name]="control.value.meta.name"
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   ></app-text-area>
 
   <app-checkbox
@@ -75,6 +82,7 @@
     [name]="control.value.meta.name"
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   ></app-checkbox>
 
   <app-checkbox-group
@@ -85,6 +93,7 @@
     [formControlName]="control.key"
     [delimited]="control.value.meta.delimited"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   ></app-checkbox-group>
 
   <app-text-input
@@ -95,6 +104,7 @@
     [numeric]="true"
     [hint]="control.value.meta.hint"
     [width]="control.value.meta.width"
+    [customId]="control.value.meta.customId"
   >
     <ng-template *ngIf="control.value.meta.suffix" appSuffix> {{ control.value.meta.suffix }} </ng-template>
   </app-text-input>
@@ -106,6 +116,7 @@
     [name]="control.value.meta.name"
     [formControlName]="control.key"
     [hint]="control.value.meta.hint"
+    [customId]="control.value.meta.customId"
   >
     <ng-template *ngIf="control.value.meta.suffix" appSuffix> {{ control.value.meta.suffix }} </ng-template></app-text-input
   >

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -13,6 +13,7 @@ import { Observable, of, map } from 'rxjs';
 export class DynamicFormFieldComponent implements AfterContentInit {
   @Input() control?: KeyValue<string, CustomFormControl>;
   @Input() form?: FormGroup;
+  @Input() customId?: string;
 
   constructor(private optionsService: MultiOptionsService) {}
 

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
@@ -77,6 +77,7 @@
         *ngSwitchCase="true"
         [control]="control"
         [form]="formGroup"
+        [customId]="control.value.meta.customId"
         [ngClass]="control.value.meta.class"
       ></app-dynamic-form-field>
     </ng-container>

--- a/src/app/forms/components/select/select.component.html
+++ b/src/app/forms/components/select/select.component.html
@@ -8,7 +8,7 @@
   <select
     [class]="style"
     class="govuk-select"
-    id="{{ name }}"
+    [id]="customId || name"
     name="{{ name }}"
     [(ngModel)]="value"
     [disabled]="disabled"

--- a/src/app/forms/components/switchable-input/switchable-input.component.html
+++ b/src/app/forms/components/switchable-input/switchable-input.component.html
@@ -70,6 +70,7 @@
     [width]="width"
     [options]="options!"
     [noBottomMargin]="true"
+    [customId]="customId"
   ></app-select>
 
   <app-text-area

--- a/src/app/forms/custom-sections/body/body.component.html
+++ b/src/app/forms/custom-sections/body/body.component.html
@@ -41,7 +41,7 @@
     <app-switchable-input
       [form]="bodyTypeForm"
       [type]="editTypes.TEXT"
-      name="description"
+      name="bodyType"
       label="Body type"
       [isEditing]="isEditing"
       [options]="bodyTypes"
@@ -98,6 +98,7 @@
     [isEditing]="isEditing"
     [options]="bodyTypes"
     [width]="widths.L"
+    customId="bodyType"
   ></app-switchable-input>
 </ng-container>
 

--- a/src/app/forms/custom-sections/body/body.component.html
+++ b/src/app/forms/custom-sections/body/body.component.html
@@ -41,11 +41,12 @@
     <app-switchable-input
       [form]="bodyTypeForm"
       [type]="editTypes.TEXT"
-      name="bodyType"
+      name="description"
       label="Body type"
       [isEditing]="isEditing"
       [options]="bodyTypes"
       [width]="widths.L"
+      customId="bodyType"
     ></app-switchable-input>
 
     <app-switchable-input


### PR DESCRIPTION
**Vehicle Class and Body Type elements have the same `id`**

Vehicle Class and Body type dropdown both same same object id as description. Could you please get this fixed for HGV and TRL, thanks.
[CB2-7839](https://dvsa.atlassian.net/browse/CB2-7839)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
