### PR TITLE
fix(cb2-8161): navigates back nicely on browser refresh

### DIFF
--- a/cypress/e2e/techRecord/HGV/hgv.cy.ts
+++ b/cypress/e2e/techRecord/HGV/hgv.cy.ts
@@ -30,4 +30,16 @@ describe('HGV technical record', () => {
     cy.get('.govuk-accordion__show-all-text').click();
     cy.get('#test-approvalType').should('have.text', ' NTA ');
   });
+
+  it('should display the create vehicle page', () => {
+    const vin = randomString(10);
+    const vrm = randomString(7);
+    cy.get('#create-new-technical-record-link').click();
+    cy.get('#input-vin').type(vin);
+    cy.get('#input-vrm-or-trailer-id').type(vrm);
+    cy.get('#change-vehicle-type-select').select('1: hgv');
+    cy.get('#create-record-continue').click();
+    cy.get('#vehicleType').should('have.text', ' HGV ');
+    cy.get('#vin').should('have.text', ` ${vin.toUpperCase()} `);
+  });
 });

--- a/cypress/e2e/techRecord/HGV/hgv.cy.ts
+++ b/cypress/e2e/techRecord/HGV/hgv.cy.ts
@@ -31,19 +31,36 @@ describe('HGV technical record', () => {
     cy.get('#test-approvalType').should('have.text', ' NTA ');
   });
 
-  it('should display the create vehicle page', () => {
-    const vin = randomString(10);
-    const vrm = randomString(7);
-    cy.get('#create-new-technical-record-link').click();
-    cy.get('#input-vin').type(vin);
-    cy.get('#input-vrm-or-trailer-id').type(vrm);
-    cy.get('#change-vehicle-type-select').select('1: hgv');
-    cy.get('#create-record-continue').click();
-    cy.get('#vehicleType').should('have.text', ' HGV ');
-    cy.get('#vin').should('have.text', ` ${vin.toUpperCase()} `);
-    cy.get('#current-vrm-span').should(vrmDisplay => {
-      const vrmSplit = vrm.slice(0, vrm.length - 3) + ' ' + vrm.slice(vrm.length - 3);
-      expect(vrmDisplay).to.contain(vrmSplit.toUpperCase());
+  describe('Create HGV technical record', () => {
+    it('should display the create vehicle page with details filled in', () => {
+      const vin = randomString(10);
+      const vrm = randomString(7);
+      cy.get('#create-new-technical-record-link').click();
+      cy.get('#input-vin').type(vin);
+      cy.get('#input-vrm-or-trailer-id').type(vrm);
+      cy.get('#change-vehicle-type-select').select('1: hgv');
+      cy.get('#create-record-continue').click();
+      cy.get('#vehicleType').should('have.text', ' HGV ');
+      cy.get('#vin').should('have.text', ` ${vin.toUpperCase()} `);
+      cy.get('#current-vrm-span').should(vrmDisplay => {
+        const vrmSplit = vrm.slice(0, vrm.length - 3) + ' ' + vrm.slice(vrm.length - 3);
+        expect(vrmDisplay).to.contain(vrmSplit.toUpperCase());
+      });
+    });
+
+    it('should navigate back on browser refresh', () => {
+      const vin = randomString(10);
+      const vrm = randomString(7);
+      cy.get('#create-new-technical-record-link').click();
+      cy.get('#input-vin').type(vin);
+      cy.get('#input-vrm-or-trailer-id').type(vrm);
+      cy.get('#change-vehicle-type-select').select('1: hgv');
+      cy.get('#create-record-continue').click();
+      cy.get('#vehicleType').should('have.text', ' HGV ');
+      cy.get('#vin').should('have.text', ` ${vin.toUpperCase()} `);
+      cy.reload();
+      cy.location('pathname').should('include', 'create');
+      cy.location('pathname').should('not.contain', 'new-record-details');
     });
   });
 });

--- a/cypress/e2e/techRecord/HGV/hgv.cy.ts
+++ b/cypress/e2e/techRecord/HGV/hgv.cy.ts
@@ -41,5 +41,9 @@ describe('HGV technical record', () => {
     cy.get('#create-record-continue').click();
     cy.get('#vehicleType').should('have.text', ' HGV ');
     cy.get('#vin').should('have.text', ` ${vin.toUpperCase()} `);
+    cy.get('#current-vrm-span').should(vrmDisplay => {
+      const vrmSplit = vrm.slice(0, vrm.length - 3) + ' ' + vrm.slice(vrm.length - 3);
+      expect(vrmDisplay).to.contain(vrmSplit.toUpperCase());
+    });
   });
 });

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.ts
@@ -2,11 +2,11 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Roles } from '@models/roles.enum';
 import { TechRecordActions } from '@models/tech-record/tech-record-actions.enum';
