### PR TITLE
fix(cb2-7834): added ids for add axle buttons on tyres and weights

### DIFF
--- a/src/app/forms/custom-sections/tyres/tyres.component.html
+++ b/src/app/forms/custom-sections/tyres/tyres.component.html
@@ -94,7 +94,7 @@
       </tr>
 
       <tr *ngIf="isEditing">
-        <a class="axleButton" role="button" (click)="addAxle()">Add Axle</a>
+        <a class="axleButton" role="button" id="tyresAddAxle" (click)="addAxle()">Add Axle</a>
 
         <p *ngIf="isError" class="govuk-error-message">{{ errorMessage }}</p>
       </tr>

--- a/src/app/forms/custom-sections/weights/weights.component.html
+++ b/src/app/forms/custom-sections/weights/weights.component.html
@@ -111,7 +111,7 @@
       </ng-template>
 
       <tr *ngIf="isEditing">
-        <a class="axleButton" role="button" (click)="addAxle()">Add Axle</a>
+        <a class="axleButton" role="button" id="weightsAddAxle" (click)="addAxle()">Add Axle</a>
         <p *ngIf="isError" class="govuk-error-message">{{ errorMessage }}</p>
       </tr>
 


### PR DESCRIPTION
**Add Axle from tyres and Add Axles from weights both have ids missing**

Add ids for add axle buttons in tyres and weights
[CB2-7834](https://dvsa.atlassian.net/browse/CB2-7834)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
