### PR TITLE
fix(cb2-7913): hide certificate link on cancelled tests

### DIFF
--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -130,7 +130,7 @@
           {{ combinedOdometerReading(testResult?.odometerReading | digitGroupSeparator, testResult?.odometerReadingUnits) | defaultNullOrEmpty }}
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
+      <div *ngIf="resultOfTest !== 'cancelled'" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Certificate:</dt>
         <dd id="test-certificate" class="govuk-summary-list__value">
           <app-test-certificate [testNumber]="testNumber || ''" [vin]="testResult?.vin || ''" [isClickable]="!isReview">


### PR DESCRIPTION
## Certificate link to cancelled test certificate still visible in VTM

[CB2-7913](https://dvsa.atlassian.net/browse/CB2-7913)
