### PR TITLE
Fix: cb2 8677: 404 received for some Reasons For Abandoning on saved abandoned test records

### DIFF
--- a/src/app/shared/pipes/ref-data-decode/ref-data-decode.pipe.ts
+++ b/src/app/shared/pipes/ref-data-decode/ref-data-decode.pipe.ts
@@ -1,8 +1,11 @@
 import { OnDestroy, Pipe, PipeTransform } from '@angular/core';
+import { SpecialRefData } from '@forms/services/multi-options.service';
 import { ReferenceDataModelBase, ReferenceDataResourceType, ReferenceDataResourceTypeAudit } from '@models/reference-data.model';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { State } from '@store/index';
 import { fetchReferenceData, fetchReferenceDataByKeySearch, selectReferenceDataByResourceKey, selectSearchReturn } from '@store/reference-data';
+import { selectVehicleType } from '@store/technical-records/selectors/batch-create.selectors';
 import { Observable, Subject, combineLatest, map, of } from 'rxjs';
 
 @Pipe({
@@ -25,6 +28,24 @@ export class RefDataDecodePipe implements PipeTransform, OnDestroy {
   ): Observable<string | number | undefined> {
     if (!resourceType || !value) {
       return of(value);
+    }
+
+    if (resourceType === SpecialRefData.ReasonsForAbandoning) {
+      const type = this.store.select(selectVehicleType);
+      switch (type) {
+        case of(VehicleTypes.HGV):
+          resourceType = ReferenceDataResourceType.ReasonsForAbandoningHgv;
+          break;
+        case of(VehicleTypes.PSV):
+          resourceType = ReferenceDataResourceType.ReasonsForAbandoningHgv;
+          break;
+        case of(VehicleTypes.TRL):
+          resourceType = ReferenceDataResourceType.ReasonsForAbandoningTrl;
+          break;
+        default:
+          resourceType = ReferenceDataResourceType.ReasonsForAbandoningHgv;
+          break;
+      }
     }
 
     this.store.dispatch(fetchReferenceData({ resourceType: resourceType as ReferenceDataResourceType }));


### PR DESCRIPTION
CB2-8677: 
Due to changes made to the decode pipe it was dispatching GET's for a resource type of REASONS_FOR_ABANDONING. 

The if statement looks for this type and then gets the current vehicles type and uses that to search for the correct reasons for abandoning.   
