### PR TITLE
fix(cb2-7997): fixes the axle tyre details getting values from existing tyre fields

### DIFF
--- a/src/app/forms/components/switchable-input/switchable-input.component.html
+++ b/src/app/forms/components/switchable-input/switchable-input.component.html
@@ -47,7 +47,14 @@
     ></app-date>
   </ng-template>
 
-  <app-number-input *ngSwitchCase="types.NUMBER" [formControlName]="name" [name]="name" [label]="label" [width]="width" [noBottomMargin]="true">
+  <app-number-input
+    *ngSwitchCase="types.NUMBER"
+    [formControlName]="name"
+    [name]="idExtension ? name + '-' + idExtension : name"
+    [label]="label"
+    [width]="width"
+    [noBottomMargin]="true"
+  >
     <ng-template *ngIf="prefix" appPrefix>{{ prefix }}</ng-template>
     <ng-template *ngIf="suffix" appSuffix>{{ suffix }}</ng-template>
   </app-number-input>

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -552,6 +552,22 @@ describe('Vehicle Technical Record Reducer', () => {
           const updatedTechRecord = newState.editingTechRecord?.techRecord[0];
           expect(updatedTechRecord?.noOfAxles).toBe(4);
           expect(updatedTechRecord?.axles?.length).toBe(4);
+
+          const newAxleField = updatedTechRecord?.axles || [];
+          expect(newAxleField[3].tyres).toEqual({
+            dataTrAxles: null,
+            fitmentCode: null,
+            plyRating: null,
+            speedCategorySymbol: null,
+            tyreCode: null,
+            tyreSize: null
+          });
+          expect(newAxleField[3].weights).toEqual({
+            designWeight: null,
+            gbWeight: null,
+            kerbWeight: null,
+            ladenWeight: null
+          });
           expect(updatedTechRecord?.axles?.pop()?.axleNumber).toBe(4);
         });
 
@@ -569,6 +585,22 @@ describe('Vehicle Technical Record Reducer', () => {
           const updatedTechRecord = newState.editingTechRecord?.techRecord[0];
           expect(updatedTechRecord?.noOfAxles).toBe(1);
           expect(updatedTechRecord?.axles?.length).toBe(1);
+
+          const newAxleField = updatedTechRecord?.axles || [];
+          expect(newAxleField[0].tyres).toEqual({
+            dataTrAxles: null,
+            fitmentCode: null,
+            plyRating: null,
+            speedCategorySymbol: null,
+            tyreCode: null,
+            tyreSize: null
+          });
+          expect(newAxleField[0].weights).toEqual({
+            designWeight: null,
+            gbWeight: null,
+            kerbWeight: null,
+            ladenWeight: null
+          });
           expect(updatedTechRecord?.axles?.pop()?.axleNumber).toBe(1);
         });
       });

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -225,13 +225,18 @@ function handleAddAxle(state: TechnicalRecordServiceState): TechnicalRecordServi
 
   const newAxle: Axle = {
     axleNumber: newState.editingTechRecord.techRecord[0].axles.length + 1,
-    tyres: { dataTrAxles: null },
-    weights: {},
+    tyres: { tyreSize: null, fitmentCode: null, dataTrAxles: null, plyRating: null, tyreCode: null },
+    weights: { gbWeight: null, designWeight: null },
     parkingBrakeMrk: false
   };
 
   if (vehicleType === VehicleTypes.HGV || vehicleType === VehicleTypes.TRL) {
     newAxle.weights!.eecWeight = null;
+  }
+  if (vehicleType === VehicleTypes.PSV) {
+    newAxle.weights!.kerbWeight = null;
+    newAxle.weights!.ladenWeight = null;
+    newAxle.tyres!.speedCategorySymbol = null;
   }
 
   newState.editingTechRecord.techRecord[0].axles.push(newAxle);


### PR DESCRIPTION
## Tyre details populated with details from existing details when search is canceled

Tested for PSV, HGV, and trailers.

[CB2-7997](https://dvsa.atlassian.net/browse/CB2-7997)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Necessary `id` required prepended with `"test-"` have been checked with automation testers and added
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Link to the PR added to the repo
- [ ] Delete branch after merge
