### PR TITLE
fix(cb2-7914): adds vehicle configuration 'Other' to light vehicles

### DIFF
--- a/src/app/forms/templates/car/car-tech-record.template.ts
+++ b/src/app/forms/templates/car/car-tech-record.template.ts
@@ -1,6 +1,7 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
+import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
 
 export const CarTechRecord: FormNode = {
@@ -61,6 +62,15 @@ export const CarTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CHECKBOXGROUP,
       options: getOptionsFromEnum(VehicleSubclass)
+    },
+    {
+      name: 'vehicleConfiguration',
+      label: 'Vehicle configuration',
+      value: VehicleConfiguration.OTHER,
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(VehicleConfiguration),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'euVehicleCategory',

--- a/src/app/forms/templates/lgv/lgv-tech-record.template.ts
+++ b/src/app/forms/templates/lgv/lgv-tech-record.template.ts
@@ -1,6 +1,7 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
+import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
 
 export const LgvTechRecord: FormNode = {
@@ -63,6 +64,15 @@ export const LgvTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CHECKBOXGROUP,
       options: getOptionsFromEnum(VehicleSubclass)
+    },
+    {
+      name: 'vehicleConfiguration',
+      label: 'Vehicle configuration',
+      value: VehicleConfiguration.OTHER,
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(VehicleConfiguration),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'euVehicleCategory',

--- a/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
+++ b/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
@@ -2,6 +2,7 @@ import { ValidatorNames } from '@forms/models/validators.enum';
 import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleClass } from '@models/vehicle-class.model';
+import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 
 export const MotorcycleTechRecord: FormNode = {
@@ -75,6 +76,15 @@ export const MotorcycleTechRecord: FormNode = {
           validators: [{ name: ValidatorNames.Required }]
         }
       ]
+    },
+    {
+      name: 'vehicleConfiguration',
+      label: 'Vehicle configuration',
+      value: VehicleConfiguration.OTHER,
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      options: getOptionsFromEnum(VehicleConfiguration),
+      validators: [{ name: ValidatorNames.Required }]
     },
     {
       name: 'euVehicleCategory',


### PR DESCRIPTION
## Bug: VehicleConfiguration value of 'Other' missing from LGV creation/amend

adds vehicle configuration 'Other' to light vehicles

[CB2-7914](https://dvsa.atlassian.net/browse/CB2-7914)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
