### PR TITLE
fix(cb2-7926): adds custom defect in amend specialist test for car

### DIFF
--- a/src/app/forms/templates/test-records/master.template.ts
+++ b/src/app/forms/templates/test-records/master.template.ts
@@ -539,6 +539,7 @@ export const masterTpl: Record<VehicleTypes, Partial<Record<keyof typeof TEST_TY
       required: SpecialistRequiredSectionLgvCarSmallTrl,
       vehicle: VehicleSectionDefaultPsvHgvLight,
       test: SpecialistTestSectionGroup5,
+      customDefects: CustomDefectsSection,
       visit: VisitSection,
       notes: NotesSection,
       reasonForCreation: reasonForCreationSection


### PR DESCRIPTION
## Bug: custom defects missing

Adding back the custom defect in the amend specialist test for car
[CB2-7926](https://dvsa.atlassian.net/browse/CB2-7926)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
