### PR TITLE
feat(cb2-8099): save state for accordion sections

### DIFF
--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -5,6 +5,8 @@ import { GlobalErrorService } from '@core/components/global-error/global-error.s
 import { map, Observable } from 'rxjs';
 import { Roles } from '@models/roles.enum';
 import { SEARCH_TYPES } from '@services/technical-record-http/technical-record-http.service';
+import { clearAllSectionStates } from '@store/technical-records';
+import { Store } from '@ngrx/store';
 
 @Component({
   selector: 'app-search',
@@ -14,10 +16,11 @@ export class SearchComponent {
   missingTermErrorMessage = 'You must provide a vehicle registration mark, trailer ID or vehicle identification number.';
   missingTypeErrorMessage = 'You must select a valid search criteria';
 
-  constructor(public globalErrorService: GlobalErrorService, private router: Router) {}
+  constructor(public globalErrorService: GlobalErrorService, private router: Router, private store: Store) {}
 
   navigateSearch(term: string, type: string): void {
     this.globalErrorService.clearErrors();
+    this.store.dispatch(clearAllSectionStates());
     term = term.trim();
 
     if (!term) {

--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -8,12 +8,12 @@ import { Store } from '@ngrx/store';
 import { RouterService } from '@services/router/router.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import {
+  clearAllSectionStates,
   createProvisionalTechRecordSuccess,
-  selectVehicleTechnicalRecordsBySystemNumber,
   updateEditingTechRecordCancel,
   updateTechRecordsSuccess
 } from '@store/technical-records';
-import { Subject, take, takeUntil, withLatestFrom } from 'rxjs';
+import { Subject, takeUntil, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-edit-tech-record-button[vehicle][viewableTechRecord]',
@@ -79,6 +79,7 @@ export class EditTechRecordButtonComponent implements OnInit, OnDestroy {
       this.toggleEditMode();
       this.errorService.clearErrors();
       this.store.dispatch(updateEditingTechRecordCancel());
+      this.store.dispatch(clearAllSectionStates());
       this.router.navigate(['../'], { relativeTo: this.route });
     }
   }
@@ -86,5 +87,6 @@ export class EditTechRecordButtonComponent implements OnInit, OnDestroy {
   submit() {
     this.submitChange.emit();
     this.viewportScroller.scrollToPosition([0, 0]);
+    this.store.dispatch(clearAllSectionStates());
   }
 }

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -1,8 +1,8 @@
 <section class="govuk-grid-row">
-  <app-accordion-control [class]="'padding'">
+  <app-accordion-control [class]="'padding'" [sectionState]="sectionTemplateState">
     <div class="govuk-grid-column-one-half">
       <ng-container *ngFor="let section of sectionTemplates; let i = index">
-        <app-accordion *ngIf="i < middleIndex" [id]="section.name" [title]="section.label">
+        <app-accordion *ngIf="i < middleIndex" [id]="section.name" [title]="section.label" [isExpanded]="isSectionExpanded(section.name)">
           <ng-template [ngTemplateOutlet]="accordion" [ngTemplateOutletContext]="{ sectionName: section.name, section: section }"></ng-template>
         </app-accordion>
       </ng-container>

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -1,5 +1,5 @@
 <section class="govuk-grid-row">
-  <app-accordion-control [class]="'padding'" [sectionState]="sectionTemplateState$ | async">
+  <app-accordion-control [class]="'padding'" [sectionState]="sectionTemplatesState$ | async">
     <div class="govuk-grid-column-one-half">
       <ng-container *ngFor="let section of sectionTemplates; let i = index">
         <app-accordion *ngIf="i < middleIndex" [id]="section.name" [title]="section.label" [isExpanded]="isSectionExpanded$(section.name) | async">

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -1,5 +1,5 @@
 <section class="govuk-grid-row">
-  <app-accordion-control [class]="'padding'" [sectionState]="sectionTemplateState">
+  <app-accordion-control [class]="'padding'" [sectionState]="sectionTemplateState$ | async">
     <div class="govuk-grid-column-one-half">
       <ng-container *ngFor="let section of sectionTemplates; let i = index">
         <app-accordion *ngIf="i < middleIndex" [id]="section.name" [title]="section.label" [isExpanded]="isSectionExpanded(section.name)">

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -2,7 +2,7 @@
   <app-accordion-control [class]="'padding'" [sectionState]="sectionTemplateState$ | async">
     <div class="govuk-grid-column-one-half">
       <ng-container *ngFor="let section of sectionTemplates; let i = index">
-        <app-accordion *ngIf="i < middleIndex" [id]="section.name" [title]="section.label" [isExpanded]="isSectionExpanded(section.name)">
+        <app-accordion *ngIf="i < middleIndex" [id]="section.name" [title]="section.label" [isExpanded]="isSectionExpanded$(section.name) | async">
           <ng-template [ngTemplateOutlet]="accordion" [ngTemplateOutletContext]="{ sectionName: section.name, section: section }"></ng-template>
         </app-accordion>
       </ng-container>

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -28,7 +28,7 @@ import { AxlesService } from '@services/axles/axles.service';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { cloneDeep, mergeWith } from 'lodash';
-import { map, Subject, take, takeUntil } from 'rxjs';
+import { map, Observable, Subject, take, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record-summary[techRecord]',
@@ -55,7 +55,6 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
   techRecordCalculated!: TechRecordModel;
   sectionTemplates: Array<FormNode> = [];
   middleIndex = 0;
-  sectionTemplateState: (string | number)[] | undefined;
 
   private destroy$ = new Subject<void>();
 
@@ -114,12 +113,12 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     );
   }
 
-  get sectionTemplatesState$ {
-    return this.technicalRecordService.sectionStates$
+  get sectionTemplatesState$() {
+    return this.technicalRecordService.sectionStates$;
   }
 
-  isSectionExpanded(sectionName: string | number) {
-    return this.sectionTemplatesState.pipe(map(sections => sections?.includes(sectionName));
+  isSectionExpanded$(sectionName: string | number) {
+    return this.sectionTemplatesState$?.pipe(map(sections => sections?.includes(sectionName)));
   }
 
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -115,8 +115,12 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     );
   }
 
+  get sectionTemplatesState$ {
+    return this.technicalRecordService.sectionStates$
+  }
+
   isSectionExpanded(sectionName: string | number) {
-    return this.sectionTemplateState ? this.sectionTemplateState.includes(sectionName) : false;
+    return this.sectionTemplatesState.pipe(map(sections => sections?.includes(sectionName));
   }
 
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -96,7 +96,6 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
         this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
       });
 
-    this.technicalRecordService.sectionStates$.pipe(take(1)).subscribe(sectionStates => (this.sectionTemplateState = sectionStates));
     isOnInit = false;
   }
 

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -23,15 +23,12 @@ import { WeightsComponent } from '@forms/custom-sections/weights/weights.compone
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode } from '@forms/services/dynamic-form.types';
 import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
-import { EuVehicleCategories, TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
-import { select, Store } from '@ngrx/store';
+import { TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { AxlesService } from '@services/axles/axles.service';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
-import { editableTechRecord } from '@store/technical-records';
-import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
 import { cloneDeep, mergeWith } from 'lodash';
-import { map, Subject, takeUntil } from 'rxjs';
+import { map, Subject, take, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record-summary[techRecord]',
@@ -58,6 +55,7 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
   techRecordCalculated!: TechRecordModel;
   sectionTemplates: Array<FormNode> = [];
   middleIndex = 0;
+  sectionTemplateState: (string | number)[] | undefined;
 
   private destroy$ = new Subject<void>();
 
@@ -97,6 +95,8 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
         this.sectionTemplates = this.vehicleTemplates;
         this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
       });
+
+    this.technicalRecordService.sectionStates$.pipe(take(1)).subscribe(sectionStates => (this.sectionTemplateState = sectionStates));
     isOnInit = false;
   }
 
@@ -113,6 +113,10 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     return (
       vehicleTemplateMap.get(this.vehicleType)?.filter(template => template.name !== (this.isEditing ? 'audit' : 'reasonForCreationSection')) ?? []
     );
+  }
+
+  isSectionExpanded(sectionName: string | number) {
+    return this.sectionTemplateState ? this.sectionTemplateState.includes(sectionName) : false;
   }
 
   get customSectionForms(): Array<CustomFormGroup | CustomFormArray> {

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -76,6 +76,9 @@ describe('VehicleTechnicalRecordComponent', () => {
             updateEditingTechRecord: () => {},
             get editableTechRecord$() {
               return of(mockVehicleTechnicalRecord().techRecord[2]);
+            },
+            get sectionStates$() {
+              return of(['TEST_SECTION']);
             }
           }
         }

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-results/batch-vehicle-results.component.ts
@@ -37,6 +37,7 @@ export class BatchVehicleResultsComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.batchTechRecordService.clearBatch();
+    this.technicalRecordService.clearSectionTemplateStates();
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
@@ -22,7 +22,8 @@ let batchOfVehicles: BatchRecord[] = [];
 const mockTechRecordService = (<unknown>{
   editableVehicleTechRecord$: of({ techRecord: [] }),
   updateEditingTechRecord: jest.fn(),
-  createVehicleRecord: jest.fn()
+  createVehicleRecord: jest.fn(),
+  clearSectionTemplateStates: jest.fn()
 }) as TechnicalRecordService;
 
 const mockBatchTechRecordService = (<unknown>{

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
@@ -131,7 +131,7 @@ export class BatchVehicleTemplateComponent {
               );
             }
           });
