### PR TITLE
fix(cb2-8107): fix tyre search routing for batch create

### DIFF
--- a/src/app/features/tech-record/create-batch-trl/create-batch-trl-routing.module.ts
+++ b/src/app/features/tech-record/create-batch-trl/create-batch-trl-routing.module.ts
@@ -8,6 +8,8 @@ import { BatchTrlDetailsComponent } from './components/batch-trl-details/batch-t
 import { BatchTrlResultsComponent } from './components/batch-trl-results/batch-trl-results.component';
 import { BatchTrlTemplateComponent } from './components/batch-trl-template/batch-trl-template.component';
 import { CreateBatchTrlResolver } from './resolvers/create-batch-trl.resolver';
+import { TechRecordSearchTyresComponent } from '../components/tech-record-search-tyres/tech-record-search-tyres.component';
+import { ReasonForEditing } from '@models/vehicle-tech-record.model';
 
 const routes: Routes = [
   {
@@ -31,6 +33,12 @@ const routes: Routes = [
         path: 'batch-results',
         data: { tile: 'Batch summary' },
         component: BatchTrlResultsComponent
+      },
+      {
+        path: 'tyre-search/:axleNumber',
+        component: TechRecordSearchTyresComponent,
+        data: { title: 'Tyre search', roles: Roles.TechRecordCreate, isEditing: true },
+        canActivate: [MsalGuard, RoleGuard]
       }
     ]
   }

--- a/src/app/forms/custom-sections/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.ts
@@ -173,7 +173,7 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   getTyreSearchPage(axleNumber: number) {
-    const route = this.editingReason ? `../${this.editingReason}/tyre-search/${axleNumber}` : `../new-record-details/tyre-search/${axleNumber}`;
+    const route = this.editingReason ? `../${this.editingReason}/tyre-search/${axleNumber}` : `./tyre-search/${axleNumber}`;
 
     this.router.navigate([route], { relativeTo: this.route, state: this.vehicleTechRecord });
   }


### PR DESCRIPTION
## Can't add tyres when creating a batch of trailer records

PR to add the tyre search component to the batch routing, and tweaks the tyre component routing to accommodate for this.
[CB2-8107](https://dvsa.atlassian.net/browse/CB2-8107)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
