### PR TITLE
feature CB2-7951: Unable to identify a small trailer as an O2 EU category

### DIFF
--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -83,7 +83,7 @@ export const SmallTrailerTechRecord: FormNode = {
       label: 'EU vehicle category',
       value: EuVehicleCategories.O1,
       type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.AUTOCOMPLETE,
+      editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
       options: [
         {


### PR DESCRIPTION

CB2-7951: changed the autocomplete to a select so that the options for EU vehicle category display correctly. 