### PR TITLE
test(cb2-7951): update cypress data to match new trailer rules

### DIFF
--- a/cypress/e2e/testResults/TRL/tests.cy.ts
+++ b/cypress/e2e/testResults/TRL/tests.cy.ts
@@ -17,7 +17,7 @@ describe('TRL tests', () => {
     cy.get('#test-list-item-94').click();
     cy.get('#countryOfRegistration').type('g');
     cy.get('#countryOfRegistration__option--1').click();
-    cy.get('#euVehicleCategory').select('8: o2');
+    cy.get('#euVehicleCategory').select('9: o3');
     cy.get('#contingencyTestNumber').type('123456');
     cy.get('#testTypeStartTimestamp-day').type('14');
     cy.get('#testTypeStartTimestamp-month').type('02');
@@ -50,7 +50,7 @@ describe('TRL tests', () => {
     cy.get('#test-list-item-94').click();
     cy.get('#countryOfRegistration').type('g');
     cy.get('#countryOfRegistration__option--1').click();
-    cy.get('#euVehicleCategory').select('8: o2');
+    cy.get('#euVehicleCategory').select('9: o3');
     cy.get('#contingencyTestNumber').type('123456');
     cy.get('#testTypeStartTimestamp-day').type('14');
     cy.get('#testTypeStartTimestamp-month').type('02');


### PR DESCRIPTION
Update cypress test data to match changes for [CB2-7951](https://dvsa.atlassian.net/browse/CB2-7951)
 CVS-Unable to identify a small trailer as an O2 EU category 
## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [x] Delete branch after merge
