### PR TITLE
chore(cb2-0000): update ts config to handle cypress and jest types

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "target": "es5",
     "lib": ["es5", "dom"],
     "types": ["cypress", "node"]
   },
-  "include": ["**/*.ts"]
+  "include": ["./**/*.ts"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,5 +44,6 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "exclude": ["cypress.config.ts", "cypress", "node_modules"]
 }


### PR DESCRIPTION
## Update TS config to handle jest and cypress types

Multiple people are getting errors in VS code because it is detecting cypress types in `.spec` files rather than jest. The tests run fine, however this hinders autocomplete behaviour and erroneously displays errors in the IDE.

Followed the fix on https://github.com/cypress-io/cypress/issues/22059

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
