### PR TITLE
Fix/cb2-8598 - Error message widths

### DIFF
--- a/src/app/forms/components/field-error-message/field-error-message.component.html
+++ b/src/app/forms/components/field-error-message/field-error-message.component.html
@@ -1,1 +1,1 @@
-<p *ngIf="error" id="{{ name }}-error" [ngClass]="style" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> {{ error }}</p>
+<p *ngIf="error" id="{{ name }}-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> {{ error }}</p>

--- a/src/app/forms/components/field-error-message/field-error-message.component.ts
+++ b/src/app/forms/components/field-error-message/field-error-message.component.ts
@@ -9,9 +9,4 @@ import { FormNodeWidth } from '@forms/services/dynamic-form.types';
 export class FieldErrorMessageComponent {
   @Input() name: string = '';
   @Input() error?: string | null;
-  @Input() width?: FormNodeWidth;
-
-  get style(): string {
-    return this.width ? 'width-' + this.width : '';
-  }
 }

--- a/src/app/forms/components/text-input/text-input.component.html
+++ b/src/app/forms/components/text-input/text-input.component.html
@@ -3,7 +3,7 @@
 
   <div *ngIf="hint" id="{{ name }}-hint" class="govuk-hint">{{ hint }}</div>
 
-  <app-field-error-message [width]="width" [error]="error ? error : warning" [name]="name"></app-field-error-message>
+  <app-field-error-message [error]="error ? error : warning" [name]="name"></app-field-error-message>
 
   <div class="govuk-input__wrapper">
     <div *ngIf="prefix" class="govuk-input__suffix prefix" aria-hidden="true">

--- a/src/app/forms/custom-sections/tyres/tyres.component.html
+++ b/src/app/forms/custom-sections/tyres/tyres.component.html
@@ -116,6 +116,7 @@
       [type]="types.TEXT"
       name="tyreUseCode"
       label="Tyre Use Code"
+      [width]="widths.XS"
       [isEditing]="isEditing"
     ></app-switchable-input>
   </ng-container>

--- a/src/app/forms/templates/hgv/hgv-tyres.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tyres.template.ts
@@ -1,5 +1,5 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
-import { FormNode, FormNodeEditTypes, FormNodeTypes } from '@forms/services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 
 export const tyresTemplateHgv: FormNode = {
   name: 'tyreSection',
@@ -12,6 +12,7 @@ export const tyresTemplateHgv: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.NUMBER,
+      width: FormNodeWidth.XS,
       validators: [
         { name: ValidatorNames.MaxLength, args: 2 },
         { name: ValidatorNames.Min, args: 0 }

--- a/src/app/forms/templates/trl/trl-tyres.template.ts
+++ b/src/app/forms/templates/trl/trl-tyres.template.ts
@@ -1,5 +1,5 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
-import { FormNode, FormNodeEditTypes, FormNodeTypes } from '@forms/services/dynamic-form.types';
+import { FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 
 export const tyresTemplateTrl: FormNode = {
   name: 'tyreSection',
@@ -12,6 +12,7 @@ export const tyresTemplateTrl: FormNode = {
       value: '',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.NUMBER,
+      width: FormNodeWidth.XS,
       validators: [
         { name: ValidatorNames.MaxLength, args: 2 },
         { name: ValidatorNames.Min, args: 0 }


### PR DESCRIPTION
## In-line error message widths

Removed the error message width input as the error message field will always inherit the width of its parent. This change prevents text input controls from making their in-line error messages fit the width of the input field rather than the parent container.
[CB2-8598](https://dvsa.atlassian.net/browse/CB2-8598)

Example of prior issue:

![image](https://github.com/dvsa/cvs-app-vtm/assets/127743278/87bc9c0a-029e-4e01-b2d9-cd19adfbbb81)

Example of updated error message:

![image](https://github.com/dvsa/cvs-app-vtm/assets/127743278/00367e6b-2da1-4e6d-a577-efaa9be82bc0)


## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
