### PR TITLE
fix(cb2-8321): Technical record service reducer brake forces

### DIFF
--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -297,9 +297,9 @@ describe('Vehicle Technical Record Reducer', () => {
         expect(updatedBrakes?.brakeForceWheelsNotLocked?.secondaryBrakeForceA).toBe(Math.round((2000 * 22.5) / 100));
         expect(updatedBrakes?.brakeForceWheelsNotLocked?.parkingBrakeForceA).toBe(Math.round((2000 * 45) / 100));
 
-        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.serviceBrakeForceB).toBe(50);
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.serviceBrakeForceB).toBe(10);
         expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.secondaryBrakeForceB).toBe(30);
-        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.parkingBrakeForceB).toBe(10);
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.parkingBrakeForceB).toBe(50);
       });
 
       it('should not update half locked brake forces with no gross laden weight', () => {
@@ -315,9 +315,9 @@ describe('Vehicle Technical Record Reducer', () => {
         const updatedBrakes = newState.editingTechRecord?.techRecord[0].brakes;
         expect(updatedBrakes?.brakeCode).toBe('1234');
 
-        expect(updatedBrakes?.brakeForceWheelsNotLocked?.serviceBrakeForceA).toBe(50);
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.serviceBrakeForceA).toBe(10);
         expect(updatedBrakes?.brakeForceWheelsNotLocked?.secondaryBrakeForceA).toBe(30);
-        expect(updatedBrakes?.brakeForceWheelsNotLocked?.parkingBrakeForceA).toBe(10);
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.parkingBrakeForceA).toBe(50);
 
         expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.serviceBrakeForceB).toBe(Math.round((1000 * 16) / 100));
         expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.secondaryBrakeForceB).toBe(Math.round((1000 * 25) / 100));

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -277,6 +277,62 @@ describe('Vehicle Technical Record Reducer', () => {
     beforeEach(() => (initialState.editingTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV)));
 
     describe('updateBrakeForces', () => {
+
+      it('should not update half locked brake forces with no gross kerb weight', () => {
+        initialState.editingTechRecord!.techRecord[0].brakes!.brakeCodeOriginal = '80';
+        initialState.editingTechRecord!.techRecord[0].brakes!.brakeForceWheelsUpToHalfLocked = {
+          parkingBrakeForceB: 50,
+          secondaryBrakeForceB: 30,
+          serviceBrakeForceB: 10 
+        };
+        const brakes = initialState.editingTechRecord?.techRecord[0].brakes;
+        expect(brakes?.brakeCode).toBe('1234');
+
+        const newState = vehicleTechRecordReducer(initialState, updateBrakeForces({ grossLadenWeight: 2000 }));
+
+        const updatedBrakes = newState.editingTechRecord?.techRecord[0].brakes;
+        expect(updatedBrakes?.brakeCode).toBe(`0${2000 / 100}${brakes?.brakeCodeOriginal}`);
+
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.serviceBrakeForceA).toBe(Math.round((2000 * 16) / 100));
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.secondaryBrakeForceA).toBe(Math.round((2000 * 22.5) / 100));
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.parkingBrakeForceA).toBe(Math.round((2000 * 45) / 100));
+
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.serviceBrakeForceB).toBe(50);
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.secondaryBrakeForceB).toBe(30);
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.parkingBrakeForceB).toBe(10);
+      });
+
+      it('should not update half locked brake forces with no gross laden weight', () => {
+        initialState.editingTechRecord!.techRecord[0].brakes!.brakeCodeOriginal = '80';
+        initialState.editingTechRecord!.techRecord[0].brakes!.brakeForceWheelsNotLocked = {
+          parkingBrakeForceA: 50,
+          secondaryBrakeForceA: 30,
+          serviceBrakeForceA: 10 
+        };
+        
+        const newState = vehicleTechRecordReducer(initialState, updateBrakeForces({ grossKerbWeight: 1000 }));
+
+        const updatedBrakes = newState.editingTechRecord?.techRecord[0].brakes;
+        expect(updatedBrakes?.brakeCode).toBe('1234');
+
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.serviceBrakeForceA).toBe(50);
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.secondaryBrakeForceA).toBe(30);
+        expect(updatedBrakes?.brakeForceWheelsNotLocked?.parkingBrakeForceA).toBe(10);
+
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.serviceBrakeForceB).toBe(Math.round((1000 * 16) / 100));
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.secondaryBrakeForceB).toBe(Math.round((1000 * 25) / 100));
+        expect(updatedBrakes?.brakeForceWheelsUpToHalfLocked?.parkingBrakeForceB).toBe(Math.round((1000 * 50) / 100));
+      });
+
+      it('should not update brakeCode with no gross laden weight', () => {
+        initialState.editingTechRecord!.techRecord[0].brakes!.brakeCodeOriginal = '80';
+        initialState.editingTechRecord!.techRecord[0].brakes!.brakeCode = '37';
+
+        const newState = vehicleTechRecordReducer(initialState, updateBrakeForces({ grossKerbWeight: 1000 }));
+        const updatedBrakes = newState.editingTechRecord?.techRecord[0].brakes;
+        expect(updatedBrakes?.brakeCode).toBe('37');
+      });
+
       it('should update brake forces', () => {
         initialState.editingTechRecord!.techRecord[0].brakes!.brakeCodeOriginal = '80';
         const brakes = initialState.editingTechRecord?.techRecord[0].brakes;

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -146,29 +146,32 @@ function handleUpdateBrakeForces(
   data: { grossLadenWeight?: number; grossKerbWeight?: number }
 ): TechnicalRecordServiceState {
   const newState = cloneDeep(state);
-
   if (!newState.editingTechRecord) return newState;
 
-  const newGrossLadenWeight = data.grossLadenWeight ?? 0;
-  const newGrossKerbWeight = data.grossKerbWeight ?? 0;
+  if(data.grossLadenWeight) {
+    const prefix = `${Math.round(data.grossLadenWeight / 100)}`;
 
-  const prefix = `${Math.round(newGrossLadenWeight / 100)}`;
-
-  newState.editingTechRecord.techRecord[0].brakes = {
-    ...newState.editingTechRecord?.techRecord[0].brakes,
-    brakeCode: (prefix.length <= 2 ? '0' + prefix : prefix) + newState.editingTechRecord.techRecord[0].brakes?.brakeCodeOriginal,
-    brakeForceWheelsNotLocked: {
-      serviceBrakeForceA: Math.round((newGrossLadenWeight * 16) / 100),
-      secondaryBrakeForceA: Math.round((newGrossLadenWeight * 22.5) / 100),
-      parkingBrakeForceA: Math.round((newGrossLadenWeight * 45) / 100)
-    },
-    brakeForceWheelsUpToHalfLocked: {
-      serviceBrakeForceB: Math.round((newGrossKerbWeight * 16) / 100),
-      secondaryBrakeForceB: Math.round((newGrossKerbWeight * 25) / 100),
-      parkingBrakeForceB: Math.round((newGrossKerbWeight * 50) / 100)
+    newState.editingTechRecord.techRecord[0].brakes = {
+      ...newState.editingTechRecord?.techRecord[0].brakes,
+      brakeCode: (prefix.length <= 2 ? '0' + prefix : prefix) + newState.editingTechRecord.techRecord[0].brakes?.brakeCodeOriginal,
+      brakeForceWheelsNotLocked: {
+        serviceBrakeForceA: Math.round((data.grossLadenWeight * 16) / 100),
+        secondaryBrakeForceA: Math.round((data.grossLadenWeight * 22.5) / 100),
+        parkingBrakeForceA: Math.round((data.grossLadenWeight * 45) / 100)
+      }
     }
-  };
+  }
 
+  if(data.grossKerbWeight) {
+    newState.editingTechRecord.techRecord[0].brakes = {
+      ...newState.editingTechRecord?.techRecord[0].brakes,
+      brakeForceWheelsUpToHalfLocked: {
+        serviceBrakeForceB: Math.round((data.grossKerbWeight * 16) / 100),
+        secondaryBrakeForceB: Math.round((data.grossKerbWeight * 25) / 100),
+        parkingBrakeForceB: Math.round((data.grossKerbWeight * 50) / 100)
+      }
+    }
+  }
   return newState;
 }
 


### PR DESCRIPTION
## Technical Record Service Reducer Brake Forces

The technical record service reducer no longer overwrites the grossLadenWeight or grossKerbWeight if a null or undefined value is provided by the calling components.
[CB2-8321](https://dvsa.atlassian.net/browse/CB2-8321)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