-
+          this.technicalRecordService.clearSectionTemplateStates();
           this.router.navigate(['batch-results'], { relativeTo: this.route });
         });
     } else {

--- a/src/app/features/tech-record/create-batch/components/select-vehicle-type/select-vehicle-type.component.ts
+++ b/src/app/features/tech-record/create-batch/components/select-vehicle-type/select-vehicle-type.component.ts
@@ -45,6 +45,7 @@ export class SelectVehicleTypeComponent {
     private router: Router
   ) {
     this.batchTechRecordService.clearBatch();
+    this.trs.clearSectionTemplateStates();
   }
 
   get isFormValid(): boolean {

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record/hydrate-new-vehicle-record.component.ts
@@ -98,7 +98,7 @@ export class HydrateNewVehicleRecordComponent implements OnDestroy {
       )
       .subscribe(([vehicleList, isBatch]) => {
         vehicleList.forEach(vehicle => this.store.dispatch(createVehicleRecord({ vehicle })));
-
+        this.technicalRecordService.clearSectionTemplateStates();
         if (isBatch) this.navigate();
       });
   }

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnChanges } from '@angular/core';
-import { FormGroup, Validators } from '@angular/forms';
+import { Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
@@ -75,6 +75,7 @@ export class CreateTechRecordComponent implements OnChanges {
     private store: Store
   ) {
     this.batchTechRecordService.clearBatch();
+    this.technicalRecordService.clearSectionTemplateStates();
   }
 
   ngOnChanges(): void {
@@ -143,6 +144,7 @@ export class CreateTechRecordComponent implements OnChanges {
 
     this.technicalRecordService.updateEditingTechRecord(this.vehicle as VehicleTechRecordModel);
     this.technicalRecordService.generateEditingVehicleTechnicalRecordFromVehicleType(this.vehicle.techRecord![0].vehicleType);
+    this.technicalRecordService.clearSectionTemplateStates();
     this.router.navigate(['../create/new-record-details'], { relativeTo: this.route });
   }
 

--- a/src/app/features/test-records/create/views/create-test-type/create-test-type.component.ts
+++ b/src/app/features/test-records/create/views/create-test-type/create-test-type.component.ts
@@ -4,8 +4,9 @@ import { TestType } from '@api/test-types';
 import { Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { State } from '@store/.';
+import { clearAllSectionStates } from '@store/technical-records';
 import { contingencyTestTypeSelected } from '@store/test-records';
-import { mergeMap, of, take } from 'rxjs';
+import { take } from 'rxjs';
 
 @Component({
   selector: 'app-create-test-type',
@@ -40,6 +41,7 @@ export class CreateTestTypeComponent implements AfterContentInit {
 
   handleSelectedTestType(testType: TestType) {
     this.store.dispatch(contingencyTestTypeSelected({ testType: testType.id }));
+    this.store.dispatch(clearAllSectionStates());
     this.router.navigate(['..', 'test-details'], {
       queryParams: { testType: testType.id },
       queryParamsHandling: 'merge',

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -10,9 +10,11 @@ import {
   selectTechRecordSearchResultsBySystemNumber
 } from '@store/tech-record-search/selector/tech-record-search.selector';
 import {
+  clearAllSectionStates,
   createVehicle,
   editableTechRecord,
   editableVehicleTechRecord,
+  selectSectionState,
   selectTechRecord,
   selectVehicleTechnicalRecordsBySystemNumber,
   updateEditingTechRecord,
@@ -179,5 +181,12 @@ export class TechnicalRecordService {
   }
   get viewableRecordStatus$(): Observable<StatusCodes | undefined> {
     return this.viewableTechRecord$.pipe(map(techRecord => techRecord?.statusCode));
+  }
+
+  get sectionStates$(): Observable<(string | number)[] | undefined> {
+    return this.store.pipe(select(selectSectionState));
+  }
+  clearSectionTemplateStates() {
+    this.store.dispatch(clearAllSectionStates());
   }
 }

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -186,6 +186,7 @@ export class TechnicalRecordService {
   get sectionStates$(): Observable<(string | number)[] | undefined> {
     return this.store.pipe(select(selectSectionState));
   }
+  
   clearSectionTemplateStates() {
     this.store.dispatch(clearAllSectionStates());
   }

--- a/src/app/shared/components/accordion-control/accordion-control.component.spec.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.spec.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialAppState } from '@store/index';
 import { AccordionComponent } from '../accordion/accordion.component';
 import { AccordionControlComponent } from './accordion-control.component';
 
@@ -18,7 +20,8 @@ describe('AccordionControlComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AccordionControlComponent, HostComponent, AccordionComponent]
+      declarations: [AccordionControlComponent, HostComponent, AccordionComponent],
+      providers: [provideMockStore({ initialState: initialAppState })]
     }).compileComponents();
   });
 

--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -16,12 +16,13 @@ export class AccordionControlComponent {
     value: QueryList<AccordionComponent> | undefined
   ) {
     this._accordions = value;
-    this.toggleAccordions();
+    this.expandAccordians();
   }
 
   @Input() isExpanded = false;
   @Input() layout?: string;
   @Input() class: string = '';
+  @Input() sectionState: (string | number)[] | undefined = [];
 
   constructor(private cdr: ChangeDetectorRef) {}
 
@@ -35,9 +36,15 @@ export class AccordionControlComponent {
     this.cdr.markForCheck();
   }
 
+  private expandAccordians(): void {
+    if (this.accordions && this.sectionState && this.sectionState.length > 0) {
+      this.accordions?.forEach(a => (this.sectionState?.includes(a.id) ? a.open(a.id) : a.close(a.id)));
+    }
+  }
+
   private toggleAccordions(): void {
     if (this.accordions) {
-      this.accordions.forEach(a => (this.isExpanded ? a.open() : a.close()));
+      this.accordions.forEach(a => (this.isExpanded ? a.open(a.id) : a.close(a.id)));
     }
   }
 }

--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -16,7 +16,7 @@ export class AccordionControlComponent {
     value: QueryList<AccordionComponent> | undefined
   ) {
     this._accordions = value;
-    this.expandAccordians();
+    this.isExpanded ? this.toggleAccordions() : this.expandAccordians();
   }
 
   @Input() isExpanded = false;

--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -22,7 +22,7 @@ export class AccordionControlComponent {
   @Input() isExpanded = false;
   @Input() layout?: string;
   @Input() class: string = '';
-  @Input() sectionState: (string | number)[] | undefined = [];
+  @Input() sectionState: (string | number)[] | undefined | null = [];
 
   constructor(private cdr: ChangeDetectorRef) {}
 

--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -36,7 +36,7 @@ export class AccordionControlComponent {
     this.cdr.markForCheck();
   }
 
-  private expandAccordians(): void {
+  private expandAccordions(): void {
     if (this.accordions && this.sectionState && this.sectionState.length > 0) {
       this.accordions?.forEach(a => (this.sectionState?.includes(a.id) ? a.open(a.id) : a.close(a.id)));
     }

--- a/src/app/shared/components/accordion-control/accordion-control.component.ts
+++ b/src/app/shared/components/accordion-control/accordion-control.component.ts
@@ -16,7 +16,7 @@ export class AccordionControlComponent {
     value: QueryList<AccordionComponent> | undefined
   ) {
     this._accordions = value;
-    this.isExpanded ? this.toggleAccordions() : this.expandAccordians();
+    this.isExpanded ? this.toggleAccordions() : this.expandAccordions();
   }
 
   @Input() isExpanded = false;

--- a/src/app/shared/components/accordion/accordion.component.html
+++ b/src/app/shared/components/accordion/accordion.component.html
@@ -7,7 +7,7 @@
         attr.aria-controls="accordion-details-{{ id }}"
         class="govuk-accordion__section-button"
         [attr.aria-expanded]="isExpanded"
-        (click)="isExpanded ? close() : open()"
+        (click)="isExpanded ? close(id) : open(id)"
       >
         <span class="govuk-accordion__section-heading-text" id="accordion-title-{{ id }}">
           <span class="govuk-accordion__section-heading-text-focus">{{ title }}</span>

--- a/src/app/shared/components/accordion/accordion.component.spec.ts
+++ b/src/app/shared/components/accordion/accordion.component.spec.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialAppState } from '@store/index';
+import { initialAppState, State } from '@store/.';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { AccordionComponent } from './accordion.component';
+import { addSectionState, removeSectionState } from '@store/technical-records';
 
 @Component({
   selector: 'app-host',
@@ -14,12 +15,13 @@ class HostComponent {}
 describe('AccordionComponent', () => {
   let component: AccordionComponent;
   let fixture: ComponentFixture<HostComponent>;
-
+  let store: MockStore<State>;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AccordionComponent, HostComponent],
       providers: [provideMockStore({ initialState: initialAppState })]
     }).compileComponents();
+    store = TestBed.inject(MockStore);
   });
 
   beforeEach(() => {
@@ -49,16 +51,24 @@ describe('AccordionComponent', () => {
 
   it('should set expanded value to true', () => {
     const markForCheckSpy = jest.spyOn(component['cdr'], 'markForCheck');
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
     component.open('TEST_SECTION');
     expect(component.isExpanded).toBeTruthy();
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(addSectionState({ section: 'TEST_SECTION' }));
   });
 
   it('should set expanded value to false', () => {
     const markForCheckSpy = jest.spyOn(component['cdr'], 'markForCheck');
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
+
     component.isExpanded = true;
     component.close('TEST_SECTION');
     expect(component.isExpanded).toBeFalsy();
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(removeSectionState({ section: 'TEST_SECTION' }));
   });
 });

--- a/src/app/shared/components/accordion/accordion.component.spec.ts
+++ b/src/app/shared/components/accordion/accordion.component.spec.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialAppState } from '@store/index';
 import { AccordionComponent } from './accordion.component';
 
 @Component({
@@ -15,7 +17,8 @@ describe('AccordionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AccordionComponent, HostComponent]
+      declarations: [AccordionComponent, HostComponent],
+      providers: [provideMockStore({ initialState: initialAppState })]
     }).compileComponents();
   });
 
@@ -46,7 +49,7 @@ describe('AccordionComponent', () => {
 
   it('should set expanded value to true', () => {
     const markForCheckSpy = jest.spyOn(component['cdr'], 'markForCheck');
-    component.open();
+    component.open('TEST_SECTION');
     expect(component.isExpanded).toBeTruthy();
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
   });
@@ -54,7 +57,7 @@ describe('AccordionComponent', () => {
   it('should set expanded value to false', () => {
     const markForCheckSpy = jest.spyOn(component['cdr'], 'markForCheck');
     component.isExpanded = true;
-    component.close();
+    component.close('TEST_SECTION');
     expect(component.isExpanded).toBeFalsy();
     expect(markForCheckSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/app/shared/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/accordion/accordion.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
-
+import { Store } from '@ngrx/store';
+import { addSectionState, removeSectionState } from '@store/technical-records';
 @Component({
   selector: 'app-accordion[id]',
   templateUrl: './accordion.component.html',
@@ -12,19 +13,21 @@ export class AccordionComponent {
 
   @Input() isExpanded = false;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(private cdr: ChangeDetectorRef, private store: Store) {}
 
   get iconStyle(): string {
     return 'govuk-accordion-nav__chevron' + (this.isExpanded ? '' : ' govuk-accordion-nav__chevron--down');
   }
 
-  open(): void {
+  open(sectionName: string | number | undefined): void {
     this.isExpanded = true;
     this.cdr.markForCheck();
+    if (sectionName) this.store.dispatch(addSectionState({ section: sectionName }));
   }
 
-  close(): void {
+  close(sectionName: string | number | undefined): void {
     this.isExpanded = false;
     this.cdr.markForCheck();
+    if (sectionName) this.store.dispatch(removeSectionState({ section: sectionName }));
   }
 }

--- a/src/app/shared/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/accordion/accordion.component.ts
@@ -11,7 +11,7 @@ export class AccordionComponent {
   @Input() title: string | undefined = '';
   @Input() id: string | number = '';
 
-  @Input() isExpanded = false;
+  @Input() isExpanded: boolean | null | undefined = false;
 
   constructor(private cdr: ChangeDetectorRef, private store: Store) {}
 

--- a/src/app/store/technical-records/actions/technical-record-service.actions.ts
+++ b/src/app/store/technical-records/actions/technical-record-service.actions.ts
@@ -54,6 +54,10 @@ export const updateBody = createAction(`${prefix} updatebody`, props<{ psvMake: 
 export const addAxle = createAction(`${prefix} addAxle`);
 export const removeAxle = createAction(`${prefix} removeAxle`, props<{ index: number }>());
 
+export const addSectionState = createAction(`${prefix} addSectionState`, props<{ section: string | number }>());
+export const removeSectionState = createAction(`${prefix} removeSectionState`, props<{ section: string | number }>());
+export const clearAllSectionStates = createAction(`${prefix} clearAllSectionState`);
+
 function createOutcomeAction(title: string, isSuccess: boolean = false): ActionCreator<string, (props: any) => any> {
   const suffix = isSuccess ? 'Success' : 'Failure';
   const type = `${prefix} ${title} ${suffix}`;

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -287,6 +287,16 @@ describe('Vehicle Technical Record Reducer', () => {
       expect(initialState).not.toBe(newState);
     });
 
+    it('should avoid duplicating the section name', () => {
+      initialState.sectionState = ['TEST_SECTION'];
+      const action = addSectionState({ section: 'TEST_SECTION' });
+      const newState = vehicleTechRecordReducer(initialState, action);
+
+      expect(initialState).toEqual(newState);
+      expect(newState.sectionState).toEqual(['TEST_SECTION']);
+      expect(initialState).not.toBe(newState);
+    });
+
     it('should remove the section name from the state', () => {
       initialState.sectionState = ['TEST_SECTION1', 'TEST_SECTION2'];
       const action = removeSectionState({ section: 'TEST_SECTION1' });

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -23,7 +23,10 @@ import {
   addAxle,
   removeAxle,
   updateBrakeForces,
-  updateBody
+  updateBody,
+  addSectionState,
+  removeSectionState,
+  clearAllSectionStates
 } from '../actions/technical-record-service.actions';
 import { initialState, TechnicalRecordServiceState, vehicleTechRecordReducer } from './technical-record-service.reducer';
 
@@ -273,17 +276,48 @@ describe('Vehicle Technical Record Reducer', () => {
     });
   });
 
+  describe('Section state changes', () => {
+    it('should add the section name to the state', () => {
+      initialState.sectionState = [];
+      const action = addSectionState({ section: 'TEST_SECTION' });
+      const newState = vehicleTechRecordReducer(initialState, action);
+
+      expect(initialState).not.toEqual(newState);
+      expect(newState.sectionState).toEqual(['TEST_SECTION']);
+      expect(initialState).not.toBe(newState);
+    });
+
+    it('should remove the section name from the state', () => {
+      initialState.sectionState = ['TEST_SECTION1', 'TEST_SECTION2'];
+      const action = removeSectionState({ section: 'TEST_SECTION1' });
+      const newState = vehicleTechRecordReducer(initialState, action);
+
+      expect(initialState).not.toEqual(newState);
+      expect(newState.sectionState).toEqual(['TEST_SECTION2']);
+      expect(initialState).not.toBe(newState);
+    });
+
+    it('should clear all the section names from the state', () => {
+      initialState.sectionState = ['TEST_SECTION1', 'TEST_SECTION2'];
+      const action = clearAllSectionStates();
+      const newState = vehicleTechRecordReducer(initialState, action);
+
+      expect(initialState).not.toEqual(newState);
+      expect(newState.sectionState).toEqual([]);
+      expect(initialState).not.toBe(newState);
+    });
+  });
+
   describe('updating properties of the tech record in edit', () => {
     beforeEach(() => (initialState.editingTechRecord = mockVehicleTechnicalRecord(VehicleTypes.PSV)));
 
     describe('updateBrakeForces', () => {
-
       it('should not update half locked brake forces with no gross kerb weight', () => {
         initialState.editingTechRecord!.techRecord[0].brakes!.brakeCodeOriginal = '80';
         initialState.editingTechRecord!.techRecord[0].brakes!.brakeForceWheelsUpToHalfLocked = {
           parkingBrakeForceB: 50,
           secondaryBrakeForceB: 30,
-          serviceBrakeForceB: 10 
+          serviceBrakeForceB: 10
         };
         const brakes = initialState.editingTechRecord?.techRecord[0].brakes;
         expect(brakes?.brakeCode).toBe('1234');
@@ -307,9 +341,9 @@ describe('Vehicle Technical Record Reducer', () => {
         initialState.editingTechRecord!.techRecord[0].brakes!.brakeForceWheelsNotLocked = {
           parkingBrakeForceA: 50,
           secondaryBrakeForceA: 30,
-          serviceBrakeForceA: 10 
+          serviceBrakeForceA: 10
         };
-        
+
         const newState = vehicleTechRecordReducer(initialState, updateBrakeForces({ grossKerbWeight: 1000 }));
 
         const updatedBrakes = newState.editingTechRecord?.techRecord[0].brakes;

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -42,7 +42,10 @@ import {
   updateTechRecordsSuccess,
   updateVin,
   updateVinSuccess,
-  updateVinFailure
+  updateVinFailure,
+  addSectionState,
+  removeSectionState,
+  clearAllSectionStates
 } from '../actions/technical-record-service.actions';
 import { BatchRecords, initialBatchState, vehicleBatchCreateReducer } from './batch-create.reducer';
 
@@ -54,12 +57,14 @@ export interface TechnicalRecordServiceState {
   editingTechRecord?: VehicleTechRecordModel;
   error?: unknown;
   batchVehicles: BatchRecords;
+  sectionState?: (string | number)[];
 }
 
 export const initialState: TechnicalRecordServiceState = {
   vehicleTechRecords: [],
   batchVehicles: initialBatchState,
-  loading: false
+  loading: false,
+  sectionState: []
 };
 
 export const getVehicleTechRecordState = createFeatureSelector<TechnicalRecordServiceState>(STORE_FEATURE_TECHNICAL_RECORDS_KEY);
@@ -105,6 +110,10 @@ export const vehicleTechRecordReducer = createReducer(
   on(addAxle, state => handleAddAxle(state)),
   on(removeAxle, (state, action) => handleRemoveAxle(state, action)),
 
+  on(addSectionState, (state, action) => handleAddSection(state, action)),
+  on(removeSectionState, (state, action) => handleRemoveSection(state, action)),
+  on(clearAllSectionStates, state => ({ ...state, sectionState: [] })),
+
   on(updateVin, defaultArgs),
   on(updateVinSuccess, state => ({ ...state, loading: false })),
   on(updateVinFailure, updateFailureArgs),
@@ -148,7 +157,7 @@ function handleUpdateBrakeForces(
   const newState = cloneDeep(state);
   if (!newState.editingTechRecord) return newState;
 
-  if(data.grossLadenWeight) {
+  if (data.grossLadenWeight) {
     const prefix = `${Math.round(data.grossLadenWeight / 100)}`;
 
     newState.editingTechRecord.techRecord[0].brakes = {
@@ -159,10 +168,10 @@ function handleUpdateBrakeForces(
         secondaryBrakeForceA: Math.round((data.grossLadenWeight * 22.5) / 100),
         parkingBrakeForceA: Math.round((data.grossLadenWeight * 45) / 100)
       }
-    }
+    };
   }
 
-  if(data.grossKerbWeight) {
+  if (data.grossKerbWeight) {
     newState.editingTechRecord.techRecord[0].brakes = {
       ...newState.editingTechRecord?.techRecord[0].brakes,
       brakeForceWheelsUpToHalfLocked: {
@@ -170,7 +179,7 @@ function handleUpdateBrakeForces(
         secondaryBrakeForceB: Math.round((data.grossKerbWeight * 25) / 100),
         parkingBrakeForceB: Math.round((data.grossKerbWeight * 50) / 100)
       }
-    }
+    };
   }
   return newState;
 }
@@ -253,4 +262,16 @@ function handleRemoveAxle(state: TechnicalRecordServiceState, action: { index: n
   }
 
   return newState;
+}
+
+function handleAddSection(state: TechnicalRecordServiceState, action: { section: string | number }) {
+  const newState = cloneDeep(state);
+  if (newState.sectionState?.includes(action.section)) return newState;
+  return { ...newState, sectionState: newState.sectionState?.concat(action.section) };
+}
+
+function handleRemoveSection(state: TechnicalRecordServiceState, action: { section: string | number }) {
+  const newState = cloneDeep(state);
+  if (!newState.sectionState?.includes(action.section)) return newState;
+  return { ...newState, sectionState: newState.sectionState?.filter(section => section !== action.section) };
 }

--- a/src/app/store/technical-records/selectors/technical-record-service.selectors.spec.ts
+++ b/src/app/store/technical-records/selectors/technical-record-service.selectors.spec.ts
@@ -5,7 +5,8 @@ import {
   selectTechRecord,
   selectVehicleTechnicalRecordsBySystemNumber,
   technicalRecordsLoadingState,
-  vehicleTechRecords
+  vehicleTechRecords,
+  selectSectionState
 } from './technical-record-service.selectors';
 
 describe('Tech Record Selectors', () => {
@@ -110,6 +111,14 @@ describe('Tech Record Selectors', () => {
       expect(techRecord).toBeDefined();
       expect(techRecord?.statusCode).toBe(statusExpected);
       createdAt && techRecord && expect(new Date(techRecord.createdAt).getTime()).toBe(createdAt);
+    });
+  });
+
+  describe('selectSectionState', () => {
+    it('should return the sectionState in the technical record state', () => {
+      const state: TechnicalRecordServiceState = { ...initialState, sectionState: ['TestSection1', 'TestSection2'] };
+      const selectedState = selectSectionState.projector(state);
+      expect(selectedState?.length).toEqual(2);
     });
   });
 });

--- a/src/app/store/technical-records/selectors/technical-record-service.selectors.ts
+++ b/src/app/store/technical-records/selectors/technical-record-service.selectors.ts
@@ -46,3 +46,5 @@ export const selectTechRecord = createSelector(
     return vehicle && TechnicalRecordService.filterTechRecordByStatusCode(vehicle);
   }
 );
+
+export const selectSectionState = createSelector(getVehicleTechRecordState, state => state.sectionState);


### PR DESCRIPTION
## Tech record summary sections remain open after page changes

Save the state of whether a section is expanded to not, and keep it open after navigation from tyre search, vin/vrm change, batch vehicles, etc.

[CB2-8099](https://dvsa.atlassian.net/browse/CB2-8099)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
