### PR TITLE
fix(cb2-8510): added validator to tes1tes2 based on vehicletype being trl

### DIFF
--- a/src/app/features/tech-record/create-batch/components/select-vehicle-type/select-vehicle-type.component.ts
+++ b/src/app/features/tech-record/create-batch/components/select-vehicle-type/select-vehicle-type.component.ts
@@ -9,6 +9,7 @@ import { StatusCodes, TrailerFormType, VehicleTechRecordModel, VehicleTypes } fr
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { take } from 'rxjs';
+import { CustomValidators } from '@forms/validators/custom-validators';
 
 @Component({
   selector: 'app-select-vehicle-type',
@@ -19,7 +20,9 @@ export class SelectVehicleTypeComponent {
     { name: 'form-group', type: FormNodeTypes.GROUP },
     {
       vehicleType: new CustomFormControl({ name: 'vehicle-type', label: 'Vehicle type', type: FormNodeTypes.CONTROL }, '', [Validators.required]),
-      tes1Tes2: new CustomFormControl({ name: 'tes1-tes2', label: 'Trailer form type', type: FormNodeTypes.CONTROL }, '')
+      tes1Tes2: new CustomFormControl({ name: 'tes1-tes2', label: 'Trailer form type', type: FormNodeTypes.CONTROL }, '', [
+        CustomValidators.requiredIfEquals('vehicleType', VehicleTypes.TRL)
+      ])
     }
   );
 


### PR DESCRIPTION
## Without selecting a trailer form type user is able to go to batch create page

[CB2-8510](https://dvsa.atlassian.net/browse/CB2-8510)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
