### PR TITLE
fix(cb2-7932): change state systems to run only on first change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cvs-app-vtm",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cvs-app-vtm",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvs-app-vtm",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "DVSA CVS Vehicle Testing Management Application",
   "main": "index.js",
   "engines": {

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -10,12 +10,12 @@ import { MultiOptionsService } from '@forms/services/multi-options.service';
 import { mockVehicleTechnicalRecord, mockVehicleTechnicalRecordList } from '@mocks/mock-vehicle-technical-record.mock';
 import { createMockTrl } from '@mocks/trl-record.mock';
 import { Roles } from '@models/roles.enum';
-import { LettersOfAuth, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { LettersOfAuth, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { UserService } from '@services/user-service/user-service';
 import { SharedModule } from '@shared/shared.module';
 import { initialAppState, State } from '@store/index';
-import { editableVehicleTechRecord, updateEditingTechRecord } from '@store/technical-records';
+import { editableTechRecord, editableVehicleTechRecord, updateEditingTechRecord } from '@store/technical-records';
 import { of } from 'rxjs';
 import { TechRecordSummaryComponent } from './tech-record-summary.component';
 
@@ -58,7 +58,9 @@ describe('TechRecordSummaryComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  function checkHeadingAndForm(): void {
+  function checkHeadingAndForm(technicalRecord?: TechRecordModel): void {
+    technicalRecord && store.overrideSelector(editableTechRecord, technicalRecord);
+    fixture.detectChanges();
     const heading = fixture.debugElement.query(By.css('.govuk-heading-s'));
     expect(heading).toBeFalsy();
 
@@ -68,72 +70,70 @@ describe('TechRecordSummaryComponent', () => {
 
   describe('TechRecordSummaryComponent View', () => {
     it('should show PSV record found', () => {
+      const mockRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       component.isEditing = false;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
-      fixture.detectChanges();
+      component.techRecord = mockRecord;
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord);
     });
 
     it('should show PSV record found without dimensions', () => {
+      const mockRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       component.isEditing = false;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
+      component.techRecord = mockRecord;
       component.techRecord!.dimensions = undefined;
-      fixture.detectChanges();
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord);
     });
 
     it('should show HGV record found', () => {
+      const mockRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
       component.isEditing = false;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
-      fixture.detectChanges();
+      component.techRecord = mockRecord;
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord);
     });
 
     it('should show HGV record found without dimensions', () => {
+      const mockRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
       component.isEditing = false;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.HGV).techRecord.pop()!;
+      component.techRecord = mockRecord;
       component.techRecord!.dimensions = undefined;
-      fixture.detectChanges();
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord);
     });
 
     it('should show TRL record found', async () => {
+      const mockRecord = createMockTrl(12345);
       component.isEditing = false;
       component.techRecord = {
-        ...createMockTrl(12345).techRecord[0],
+        ...mockRecord.techRecord[0],
         letterOfAuth: {} as LettersOfAuth
       };
-      fixture.detectChanges();
-      component.letters.vehicle = createMockTrl(12345);
-      await fixture.whenStable();
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord.techRecord[0]);
     });
 
     it('should show TRL record found without dimensions', () => {
+      const mockRecord = createMockTrl(12345).techRecord[0];
       component.isEditing = false;
       component.techRecord = {
-        ...createMockTrl(12345).techRecord[0],
+        ...mockRecord,
         letterOfAuth: {} as LettersOfAuth
       };
-      component.techRecord!.dimensions = undefined;
-      fixture.detectChanges();
+      component.techRecord.dimensions = undefined;
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord);
     });
   });
 
   describe('TechRecordSummaryComponent Amend', () => {
     it('should make reason for change null in editMode', () => {
+      const mockRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
       component.isEditing = true;
-      component.techRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV).techRecord.pop()!;
-      fixture.detectChanges();
+      component.techRecord = mockRecord;
 
-      checkHeadingAndForm();
+      checkHeadingAndForm(mockRecord);
     });
   });
 

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -76,14 +76,11 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, OnChanges 
       .pipe(
         select(editableTechRecord),
         skipWhile(editableTechRecord => !editableTechRecord),
-        map(editingTechRecord => {
-          return cloneDeep(editingTechRecord);
-        }),
         takeUntil(this.destroy$)
       )
       .subscribe(techRecord => {
         if (techRecord) {
-          this.techRecordCalculated = techRecord;
+          this.techRecordCalculated = cloneDeep(techRecord);
           this.referenceDataService.removeTyreSearch();
           this.sectionTemplates = this.vehicleTemplates;
           this.middleIndex = Math.floor(this.sectionTemplates.length / 2);

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -3,10 +3,12 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnChanges,
   OnDestroy,
   OnInit,
   Output,
   QueryList,
+  SimpleChanges,
   ViewChild,
   ViewChildren
 } from '@angular/core';
@@ -31,7 +33,7 @@ import { TechnicalRecordService } from '@services/technical-record/technical-rec
 import { editableTechRecord } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
 import { cloneDeep, mergeWith } from 'lodash';
-import { map, Subject, takeUntil } from 'rxjs';
+import { map, skipWhile, Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record-summary[techRecord]',
@@ -39,7 +41,7 @@ import { map, Subject, takeUntil } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./tech-record-summary.component.scss']
 })
-export class TechRecordSummaryComponent implements OnInit, OnDestroy {
+export class TechRecordSummaryComponent implements OnInit, OnDestroy, OnChanges {
   @ViewChildren(DynamicFormGroupComponent) sections!: QueryList<DynamicFormGroupComponent>;
   @ViewChild(BodyComponent) body!: BodyComponent;
   @ViewChild(DimensionsComponent) dimensions!: DimensionsComponent;
@@ -73,31 +75,36 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     this.store
       .pipe(
         select(editableTechRecord),
+        skipWhile(editableTechRecord => !editableTechRecord),
         //Need to check that the editing tech record has more than just reason for creation on and is the full object.
-        map(techRecord => {
-          if (techRecord && Object.keys(techRecord).length > 1) {
-            return cloneDeep(techRecord);
-          } else {
-            if (this.techRecord.vehicleType === VehicleTypes.HGV || this.techRecord.vehicleType === VehicleTypes.TRL) {
-              const [axles, axleSpacing] = this.axlesService.normaliseAxles(this.techRecord.axles, this.techRecord.dimensions?.axleSpacing);
-              this.techRecord = cloneDeep(this.techRecord);
-              this.techRecord.dimensions = { ...this.techRecord.dimensions, axleSpacing };
-              this.techRecord.axles = axles;
-            }
-
-            this.technicalRecordService.updateEditingTechRecord(this.techRecord, true);
-
-            return { ...cloneDeep(this.techRecord), reasonForCreation: '' };
-          }
+        map(editingTechRecord => {
+          return cloneDeep(editingTechRecord);
         }),
         takeUntil(this.destroy$)
       )
       .subscribe(techRecord => {
-        this.techRecordCalculated = techRecord;
-        this.referenceDataService.removeTyreSearch();
-        this.sectionTemplates = this.vehicleTemplates;
-        this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
+        if (techRecord) {
+          this.techRecordCalculated = techRecord;
+          this.referenceDataService.removeTyreSearch();
+          this.sectionTemplates = this.vehicleTemplates;
+          this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
+        }
       });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const { techRecord } = changes;
+
+    if (techRecord.previousValue !== techRecord.currentValue && techRecord.isFirstChange()) {
+      if (this.techRecord.vehicleType === VehicleTypes.HGV || this.techRecord.vehicleType === VehicleTypes.TRL) {
+        const [axles, axleSpacing] = this.axlesService.normaliseAxles(this.techRecord.axles, this.techRecord.dimensions?.axleSpacing);
+        this.techRecord = cloneDeep(this.techRecord);
+        this.techRecord.dimensions = { ...this.techRecord.dimensions, axleSpacing };
+        this.techRecord.axles = axles;
+      }
+
+      this.technicalRecordService.updateEditingTechRecord({ ...cloneDeep(this.techRecord), reasonForCreation: '' }, true);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -76,7 +76,6 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, OnChanges 
       .pipe(
         select(editableTechRecord),
         skipWhile(editableTechRecord => !editableTechRecord),
-        //Need to check that the editing tech record has more than just reason for creation on and is the full object.
         map(editingTechRecord => {
           return cloneDeep(editingTechRecord);
         }),


### PR DESCRIPTION
## Ticket title

This adds on changes and makes it only run on inital load. The store now only pipes and changes the editing record when it is not falsy.
[https://dvsa.atlassian.net/browse/CB2-7932](7932)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
