### PR TITLE
fix(cb2-8165): fill in details in create vehicle

### DIFF
--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
@@ -2,11 +2,11 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Roles } from '@models/roles.enum';
 import { TechRecordActions } from '@models/tech-record/tech-record-actions.enum';
-import { EuVehicleCategories, StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes, Vrm } from '@models/vehicle-tech-record.model';
+import { StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes, Vrm } from '@models/vehicle-tech-record.model';
 import { select, Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { editableTechRecord } from '@store/technical-records';
-import { Observable, take } from 'rxjs';
+import { Observable, of, switchMap, take } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record-title[vehicle]',
@@ -19,6 +19,7 @@ export class TechRecordTitleComponent implements OnInit {
   @Input() hideActions: boolean = false;
   @Input() customTitle = '';
 
+  currentVehicleTechRecord$?: Observable<TechRecordModel | undefined>;
   currentTechRecord$?: Observable<TechRecordModel | undefined>;
   queryableActions: string[] = [];
   vehicleMakeAndModel = '';
@@ -28,7 +29,14 @@ export class TechRecordTitleComponent implements OnInit {
   ngOnInit(): void {
     this.queryableActions = this.actions.split(',');
 
-    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$;
+    this.currentVehicleTechRecord$ = this.technicalRecordService.viewableTechRecord$;
+
+    // On create new vehicle, when vehicleTechRecords is empty use the editableTechRecord
+    this.currentTechRecord$ = this.currentVehicleTechRecord$.pipe(
+      switchMap(value => {
+        return value ? of(value) : this.technicalRecordService.editableTechRecord$;
+      })
+    );
 
     this.currentTechRecord$
       .pipe(take(1))

--- a/src/app/forms/components/checkbox-group/checkbox-group.component.html
+++ b/src/app/forms/components/checkbox-group/checkbox-group.component.html
@@ -21,7 +21,7 @@
           (focus)="handleEvent($event)"
         />
 
-        <label class="govuk-label govuk-checkboxes__label" [for]="name"> {{ option.label }} </label>
+        <label class="govuk-label govuk-checkboxes__label" [for]="name + '-' + option.value + '-checkbox'"> {{ option.label }} </label>
       </div>
     </div>
   </fieldset>

--- a/src/app/forms/components/checkbox/checkbox.component.html
+++ b/src/app/forms/components/checkbox/checkbox.component.html
@@ -20,7 +20,7 @@
       (focus)="handleEvent($event)"
     />
 
-    <label class="govuk-label govuk-checkboxes__label" [for]="name">{{ label }}</label>
+    <label class="govuk-label govuk-checkboxes__label" [for]="customId ?? name">{{ label }}</label>
 
     <div *ngIf="suffix" class="govuk-input__suffix" aria-hidden="true">
       <ng-container [ngTemplateOutlet]="suffix.templateRef"></ng-container>


### PR DESCRIPTION
## New tech record details (vehicle type, vin and vrm etc) not visible anymore on tech record page

1. Display information while creating tech record
2. Checkbox labels are clickable
 
[CB2-8165](https://dvsa.atlassian.net/browse/CB2-8165)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
