### PR TITLE
fix(cb2-8556, 8558): change variables, fix trailer batch update

### DIFF
--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.html
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.html
@@ -40,7 +40,7 @@
         appNoSpace
         appTrimWhitespace
         appToUppercase
-        formControlName="trailerId"
+        formControlName="trailerIdOrVrm"
         name="{{ vehicleType === 'trl' ? 'trailerId' : 'vrm' }}{{ i }}"
         label="{{ vehicleType === 'trl' ? 'Trailer ID' : 'VRM' }}"
         [width]="width.L"

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.html
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.html
@@ -41,7 +41,7 @@
         appTrimWhitespace
         appToUppercase
         formControlName="trailerId"
-        name="trailerId{{ i }}"
+        name="{{ vehicleType === 'trl' ? 'trailerId' : 'vrm' }}{{ i }}"
         label="{{ vehicleType === 'trl' ? 'Trailer ID' : 'VRM' }}"
         [width]="width.L"
         (focusout)="validate(group)"

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-details/batch-vehicle-details.component.ts
@@ -84,7 +84,7 @@ export class BatchVehicleDetailsComponent implements OnInit, OnDestroy {
         [CustomValidators.alphanumeric(), Validators.minLength(3), Validators.maxLength(21)],
         this.batchTechRecordService.validateForBatch()
       ),
