### PR TITLE
chore(*): add merge conflict tag action

### DIFF
--- a/.github/workflows/tag-merge-conflicts.yml
+++ b/.github/workflows/tag-merge-conflicts.yml
@@ -1,0 +1,43 @@
+name: Tag Merge Conflicts
+on:
+  push:
+    branches: ['develop']
+  pull_request:
+    branches: ['develop']
+jobs:
+  merge-conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const repos = (await github.rest.pulls.list({
+                ...context.repo
+            })).data
+            const promises = repos.map(repo => {
+                const { number } = repo
+                return github.rest.pulls.get({
+                    ...context.repo,
+                    pull_number: number
+                })
+            })
+            const prs = await Promise.allSettled(promises)
+            prs.forEach(pr => {
+                const data = pr.value.data
+                if (data.mergeable === false) {
+                    github.rest.issues.addLabels({
+                        ...context.repo,
+                        issue_number: data.number,
+                        labels: ["merge conflict"]
+                    })
+                } else if (data.mergeable === true 
+                    && data.labels.some(label => label.name === "merge conflict")) {
+                            github.rest.issues.removeLabel({
+                                ...context.repo,
+                                issue_number: data.number,
+                                name: "merge conflict"
+                            })
+                    }
+            })


### PR DESCRIPTION
## Ticket title

Adds a github action to dynamically add and remove a merge conflict tag to PRs that need rebasing.

You can see it working on this PR for instance https://github.com/dvsa/cvs-app-vtm/pull/971.

Note:
Sometimes the `mergeable` status is `null`. Github says the "best" thing is to wait and retry don't feel like it's worth adding that logic at this time. Could see how much of an impact it is.
