### PR TITLE
fix(cb2-7965): improve directives and add alphanumeric validators

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
@@ -5,6 +5,7 @@ import { GlobalError } from '@core/components/global-error/global-error.interfac
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormControl, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
+import { CustomValidators } from '@forms/validators/custom-validators';
 import { TechRecordModel, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
@@ -43,7 +44,7 @@ export class AmendVinComponent implements OnDestroy {
           type: FormNodeTypes.CONTROL
         },
         '',
-        [Validators.minLength(3), Validators.maxLength(21), Validators.required],
+        [CustomValidators.alphanumeric(), Validators.minLength(3), Validators.maxLength(21), Validators.required],
         [this.technicalRecordService.validateVin(this.vehicle?.vin)]
       )
     });

--- a/src/app/features/tech-record/create-batch-trl/components/batch-trl-details/batch-trl-details.component.ts
+++ b/src/app/features/tech-record/create-batch-trl/components/batch-trl-details/batch-trl-details.component.ts
@@ -74,7 +74,7 @@ export class BatchTrlDetailsComponent implements OnDestroy {
       vin: new CustomFormControl(
         { name: 'vin', type: FormNodeTypes.CONTROL },
         null,
-        [Validators.minLength(3), Validators.maxLength(21)],
+        [CustomValidators.alphanumeric(), Validators.minLength(3), Validators.maxLength(21)],
         this.technicalRecordService.validateForBatch()
       ),
       trailerId: ['', [Validators.minLength(7), Validators.maxLength(8), CustomValidators.alphanumeric()]],

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -31,6 +31,7 @@ export class CreateTechRecordComponent implements OnChanges {
     { name: 'main-form', type: FormNodeTypes.GROUP },
     {
       vin: new CustomFormControl({ name: 'input-vin', label: 'Vin', type: FormNodeTypes.CONTROL }, '', [
+        CustomValidators.alphanumeric(),
         Validators.minLength(3),
         Validators.maxLength(21),
         Validators.required

--- a/src/app/forms/directives/app-no-space.directive.spec.ts
+++ b/src/app/forms/directives/app-no-space.directive.spec.ts
@@ -74,5 +74,58 @@ describe('NoSpaceDirective', () => {
 
       expect(input2.value).toBe('thishasspaces');
     });
+
+    describe('it should dispatch the appropriate number of input events', () => {
+      it('if the value has changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'this has spaces   ';
+        input1.dispatchEvent(new Event('focusout'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it('if the value has not changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'thishasspaces';
+        input1.dispatchEvent(new Event('focusout'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('should remove all whitespaces on input', () => {
+    it('with form', () => {
+      input1.value = 'this has spaces   ';
+      input1.dispatchEvent(new Event('input'));
+
+      expect(input1.value).toBe('thishasspaces');
+      expect(component.form.get('foo')?.value).toBe('thishasspaces');
+    });
+
+    it('without form', () => {
+      input2.value = 'this has spaces   ';
+      input2.dispatchEvent(new Event('input'));
+
+      expect(input2.value).toBe('thishasspaces');
+    });
+
+    describe('it should dispatch the appropriate number of input events', () => {
+      it('if the value has changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'this has spaces   ';
+        input1.dispatchEvent(new Event('input'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it('if the value has not changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'thishasspaces';
+        input1.dispatchEvent(new Event('input'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/src/app/forms/directives/app-no-space.directive.ts
+++ b/src/app/forms/directives/app-no-space.directive.ts
@@ -13,12 +13,17 @@ export class NoSpaceDirective {
 
   @HostListener('focusout', ['$event.target'])
   public onBlur(input: HTMLInputElement): void {
+    const oldValue = input.value;
     input.value = input.value.replace(/\s/g, '');
-    input.dispatchEvent(new Event('input'));
+
+    if (input.value !== oldValue) input.dispatchEvent(new Event('input'));
   }
 
   @HostListener('input', ['$event.target'])
   public onInput(input: HTMLInputElement): void {
+    const oldValue = input.value;
     input.value = input.value.replace(/\s/g, '');
+
+    if (input.value !== oldValue) input.dispatchEvent(new Event('input'));
   }
 }

--- a/src/app/forms/directives/app-no-space.directive.ts
+++ b/src/app/forms/directives/app-no-space.directive.ts
@@ -16,4 +16,9 @@ export class NoSpaceDirective {
     input.value = input.value.replace(/\s/g, '');
     input.dispatchEvent(new Event('input'));
   }
+
+  @HostListener('input', ['$event.target'])
+  public onInput(input: HTMLInputElement): void {
+    input.value = input.value.replace(/\s/g, '');
+  }
 }

--- a/src/app/forms/directives/app-trim-whitespace.directive.spec.ts
+++ b/src/app/forms/directives/app-trim-whitespace.directive.spec.ts
@@ -49,5 +49,58 @@ describe('TrimWhitespaceDirective', () => {
 
       expect(input2.value).toBe('this has spaces');
     });
+
+    describe('it should dispatch the appropriate number of events', () => {
+      it('if the value has changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'this has spaces   ';
+        input1.dispatchEvent(new Event('focusout'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it('if the value has not changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'this has spaces';
+        input1.dispatchEvent(new Event('focusout'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('should trim whitespaces on input', () => {
+    it('should trim the values and update the form', () => {
+      input1.value = 'this has spaces   ';
+      input1.dispatchEvent(new Event('input'));
+
+      expect(input1.value).toBe('this has spaces');
+      expect(component.form.get('foo')?.value).toBe('this has spaces');
+    });
+
+    it('without form', () => {
+      input2.value = 'this has spaces   ';
+      input2.dispatchEvent(new Event('input'));
+
+      expect(input2.value).toBe('this has spaces');
+    });
+
+    describe('it should dispatch the appropriate number of input events', () => {
+      it('if the value has changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'this has spaces   ';
+        input1.dispatchEvent(new Event('input'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it('if the value has not changed', () => {
+        const dispatchEventSpy = jest.spyOn(input1, 'dispatchEvent');
+        input1.value = 'this has spaces';
+        input1.dispatchEvent(new Event('input'));
+
+        expect(dispatchEventSpy).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/src/app/forms/directives/app-trim-whitespace.directive.ts
+++ b/src/app/forms/directives/app-trim-whitespace.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, HostListener } from '@angular/core';
+import { NgForm } from '@angular/forms';
 
 @Directive({
   selector: '[appTrimWhitespace]'
@@ -8,5 +9,10 @@ export class TrimWhitespaceDirective {
   public onBlur(input: HTMLInputElement): void {
     input.value = input.value.trim();
     input.dispatchEvent(new Event('input'));
+  }
+
+  @HostListener('input', ['$event.target'])
+  public onInput(input: HTMLInputElement): void {
+    input.value = input.value.trim();
   }
 }

--- a/src/app/forms/directives/app-trim-whitespace.directive.ts
+++ b/src/app/forms/directives/app-trim-whitespace.directive.ts
@@ -7,12 +7,17 @@ import { NgForm } from '@angular/forms';
 export class TrimWhitespaceDirective {
   @HostListener('focusout', ['$event.target'])
   public onBlur(input: HTMLInputElement): void {
+    const oldValue = input.value;
     input.value = input.value.trim();
-    input.dispatchEvent(new Event('input'));
+
+    if (input.value !== oldValue) input.dispatchEvent(new Event('input'));
   }
 
   @HostListener('input', ['$event.target'])
   public onInput(input: HTMLInputElement): void {
+    const oldValue = input.value;
     input.value = input.value.trim();
+
+    if (input.value !== oldValue) input.dispatchEvent(new Event('input'));
   }
 }


### PR DESCRIPTION
## CB2-7965: Prevent user from submitting whitespaces in forms with whitespace directives

_Users could originally bypass the whitespace directives by pressing Enter on the VIN field, which wouldn't trigger the focusout in the directives_
[CB2-7965](https://dvsa.atlassian.net/browse/CB2-7965)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
