### PR TITLE
fix(cb2-7976, 7979): fix generate plate subscribe event

### DIFF
--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.html
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.html
@@ -1,10 +1,10 @@
 <form [formGroup]="form">
   <app-radio-group id="reason" formControlName="reason" [options]="reasons"></app-radio-group>
 
-  <ng-container *ngIf="emailAddress">
-    <p class="govuk-body">This letter will be sent to {{ emailAddress }}</p>
+  <ng-container *ngIf="emailAddress$ | async">
+    <p class="govuk-body">This letter will be sent to {{ emailAddress$ | async }}</p>
   </ng-container>
-  <ng-container *ngIf="!emailAddress">
+  <ng-container *ngIf="(emailAddress$ | async) === undefined">
     <p class="govuk-body">This technical record does not have an applicant email address associated with it</p>
     <p class="govuk-body">This letter will instead be sent to {{ userService.userEmail$ | async }}</p>
   </ng-container>

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.spec.ts
@@ -93,6 +93,7 @@ describe('TechRecordGeneratePlateComponent', () => {
     });
 
     it('should navigate back on generatePlateSuccess', fakeAsync(() => {
+      component.ngOnInit();
       component.form.get('reason')?.setValue('Provisional');
 
       const navigateBackSpy = jest.spyOn(component, 'navigateBack').mockImplementation();

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
@@ -22,7 +22,7 @@ export class GeneratePlateComponent implements OnInit {
     reason: new CustomFormControl({ name: 'reason', label: 'Reason for generating plate', type: FormNodeTypes.CONTROL }, '', [Validators.required])
   });
 
-  record$: Observable<TechRecordModel | undefined>;
+  emailAddress$: Observable<string | undefined>;
 
   constructor(
     private actions$: Actions,
@@ -32,10 +32,11 @@ export class GeneratePlateComponent implements OnInit {
     private store: Store<TechnicalRecordServiceState>,
     public userService: UserService
   ) {
-    this.record$ = this.store.select(editableTechRecord).pipe(
+    this.emailAddress$ = this.store.select(editableTechRecord).pipe(
       tap(record => {
         if (record?.vehicleType !== 'hgv' && record?.vehicleType !== 'trl') this.navigateBack();
-      })
+      }),
+      map(record => record?.applicantDetails?.emailAddress)
     );
   }
 
@@ -58,10 +59,6 @@ export class GeneratePlateComponent implements OnInit {
       { label: 'Original', value: PlatesInner.PlateReasonForIssueEnum.Original },
       { label: 'Manual', value: PlatesInner.PlateReasonForIssueEnum.Manual }
     ];
-  }
-
-  get emailAddress$(): Observable<string | undefined> {
-    return this.record$.pipe(map(record => record?.applicantDetails?.emailAddress));
   }
 
   navigateBack() {

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PlatesInner } from '@api/vehicle';
@@ -17,7 +17,7 @@ import { take } from 'rxjs';
   templateUrl: './tech-record-generate-plate.component.html',
   styleUrls: ['./tech-record-generate-plate.component.scss']
 })
-export class GeneratePlateComponent {
+export class GeneratePlateComponent implements OnInit {
   form = new FormGroup({
     reason: new CustomFormControl({ name: 'reason', label: 'Reason for generating plate', type: FormNodeTypes.CONTROL }, '', [Validators.required])
   });
@@ -32,9 +32,18 @@ export class GeneratePlateComponent {
     private store: Store<TechnicalRecordServiceState>,
     public userService: UserService
   ) {
-    this.store.select(editableTechRecord).subscribe(record => {
-      if (record?.vehicleType !== 'hgv' && record?.vehicleType !== 'trl') this.navigateBack();
-      this.record = record;
+    this.store
+      .select(editableTechRecord)
+      .pipe(take(1))
+      .subscribe(record => {
+        if (record?.vehicleType !== 'hgv' && record?.vehicleType !== 'trl') this.navigateBack();
+        this.record = record;
+      });
+  }
+
+  ngOnInit(): void {
+    this.actions$.pipe(ofType(generatePlateSuccess), take(1)).subscribe(() => {
+      this.navigateBack();
     });
   }
 
@@ -67,8 +76,6 @@ export class GeneratePlateComponent {
     if (!this.form.value.reason) {
       return this.globalErrorService.addError({ error: 'Reason for generating plate is required', anchorLink: 'reason' });
     }
-
-    this.actions$.pipe(ofType(generatePlateSuccess), take(1)).subscribe(() => this.navigateBack());
 
     this.store.dispatch(generatePlate({ reason: this.form.value.reason }));
   }

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.ts
@@ -10,7 +10,7 @@ import { Store } from '@ngrx/store';
 import { UserService } from '@services/user-service/user-service';
 import { generatePlateSuccess, generatePlate, editableTechRecord } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
-import { take } from 'rxjs';
+import { Observable, map, take, tap } from 'rxjs';
 
 @Component({
   selector: 'app-generate-plate',
@@ -22,7 +22,7 @@ export class GeneratePlateComponent implements OnInit {
     reason: new CustomFormControl({ name: 'reason', label: 'Reason for generating plate', type: FormNodeTypes.CONTROL }, '', [Validators.required])
   });
 
-  record?: TechRecordModel;
+  record$: Observable<TechRecordModel | undefined>;
 
   constructor(
     private actions$: Actions,
@@ -32,13 +32,11 @@ export class GeneratePlateComponent implements OnInit {
     private store: Store<TechnicalRecordServiceState>,
     public userService: UserService
   ) {
-    this.store
-      .select(editableTechRecord)
-      .pipe(take(1))
-      .subscribe(record => {
+    this.record$ = this.store.select(editableTechRecord).pipe(
+      tap(record => {
         if (record?.vehicleType !== 'hgv' && record?.vehicleType !== 'trl') this.navigateBack();
-        this.record = record;
-      });
+      })
+    );
   }
 
   ngOnInit(): void {
@@ -62,8 +60,8 @@ export class GeneratePlateComponent implements OnInit {
     ];
   }
 
-  get emailAddress(): string | undefined {
-    return this.record?.applicantDetails?.emailAddress;
+  get emailAddress$(): Observable<string | undefined> {
+    return this.record$.pipe(map(record => record?.applicantDetails?.emailAddress));
   }
 
   navigateBack() {


### PR DESCRIPTION
## User is not taken back to view after amending a tech record after generating a plate

_PR to fix the subscribe method in generate plates by making the subscription close_
[CB2-7976](https://dvsa.atlassian.net/browse/CB2-7976)
[CB2-7979](https://dvsa.atlassian.net/browse/CB2-7979)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
