### PR TITLE
fix(cb2-8249): numberOfWheelsDriven default value

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/required/required-hidden-section-hgv-trl.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/required/required-hidden-section-hgv-trl.template.ts
@@ -96,6 +96,7 @@ export const RequiredSectionHGVTRL: FormNode = {
     {
       name: 'numberOfWheelsDriven',
       type: FormNodeTypes.CONTROL,
+      value: null,
       editType: FormNodeEditTypes.HIDDEN,
       viewType: FormNodeViewTypes.HIDDEN
     },


### PR DESCRIPTION
## Added a default value for the numberOfWheelsDriven field
Added a default value of null for the numberOfWheelsDriven field so that historic Tech Records which lack this field now supply it before they are sent back to the test service thus fulfilling the validation requirements for the field.

[CB2-8249](https://dvsa.atlassian.net/browse/CB2-8249)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