-import { EuVehicleCategories, StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes, Vrm } from '@models/vehicle-tech-record.model';
+import { StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes, Vrm } from '@models/vehicle-tech-record.model';
 import { select, Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { editableTechRecord } from '@store/technical-records';
-import { Observable, take } from 'rxjs';
+import { Observable, of, switchMap, take } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record-title[vehicle]',
@@ -19,6 +19,7 @@ export class TechRecordTitleComponent implements OnInit {
   @Input() hideActions: boolean = false;
   @Input() customTitle = '';
 
+  currentVehicleTechRecord$?: Observable<TechRecordModel | undefined>;
   currentTechRecord$?: Observable<TechRecordModel | undefined>;
   queryableActions: string[] = [];
   vehicleMakeAndModel = '';
@@ -28,7 +29,14 @@ export class TechRecordTitleComponent implements OnInit {
   ngOnInit(): void {
     this.queryableActions = this.actions.split(',');
 
-    this.currentTechRecord$ = this.technicalRecordService.viewableTechRecord$;
+    this.currentVehicleTechRecord$ = this.technicalRecordService.viewableTechRecord$;
+
+    // On create new vehicle, when vehicleTechRecords is empty use the editableTechRecord
+    this.currentTechRecord$ = this.currentVehicleTechRecord$.pipe(
+      switchMap(value => {
+        return value ? of(value) : this.technicalRecordService.editableTechRecord$;
+      })
+    );
 
     this.currentTechRecord$
       .pipe(take(1))

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -35,6 +35,10 @@ export class HydrateNewVehicleRecordComponent implements OnDestroy {
     this.actions$
       .pipe(ofType(createVehicleRecordSuccess), takeUntil(this.destroy$))
       .subscribe(({ vehicleTechRecords }) => this.navigate(vehicleTechRecords[0].systemNumber));
+
+    this.technicalRecordService.editableVehicleTechRecord$.pipe(take(1)).subscribe(vehicle => {
+      if (!vehicle) this.router.navigate(['..'], { relativeTo: this.route });
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/forms/components/checkbox-group/checkbox-group.component.html
+++ b/src/app/forms/components/checkbox-group/checkbox-group.component.html
@@ -21,7 +21,7 @@
           (focus)="handleEvent($event)"
         />
 
-        <label class="govuk-label govuk-checkboxes__label" [for]="name"> {{ option.label }} </label>
+        <label class="govuk-label govuk-checkboxes__label" [for]="name + '-' + option.value + '-checkbox'"> {{ option.label }} </label>
       </div>
     </div>
   </fieldset>

--- a/src/app/forms/components/checkbox/checkbox.component.html
+++ b/src/app/forms/components/checkbox/checkbox.component.html
@@ -20,7 +20,7 @@
       (focus)="handleEvent($event)"
     />
 
-    <label class="govuk-label govuk-checkboxes__label" [for]="name">{{ label }}</label>
+    <label class="govuk-label govuk-checkboxes__label" [for]="customId ?? name">{{ label }}</label>
 
     <div *ngIf="suffix" class="govuk-input__suffix" aria-hidden="true">
       <ng-container [ngTemplateOutlet]="suffix.templateRef"></ng-container>


### PR DESCRIPTION
## Manually refreshing when creating a tech record wipes the template

Navigates back to create tech record if refreshed on the details page or the tyre search page

[CB2-8161](https://dvsa.atlassian.net/browse/CB2-8161)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Delete branch after merge
