### PR TITLE
fix(cb2-8286): send current record if no provisional exists

### DIFF
--- a/src/app/store/technical-records/selectors/technical-record-service.selectors.ts
+++ b/src/app/store/technical-records/selectors/technical-record-service.selectors.ts
@@ -35,7 +35,10 @@ export const selectTechRecord = createSelector(
     const lastTwoUrlParts = url?.split('/').slice(-2);
 
     if (lastTwoUrlParts?.includes(StatusCodes.PROVISIONAL)) {
-      return vehicle?.techRecord.find(techRecord => techRecord.statusCode === StatusCodes.PROVISIONAL);
+      const provisionalRecord = vehicle?.techRecord.find(techRecord => techRecord.statusCode === StatusCodes.PROVISIONAL);
+      if (provisionalRecord) {
+        return provisionalRecord;
+      }
     }
 
     if (techCreatedAt) {


### PR DESCRIPTION
## After creating a passed IVA test, user should be landing to current record page instead of provisional

Sends provisional vehicle record only if present, else defaults to current.

[CB2-8286](https://dvsa.atlassian.net/browse/CB2-8286)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
