### PR TITLE
fix(cb2-8613): fixes noOfAxles data-type issue with small trailer test results

### DIFF
--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -44,7 +44,9 @@ export const SmallTrailerTechRecord: FormNode = {
       label: 'Number of axles',
       value: '',
       width: FormNodeWidth.XXS,
-      type: FormNodeTypes.CONTROL
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.NUMBER,
+      validators: [{ name: ValidatorNames.Max, args: 99 }]
     },
     {
       name: 'vehicleClass',


### PR DESCRIPTION
Fixes an issue where IVA Test Results are failing to be processed downstream because the data-type of the numerical field `noOfAxles` is being sent as a string rather than a number.

The issue is unfortunately due to the value being stored as a string when the Small Trailer was created in VTM, which means ALL tests conducted for that trailer will exhibit this behaviour until their technical records are corrected.

[CB2-8163](https://dvsa.atlassian.net/browse/CB2-8163)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Delete branch after merge
