### PR TITLE
fix(cb2-8358): content change plus vehicle type refactor

### DIFF
--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.ts
@@ -6,7 +6,7 @@ import { GlobalErrorService } from '@core/components/global-error/global-error.s
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormControl, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { CustomValidators } from '@forms/validators/custom-validators';
-import { TechRecordModel, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { combineLatest, filter, firstValueFrom, Observable, Subject, take } from 'rxjs';
@@ -18,7 +18,7 @@ import { combineLatest, filter, firstValueFrom, Observable, Subject, take } from
 })
 export class BatchVehicleDetailsComponent implements OnInit, OnDestroy {
   form: FormGroup;
-  techRecord?: TechRecordModel;
+  vehicleType?: VehicleTypes;
   readonly maxNumberOfVehicles = 40;
 
   private destroy$ = new Subject<void>();
@@ -38,9 +38,11 @@ export class BatchVehicleDetailsComponent implements OnInit, OnDestroy {
       ])
     });
 
-    this.technicalRecordService.editableVehicleTechRecord$
-      .pipe(take(1))
-      .subscribe(vehicle => (!vehicle ? this.back() : (this.techRecord = vehicle.techRecord[0])));
+    this.technicalRecordService.editableVehicleTechRecord$.pipe(take(1)).subscribe(vehicle => {
+      if (!vehicle) return this.back();
+    });
+
+    this.batchTechRecordService.vehicleType$.pipe(take(1)).subscribe(vehicleType => (this.vehicleType = vehicleType));
   }
   ngOnInit(): void {
     this.addVehicles(this.maxNumberOfVehicles);
@@ -56,10 +58,6 @@ export class BatchVehicleDetailsComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-  }
-
-  get vehicleType(): VehicleTypes | undefined {
-    return this.techRecord ? this.technicalRecordService.getVehicleTypeWithSmallTrl(this.techRecord) : undefined;
   }
 
   get vehicles(): FormArray {
@@ -98,7 +96,7 @@ export class BatchVehicleDetailsComponent implements OnInit, OnDestroy {
           viewType: FormNodeViewTypes.HIDDEN,
           editType: FormNodeEditTypes.HIDDEN
         },
-        this.techRecord?.vehicleType
+        this.vehicleType
       ),
       systemNumber: [''],
       oldVehicleStatus: ['']

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.html
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.html
@@ -5,7 +5,7 @@
     <h2 class="govuk-heading-m">Technical records created</h2>
     <p class="govuk-body">
       You have successfully processed {{ (batchSuccessCount$ | async) ?? 0 }} out of {{ (batchCount$ | async) ?? 0 }}
-      {{ vehicleType | formatVehicleType }} technical records using application ID {{ applicationId$ | async }}.
+      {{ vehicleType$ | async | formatVehicleType }} technical records using application ID {{ applicationId$ | async }}.
     </p>
     <p class="govuk-body">
       {{ (batchCreatedCount$ | async) ?? 0 }} out of {{ (batchTotalCreatedCount$ | async) ?? 0 }} records successfully created.