-      trailerId: new CustomFormControl({ name: 'trailerId', type: FormNodeTypes.CONTROL }, '', [
+      trailerIdOrVrm: new CustomFormControl({ name: 'trailerIdOrVrm', type: FormNodeTypes.CONTROL }, '', [
         CustomValidators.validateVRMTrailerIdLength('vehicleType'),
         CustomValidators.alphanumeric()
       ]),
@@ -137,7 +137,7 @@ export class BatchVehicleDetailsComponent implements OnInit, OnDestroy {
     this.back();
   }
 
-  private cleanEmptyValues(input: { vin: string; trailerId?: string }[]): { vin: string; trailerId?: string }[] {
+  private cleanEmptyValues(input: { vin: string; trailerIdOrVrm?: string }[]): { vin: string; trailerIdOrVrm?: string }[] {
     return input.filter(formInput => !!formInput.vin);
   }
 

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.html
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.html
@@ -33,7 +33,7 @@
   <tbody class="govuk-table__body">
     <tr *ngFor="let vehicle of batchVehiclesSuccess$ | async; let i = index" class="govuk-table__row">
       <th scope="row" class="govuk-table__header">{{ vehicle.vin }}</th>
-      <td class="govuk-table__cell">{{ vehicle.trailerId ?? vehicle.primaryVrm }}</td>
+      <td class="govuk-table__cell">{{ vehicle.trailerIdOrVrm }}</td>
       <td class="govuk-table__cell">{{ vehicle.vehicleType | uppercase | defaultNullOrEmpty }}</td>
       <td class="govuk-table__cell">
         <ng-container [ngSwitch]="vehicle.status">

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.html
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.html
@@ -31,7 +31,7 @@
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">Vehicles in batch</dt>
-              <dd id="batch-trailerCount" class="govuk-summary-list__value">
+              <dd id="batch-vehicleCount" class="govuk-summary-list__value">
                 {{ (batchCount$ | async) ?? 0 }}
               </dd>
               <dd class="govuk-summary-list__actions">

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
@@ -128,8 +128,8 @@ describe('BatchVehicleTemplateComponent', () => {
       jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
 
       batchOfVehicles = [
-        { vin: 'EXAMPLEVIN000001', trailerId: '1000001', systemNumber: '1', oldVehicleStatus: StatusCodes.PROVISIONAL },
-        { vin: 'EXAMPLEVIN000002', trailerId: '1000002', systemNumber: '2', oldVehicleStatus: StatusCodes.CURRENT }
+        { vin: 'EXAMPLEVIN000001', trailerIdOrVrm: '1000001', systemNumber: '1', oldVehicleStatus: StatusCodes.PROVISIONAL },
+        { vin: 'EXAMPLEVIN000002', trailerIdOrVrm: '1000002', systemNumber: '2', oldVehicleStatus: StatusCodes.CURRENT }
       ];
       jest.spyOn(mockBatchTechRecordService, 'batchVehicles$', 'get').mockReturnValue(of(batchOfVehicles));
 
@@ -156,9 +156,9 @@ describe('BatchVehicleTemplateComponent', () => {
       jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
 
       batchOfVehicles = [
-        { vin: 'EXAMPLEVIN000001', trailerId: '1000001', systemNumber: '1', oldVehicleStatus: StatusCodes.PROVISIONAL },
+        { vin: 'EXAMPLEVIN000001', trailerIdOrVrm: '1000001', systemNumber: '1', oldVehicleStatus: StatusCodes.PROVISIONAL },
         { vin: 'EXAMPLEVIN000002' },
-        { vin: 'EXAMPLEVIN000003', trailerId: '1000002', systemNumber: '3', oldVehicleStatus: StatusCodes.PROVISIONAL },
+        { vin: 'EXAMPLEVIN000003', trailerIdOrVrm: '1000002', systemNumber: '3', oldVehicleStatus: StatusCodes.PROVISIONAL },
         { vin: 'EXAMPLEVIN000004' },
         { vin: 'EXAMPLEVIN000005' }
       ];
@@ -188,7 +188,7 @@ describe('BatchVehicleTemplateComponent', () => {
       jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
       batchOfVehicles = [];
       for (let i = 1; i <= 40; i++) {
-        batchOfVehicles.push({ vin: `EXAMPLEVIN0000${i}`, trailerId: `100000${i}` });
+        batchOfVehicles.push({ vin: `EXAMPLEVIN0000${i}`, trailerIdOrVrm: `100000${i}` });
       }
 
       jest.spyOn(mockBatchTechRecordService, 'batchVehicles$', 'get').mockReturnValue(of(batchOfVehicles));

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
@@ -6,7 +6,7 @@ import { GlobalErrorService } from '@core/components/global-error/global-error.s
 import { MultiOptions } from '@forms/models/options.model';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormControl, CustomFormGroup, FormNodeTypes } from '@forms/services/dynamic-form.types';
-import { BatchUpdateVehicleModel, StatusCodes, TechRecordModel, VehicleTechRecordModel } from '@models/vehicle-tech-record.model';
+import { BatchUpdateVehicleModel, StatusCodes, TechRecordModel, VehicleTechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -108,8 +108,8 @@ export class BatchVehicleTemplateComponent {
                     { ...record?.techRecord[0], statusCode: this.form.value.vehicleStatus ?? StatusCodes.PROVISIONAL } as unknown as TechRecordModel
                   ],
                   vin: v.vin,
-                  vrms: v.trailerId ? [{ vrm: v.trailerId, isPrimary: true }] : null,
-                  trailerId: v.trailerId ? v.trailerId : null,
+                  vrms: v.vehicleType !== VehicleTypes.TRL && v.trailerIdOrVrm ? [{ vrm: v.trailerIdOrVrm, isPrimary: true }] : null,
+                  trailerId: v.vehicleType === VehicleTypes.TRL && v.trailerIdOrVrm ? v.trailerIdOrVrm : null,
                   systemNumber: v.systemNumber ? v.systemNumber : null,
                   oldVehicleStatus: v.oldVehicleStatus ? v.oldVehicleStatus : null
                 } as BatchUpdateVehicleModel)

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -88,8 +88,8 @@ export class HydrateNewVehicleRecordComponent implements OnDestroy {
                 ({
                   ...record!,
                   vin: v.vin,
-                  vrms: v.trailerId ? [{ vrm: v.trailerId, isPrimary: true }] : null,
-                  trailerId: v.trailerId ?? null
+                  vrms: v.vehicleType !== VehicleTypes.TRL && v.trailerIdOrVrm ? [{ vrm: v.trailerIdOrVrm, isPrimary: true }] : null,
+                  trailerId: v.vehicleType === VehicleTypes.TRL && v.trailerIdOrVrm ? v.trailerIdOrVrm : null
                 } as VehicleTechRecordModel)
             )
           )

--- a/src/app/services/batch-technical-record/batch-technical-record.service.spec.ts
+++ b/src/app/services/batch-technical-record/batch-technical-record.service.spec.ts
@@ -49,7 +49,7 @@ describe('TechnicalRecordService', () => {
     beforeEach(() => {
       testGroup = new FormGroup({
         vin: new CustomFormControl({ name: 'vin', type: FormNodeTypes.CONTROL }, null, null),
-        trailerId: new FormControl({ name: 'trailerId', value: '' }, null),
+        trailerIdOrVrm: new FormControl({ name: 'trailerIdOrVrm', value: '' }, null),
         systemNumber: new FormControl({ name: 'systemNumber', value: '' }, null),
         oldVehicleStatus: new FormControl({ name: 'oldVehicleStatus', value: '' }, null),
         vehicleType: new FormControl({ name: 'vehicleType', value: '' }, null)
@@ -59,7 +59,7 @@ describe('TechnicalRecordService', () => {
     it('return null if vin and trailer id are not provided', done => {
       expect.assertions(1);
       testGroup.get('vin')!.setValue(null);
-      testGroup.get('trailerId')!.setValue(null);
+      testGroup.get('trailerIdOrVrm')!.setValue(null);
       const serviceCall = service.validateForBatch()(testGroup.get('vin')!);
       (serviceCall as Observable<ValidationErrors | null>).subscribe(errors => {
         expect(errors).toEqual(null);
@@ -79,7 +79,7 @@ describe('TechnicalRecordService', () => {
 
     it('throws an error if trailer id is provided but vin is not', done => {
       expect.assertions(1);
-      testGroup.get('trailerId')!.setValue('test');
+      testGroup.get('trailerIdOrVrm')!.setValue('test');
 
       const serviceCall = service.validateForBatch()(testGroup.get('vin')!);
       (serviceCall as Observable<ValidationErrors | null>).subscribe(errors => {
@@ -90,7 +90,7 @@ describe('TechnicalRecordService', () => {
 
     describe('when only vin is provided', () => {
       it('should return null when it is a unique vin', async () => {
-        testGroup.get('trailerId')!.setValue('');
+        testGroup.get('trailerIdOrVrm')!.setValue('');
         testGroup.get('vin')!.setValue('TESTVIN');
 
         const isUniqueSpy = jest.spyOn(technicalRecordService, 'isUnique').mockReturnValueOnce(of(true));
@@ -102,7 +102,7 @@ describe('TechnicalRecordService', () => {
       });
 
       it('should set a warning when it is not a unique vin', async () => {
-        testGroup.get('trailerId')!.setValue('');
+        testGroup.get('trailerIdOrVrm')!.setValue('');
         const vinControl = testGroup.get('vin') as CustomFormControl;
         vinControl.setValue('TESTVIN');
         jest.spyOn(technicalRecordService, 'isUnique').mockReturnValueOnce(of(false));
@@ -115,7 +115,7 @@ describe('TechnicalRecordService', () => {
       it('returns null if only 1 vehicle exists with those values with no current tech record', async () => {
         expect.assertions(1);
         testGroup.get('vin')!.setValue('TESTVIN');
-        testGroup.get('trailerId')!.setValue('TESTTRAILERID');
+        testGroup.get('trailerIdOrVrm')!.setValue('TESTTRAILERID');
         const mockSearchResult = {
           vin: 'TESTVIN',
           trailerId: 'TESTTRAILERID',
@@ -133,7 +133,7 @@ describe('TechnicalRecordService', () => {
       it('throws error if only 1 trailer exists with those values with a current tech record', async () => {
         expect.assertions(1);
         testGroup.get('vin')!.setValue('TESTVIN');
-        testGroup.get('trailerId')!.setValue('TESTTRAILERID');
+        testGroup.get('trailerIdOrVrm')!.setValue('TESTTRAILERID');
         testGroup.get('vehicleType')!.setValue(VehicleTypes.TRL);
         const mockSearchResult = {
           vin: 'TESTVIN',
@@ -153,7 +153,7 @@ describe('TechnicalRecordService', () => {
       it('returns null if only 1 vehicle other than trailer exists with those values with a current tech record', async () => {
         expect.assertions(1);
         testGroup.get('vin')!.setValue('TESTVIN');
-        testGroup.get('trailerId')!.setValue('TESTTRAILERID');
+        testGroup.get('trailerIdOrVrm')!.setValue('TESTTRAILERID');
         const mockSearchResult = {
           vin: 'TESTVIN',
           trailerId: 'TESTTRAILERID',
@@ -172,7 +172,7 @@ describe('TechnicalRecordService', () => {
       it('throws an error if more than 1 vehicle exists with those values', async () => {
         expect.assertions(1);
         testGroup.get('vin')!.setValue('TESTVIN');
-        testGroup.get('trailerId')!.setValue('TESTTRAILERID');
+        testGroup.get('trailerIdOrVrm')!.setValue('TESTTRAILERID');
         const mockSearchResult = { vin: 'TESTVIN', trailerId: 'TESTTRAILERID', techRecord_statusCode: StatusCodes.PROVISIONAL } as SearchResult;
 
         jest.spyOn(technicalRecordHttpService, 'search$').mockReturnValue(of([mockSearchResult, { ...mockSearchResult, systemNumber: 'foobar' }]));
@@ -185,7 +185,7 @@ describe('TechnicalRecordService', () => {
     it('throws an error if no vehicle exists with those values', async () => {
       expect.assertions(1);
       testGroup.get('vin')!.setValue('TESTVIN');
-      testGroup.get('trailerId')!.setValue('TESTTRAILERID');
+      testGroup.get('trailerIdOrVrm')!.setValue('TESTTRAILERID');
 
       jest.spyOn(technicalRecordHttpService, 'search$').mockReturnValue(of([]));
 

--- a/src/app/services/batch-technical-record/batch-technical-record.service.ts
+++ b/src/app/services/batch-technical-record/batch-technical-record.service.ts
@@ -42,21 +42,21 @@ export class BatchTechnicalRecordService {
 
   validateForBatch(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      const trailerIdControl = control.parent?.get('trailerId') as CustomFormControl;
+      const trailerIdOrVrmControl = control.parent?.get('trailerIdOrVrm') as CustomFormControl;
       const vinControl = control.parent?.get('vin') as CustomFormControl;
       const systemNumberControl = control.parent?.get('systemNumber') as CustomFormControl;
       const oldVehicleStatusControl = control.parent?.get('oldVehicleStatus') as CustomFormControl;
 
-      if (trailerIdControl && vinControl) {
-        const trailerId = trailerIdControl.value;
+      if (trailerIdOrVrmControl && vinControl) {
+        const trailerIdOrVrm = trailerIdOrVrmControl.value;
         const vin = vinControl.value;
         delete vinControl.meta.warning;
 
-        if (trailerId && vin) {
-          return this.validateVinAndTrailerId(vin, trailerId, systemNumberControl, oldVehicleStatusControl);
-        } else if (!trailerId && vin) {
+        if (trailerIdOrVrm && vin) {
+          return this.validateVinAndTrailerIdOrVrm(vin, trailerIdOrVrm, systemNumberControl, oldVehicleStatusControl);
+        } else if (!trailerIdOrVrm && vin) {
           return this.validateVinForBatch(vinControl);
-        } else if (trailerId && !vin) {
+        } else if (trailerIdOrVrm && !vin) {
           return of({ validateForBatch: { message: 'VIN is required' } });
         }
       }
@@ -64,16 +64,16 @@ export class BatchTechnicalRecordService {
     };
   }
 
-  private validateVinAndTrailerId(
+  private validateVinAndTrailerIdOrVrm(
     vin: string,
-    trailerId: string,
+    trailerIdOrVrm: string,
     systemNumberControl: CustomFormControl,
     oldVehicleStatusControl: CustomFormControl
   ): Observable<ValidationErrors | null> {
     return this.techRecordHttpService.search$(SEARCH_TYPES.VIN, vin).pipe(
       map(result => {
         const recordsWithMatchingTrailerId = result.filter(
-          vehicleTechRecord => vehicleTechRecord.trailerId === trailerId || vehicleTechRecord.primaryVrm === trailerId
+          vehicleTechRecord => vehicleTechRecord.trailerId === trailerIdOrVrm || vehicleTechRecord.primaryVrm === trailerIdOrVrm
         );
         if (!recordsWithMatchingTrailerId.length) {
           return { validateForBatch: { message: 'Could not find a record with matching VIN and VRM/Trailer ID' } };

--- a/src/app/services/technical-record-http/technical-record-http.service.ts
+++ b/src/app/services/technical-record-http/technical-record-http.service.ts
@@ -107,7 +107,7 @@ export class TechnicalRecordHttpService {
   private formatVrmsForUpdatePayload(vehicleTechRecord: VehicleTechRecordModel): PutVehicleTechRecordModel {
     const secondaryVrms: string[] = [];
     const putVehicleTechRecordModel: PutVehicleTechRecordModel = { ...vehicleTechRecord, secondaryVrms };
-    vehicleTechRecord.vrms.forEach(vrm => {
+    vehicleTechRecord.vrms?.forEach(vrm => {
       vrm.isPrimary ? (putVehicleTechRecordModel.primaryVrm = vrm.vrm) : putVehicleTechRecordModel.secondaryVrms!.push(vrm.vrm);
     });
     delete (putVehicleTechRecordModel as any).vrms;

--- a/src/app/store/technical-records/reducers/batch-create.reducer.ts
+++ b/src/app/store/technical-records/reducers/batch-create.reducer.ts
@@ -14,8 +14,7 @@ import { createVehicleRecordSuccess, updateTechRecordsSuccess } from '../actions
 export type BatchRecord = {
   vin: string;
   systemNumber?: string;
-  trailerId?: string;
-  primaryVrm?: string;
+  trailerIdOrVrm?: string;
   vehicleType?: string;
   status?: StatusCodes;
   created?: boolean;
@@ -62,8 +61,7 @@ function vehicleRecordsToBatchRecordMapper(vehicles: VehicleTechRecordModel[], c
       changes: {
         vin,
         systemNumber,
-        trailerId,
-        primaryVrm: vrms[0]?.vrm,
+        trailerIdOrVrm: trailerId ?? vrms[0]?.vrm,
         vehicleType: techRecord[0].vehicleType,
         status: techRecord[0].statusCode,
         created,


### PR DESCRIPTION
## When user creates batch of PSV or HGV, VRMs objects have id referenced to trailer## instead of vrm##
[CB2-8556](https://dvsa.atlassian.net/browse/CB2-8556)

## Batch update of trailers is adding VRM to the records
[CB2-8558](https://dvsa.atlassian.net/browse/CB2-8558)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
