### PR TITLE
fix(cb2-7972): add toggle to content children

### DIFF
--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -16,6 +16,7 @@ export class AccordionControlComponent {
     value: QueryList<AccordionComponent> | undefined
   ) {
     this._accordions = value;
+    this.toggleAccordions();
   }
 
   @Input() isExpanded = false;


### PR DESCRIPTION
## Accordion components do not work properly when creating a test record

Quick fix to revert changes made for batch updating that no longer applies - and breaks the accordion when creating a test record
[CB2-7972](https://dvsa.atlassian.net/browse/CB2-7972)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