@@ -23,7 +23,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">VIN</th>
-      <th scope="col" class="govuk-table__header">{{ vehicleType === 'trl' ? 'Trailer ID' : 'VRM' }}</th>
+      <th scope="col" class="govuk-table__header">{{ (vehicleType$ | async) === 'trl' ? 'Trailer ID' : 'VRM' }}</th>
       <th scope="col" class="govuk-table__header">Vehicle type</th>
       <th scope="col" class="govuk-table__header">Record type</th>
       <th scope="col" class="govuk-table__header"></th>

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.spec.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.spec.ts
@@ -40,5 +40,6 @@ describe('BatchVehicleResultsComponent', () => {
     expect(component.batchTotalUpdatedCount$).toBeTruthy();
     expect(component.applicationId$).toBeTruthy();
     expect(component.batchVehiclesSuccess$).toBeTruthy();
+    expect(component.vehicleType$).toBeTruthy();
   });
 });

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { StatusCodes } from '@models/vehicle-tech-record.model';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
-import { BatchRecord } from '@store/technical-records/reducers/batch-create.reducer';
 import { filter, race, Subject, take, withLatestFrom } from 'rxjs';
 
 @Component({
@@ -12,7 +11,6 @@ import { filter, race, Subject, take, withLatestFrom } from 'rxjs';
 })
 export class BatchVehicleResultsComponent implements OnDestroy {
   private destroy$ = new Subject<void>();
-  vehicleRecord?: BatchRecord;
 
   constructor(
     private technicalRecordService: TechnicalRecordService,
@@ -20,9 +18,6 @@ export class BatchVehicleResultsComponent implements OnDestroy {
     private route: ActivatedRoute,
     private batchTechRecordService: BatchTechnicalRecordService
   ) {
-    this.batchTechRecordService.batchVehicles$.pipe(take(1)).subscribe(batchVehicles => {
-      if (batchVehicles) this.vehicleRecord = batchVehicles[0];
-    });
     this.batchTechRecordService.batchCount$.pipe(take(1)).subscribe(count => {
       if (!count) this.router.navigate(['../..'], { relativeTo: this.route });
     });
@@ -46,8 +41,8 @@ export class BatchVehicleResultsComponent implements OnDestroy {
     this.destroy$.complete();
   }
 
-  get vehicleType(): VehicleTypes | undefined {
-    return this.vehicleRecord ? (this.vehicleRecord.vehicleType as VehicleTypes) : undefined;
+  get vehicleType$() {
+    return this.batchTechRecordService.vehicleType$;
   }
 
   get applicationId$() {

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { StatusCodes, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { BatchRecord } from '@store/technical-records/reducers/batch-create.reducer';
 import { filter, race, Subject, take, withLatestFrom } from 'rxjs';
 
 @Component({
@@ -11,7 +12,7 @@ import { filter, race, Subject, take, withLatestFrom } from 'rxjs';
 })
 export class BatchVehicleResultsComponent implements OnDestroy {
   private destroy$ = new Subject<void>();
-  techRecord?: TechRecordModel;
+  vehicleRecord?: BatchRecord;
 
   constructor(
     private technicalRecordService: TechnicalRecordService,
@@ -19,10 +20,9 @@ export class BatchVehicleResultsComponent implements OnDestroy {
     private route: ActivatedRoute,
     private batchTechRecordService: BatchTechnicalRecordService
   ) {
-    this.technicalRecordService.editableVehicleTechRecord$
-      .pipe(take(1))
-      .subscribe(vehicle => (!vehicle ? this.router.navigate(['..'], { relativeTo: this.route }) : (this.techRecord = vehicle.techRecord[0])));
-
+    this.batchTechRecordService.batchVehicles$.pipe(take(1)).subscribe(batchVehicles => {
+      if (batchVehicles) this.vehicleRecord = batchVehicles[0];
+    });
     this.batchTechRecordService.batchCount$.pipe(take(1)).subscribe(count => {
       if (!count) this.router.navigate(['../..'], { relativeTo: this.route });
     });
@@ -47,7 +47,7 @@ export class BatchVehicleResultsComponent implements OnDestroy {
   }
 
   get vehicleType(): VehicleTypes | undefined {
-    return this.techRecord ? this.technicalRecordService.getVehicleTypeWithSmallTrl(this.techRecord) : undefined;
+    return this.vehicleRecord ? (this.vehicleRecord.vehicleType as VehicleTypes) : undefined;
   }
 
   get applicationId$() {

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.html
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.html
@@ -7,7 +7,7 @@
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Vehicle type</dt>
             <dd id="batch-vehicle-type" class="govuk-summary-list__value">
-              {{ getVehicleType(vehicle.techRecord[0]) | uppercase | defaultNullOrEmpty }}
+              {{ vehicleType$ | async | uppercase | defaultNullOrEmpty }}
             </dd>
           </div>
           <div class="govuk-summary-list__row">

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
 import { TechRecordSummaryComponent } from '../../../components/tech-record-summary/tech-record-summary.component';
 import { BatchRecord } from '@store/technical-records/reducers/batch-create.reducer';
 import { createVehicleRecord, updateTechRecords } from '@store/technical-records';
-import { StatusCodes } from '@models/vehicle-tech-record.model';
+import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Router } from '@angular/router';
 import { BatchVehicleResultsComponent } from '../batch-vehicle-results/batch-vehicle-results.component';
 import { FixNavigationTriggeredOutsideAngularZoneNgModule } from '@shared/custom-module/fixNgZoneError';
@@ -32,6 +32,7 @@ const mockBatchTechRecordService = (<unknown>{
   applicationId$: of('TES_1_APPLICATION_ID'),
   isBatchCreate$: of(true),
   batchCount$: of(2),
+  vehicleType$: of(VehicleTypes.TRL),
   get vehicleStatus$() {
     return of('current');
   }
@@ -96,6 +97,10 @@ describe('BatchVehicleTemplateComponent', () => {
 
   it('should expose the batchCount$ observable', () => {
     expect(component.batchCount$).toBeTruthy();
+  });
+
+  it('should expose the vehicleType$ observable', () => {
+    expect(component.vehicleType$).toBeTruthy();
   });
 
   describe('should dispatch the createVehicleTechRecord action for every vin and trailerId given', () => {

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
@@ -1,12 +1,12 @@
 import { Component, ViewChild } from '@angular/core';
-import { FormGroup, Validators } from '@angular/forms';
+import { Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { MultiOptions } from '@forms/models/options.model';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormControl, CustomFormGroup, FormNodeTypes } from '@forms/services/dynamic-form.types';
-import { BatchUpdateVehicleModel, StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { BatchUpdateVehicleModel, StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -72,8 +72,8 @@ export class BatchVehicleTemplateComponent {
     return this.batchTechRecordService.batchCount$;
   }
 
-  getVehicleType(techRecord: TechRecordModel): VehicleTypes {
-    return this.technicalRecordService.getVehicleTypeWithSmallTrl(techRecord);
+  get vehicleType$() {
+    return this.batchTechRecordService.vehicleType$;
   }
 
   statusChange(): void {

--- a/src/app/features/tech-record/create-batch/components/select-vehicle-type/select-vehicle-type.component.ts
+++ b/src/app/features/tech-record/create-batch/components/select-vehicle-type/select-vehicle-type.component.ts
@@ -68,6 +68,9 @@ export class SelectVehicleTypeComponent {
     } else if (type === VehicleTypes.TRL && this.form.value.tes1Tes2 === TrailerFormType.TES2) {
       this.batchTechRecordService.setVehicleStatus(StatusCodes.PROVISIONAL);
     }
+
+    this.batchTechRecordService.setVehicleType(type);
+
     this.trs.editableVehicleTechRecord$.pipe(take(1)).subscribe(
       vehicle =>
         !vehicle &&

--- a/src/app/features/tech-record/tech-record.component.html
+++ b/src/app/features/tech-record/tech-record.component.html
@@ -3,7 +3,8 @@
 </ng-container>
 
 <ng-template #noVehicle>
-  <h1>This vehicle is not real, like the no vehicle page we need to create</h1>
+  <h1>Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number</h1>
+  <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> to find the information you need.</p>
 </ng-template>
 
 <ng-template #error let-name>

--- a/src/app/features/tech-record/tech-record.component.html
+++ b/src/app/features/tech-record/tech-record.component.html
@@ -3,7 +3,8 @@
 </ng-container>
 
 <ng-template #noVehicle>
-  <h1>Vehicle not found, check the vehicle registration mark, trailer ID or vehicle identification number</h1>
+  <h1 class="govuk-heading-l">Vehicle not found</h1>
+  <p class="govuk-body">Check the vehicle registration mark, trailer ID or vehicle identification number</p>
   <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> to find the information you need.</p>
 </ng-template>
 

--- a/src/app/services/batch-technical-record/batch-technical-record.service.ts
+++ b/src/app/services/batch-technical-record/batch-technical-record.service.ts
@@ -89,7 +89,8 @@ export class BatchTechnicalRecordService {
           return { validateForBatch: { message: 'This record cannot be updated as it has a Current tech record' } };
         }
         systemNumberControl.setValue(result[0].systemNumber);
-        oldVehicleStatusControl.setValue(result[0].techRecord_statusCode);
+        const techRecordToUpdate = recordsWithMatchingTrailerId.find(techRecord => techRecord.techRecord_statusCode !== StatusCodes.ARCHIVED);
+        oldVehicleStatusControl.setValue(techRecordToUpdate?.techRecord_statusCode);
         return null;
       }),
       catchError(() => of({ validateForBatch: { message: 'Could not find a record with matching VIN' } }))

--- a/src/app/services/batch-technical-record/batch-technical-record.service.ts
+++ b/src/app/services/batch-technical-record/batch-technical-record.service.ts
@@ -11,7 +11,8 @@ import {
   setApplicationId,
   setGenerateNumberFlag,
   upsertVehicleBatch,
-  setVehicleStatus
+  setVehicleStatus,
+  setVehicleType
 } from '@store/technical-records/actions/batch-create.actions';
 import { BatchRecord } from '@store/technical-records/reducers/batch-create.reducer';
 import {
@@ -26,7 +27,8 @@ import {
   selectBatchUpdatedSuccessCount,
   selectGenerateNumber,
   selectIsBatch,
-  selectVehicleStatus
+  selectVehicleStatus,
+  selectVehicleType
 } from '@store/technical-records/selectors/batch-create.selectors';
 import { Observable, catchError, map, of } from 'rxjs';
 
@@ -123,6 +125,9 @@ export class BatchTechnicalRecordService {
   setVehicleStatus(vehicleStatus: string) {
     this.store.dispatch(setVehicleStatus({ vehicleStatus }));
   }
+  setVehicleType(vehicleType: VehicleTypes) {
+    this.store.dispatch(setVehicleType({ vehicleType }));
+  }
 
   clearBatch() {
     this.store.dispatch(clearBatch());
@@ -170,6 +175,10 @@ export class BatchTechnicalRecordService {
 
   get vehicleStatus$(): Observable<string | undefined> {
     return this.store.pipe(select(selectVehicleStatus));
+  }
+
+  get vehicleType$(): Observable<VehicleTypes | undefined> {
+    return this.store.pipe(select(selectVehicleType));
   }
 
   get generateNumber$(): Observable<boolean> {

--- a/src/app/shared/pipes/format-vehicle-type/format-vehicle-type.pipe.ts
+++ b/src/app/shared/pipes/format-vehicle-type/format-vehicle-type.pipe.ts
@@ -5,7 +5,7 @@ import { VehicleTypes } from '@models/vehicle-tech-record.model';
   name: 'formatVehicleType'
 })
 export class FormatVehicleTypePipe implements PipeTransform {
-  transform(value: VehicleTypes | undefined): unknown {
+  transform(value: VehicleTypes | undefined | null): unknown {
     switch (value) {
       case VehicleTypes.TRL:
         return 'trailer';

--- a/src/app/store/technical-records/actions/batch-create.actions.ts
+++ b/src/app/store/technical-records/actions/batch-create.actions.ts
@@ -1,3 +1,4 @@
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { createAction, props } from '@ngrx/store';
 
 export const upsertVehicleBatch = createAction(
@@ -8,4 +9,5 @@ export const upsertVehicleBatch = createAction(
 export const setGenerateNumberFlag = createAction('[Technical Record Batch Create] set generate number', props<{ generateNumber: boolean }>());
 export const setApplicationId = createAction('[Technical Record Batch Create] set batch ID', props<{ applicationId: string }>());
 export const setVehicleStatus = createAction('[Technical Record Batch Create] set record status', props<{ vehicleStatus: string }>());
+export const setVehicleType = createAction('[Technical Record Batch Create] set batch vehicle type', props<{ vehicleType: VehicleTypes }>());
 export const clearBatch = createAction('[Technical Record Batch Create] clear all');

--- a/src/app/store/technical-records/reducers/batch-create.reducer.ts
+++ b/src/app/store/technical-records/reducers/batch-create.reducer.ts
@@ -1,7 +1,14 @@
-import { StatusCodes, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { StatusCodes, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { createEntityAdapter, EntityAdapter, EntityState, Update } from '@ngrx/entity';
 import { createReducer, on } from '@ngrx/store';
-import { clearBatch, setApplicationId, setGenerateNumberFlag, upsertVehicleBatch, setVehicleStatus } from '../actions/batch-create.actions';
+import {
+  clearBatch,
+  setApplicationId,
+  setGenerateNumberFlag,
+  upsertVehicleBatch,
+  setVehicleStatus,
+  setVehicleType
+} from '../actions/batch-create.actions';
 import { createVehicleRecordSuccess, updateTechRecordsSuccess } from '../actions/technical-record-service.actions';
 
 export type BatchRecord = {
@@ -17,6 +24,7 @@ export type BatchRecord = {
 };
 
 export interface BatchRecords extends EntityState<BatchRecord> {
+  vehicleType?: VehicleTypes;
   generateNumber: boolean;
   applicationId?: string;
   vehicleStatus?: string;
@@ -38,11 +46,12 @@ export const vehicleBatchCreateReducer = createReducer(
   on(setGenerateNumberFlag, (state, { generateNumber }) => ({ ...state, generateNumber })),
   on(setApplicationId, (state, { applicationId }) => ({ ...state, applicationId })),
   on(setVehicleStatus, (state, { vehicleStatus }) => ({ ...state, vehicleStatus })),
+  on(setVehicleType, (state, { vehicleType }) => ({ ...state, vehicleType })),
   on(createVehicleRecordSuccess, (state, action) => batchAdapter.updateOne(vehicleRecordsToBatchRecordMapper(action.vehicleTechRecords)[0], state)),
   on(updateTechRecordsSuccess, (state, action) =>
     batchAdapter.updateOne(vehicleRecordsToBatchRecordMapper(action.vehicleTechRecords, true, true)[0], state)
   ),
-  on(clearBatch, state => batchAdapter.removeAll({ ...state, vehicleStatus: '', applicationId: '' }))
+  on(clearBatch, state => batchAdapter.removeAll({ ...state, vehicleStatus: '', applicationId: '', vehicleType: undefined }))
 );
 
 function vehicleRecordsToBatchRecordMapper(vehicles: VehicleTechRecordModel[], created = true, amendedRecord = false): Update<BatchRecord>[] {

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -4,7 +4,14 @@ import { Axle, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech
 import { createFeatureSelector, createReducer, on } from '@ngrx/store';
 import { AxlesService } from '@services/axles/axles.service';
 import { cloneDeep } from 'lodash';
-import { clearBatch, setApplicationId, setGenerateNumberFlag, setVehicleStatus, upsertVehicleBatch } from '../actions/batch-create.actions';
+import {
+  clearBatch,
+  setApplicationId,
+  setGenerateNumberFlag,
+  setVehicleStatus,
+  setVehicleType,
+  upsertVehicleBatch
+} from '../actions/batch-create.actions';
 import {
   addAxle,
   archiveTechRecord,
@@ -108,6 +115,7 @@ export const vehicleTechRecordReducer = createReducer(
     updateTechRecordsSuccess,
     setApplicationId,
     setVehicleStatus,
+    setVehicleType,
     setGenerateNumberFlag,
     clearBatch,
     (state, action) => ({

--- a/src/app/store/technical-records/selectors/batch-create.selectors.ts
+++ b/src/app/store/technical-records/selectors/batch-create.selectors.ts
@@ -11,6 +11,7 @@ export const selectIsBatch = createSelector(selectBatchCount, state => !!state);
 export const selectApplicationId = createSelector(selectBatchState, state => state.applicationId);
 export const selectGenerateNumber = createSelector(selectBatchState, state => state.generateNumber);
 export const selectVehicleStatus = createSelector(selectBatchState, state => state.vehicleStatus);
+export const selectVehicleType = createSelector(selectBatchState, state => state.vehicleType);
 
 export const selectBatchSuccess = createSelector(selectAllBatch, state => state.filter(v => v.created));
 export const selectBatchSuccessCount = createSelector(selectBatchSuccess, state => state.length);


### PR DESCRIPTION
## Batch create summary screen not displaying

1. For the main bug - Using takeUntil in EditTechRecordButtonComponent to unsubscribe from multiple observables
2. Updated the content displayed when no vehicle is found
3. Added the vehicle type to the store - to avoid digging it up from current editingtechrecord
4. Changes to select the current or provisional record for update (only psv and hgv)

[CB2-8358](https://dvsa.atlassian.net/browse/CB2-8358)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
