### PR TITLE
fix(*): browser runs out of memory when editing some records

### DIFF
--- a/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
+++ b/src/app/features/tech-record/components/edit-tech-record-button/edit-tech-record-button.component.ts
@@ -13,7 +13,7 @@ import {
   updateEditingTechRecordCancel,
   updateTechRecordsSuccess
 } from '@store/technical-records';
-import { Observable, Subject, map, takeUntil, withLatestFrom } from 'rxjs';
+import { Observable, Subject, distinctUntilChanged, map, takeUntil, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-edit-tech-record-button',
@@ -66,7 +66,8 @@ export class EditTechRecordButtonComponent implements OnInit, OnDestroy {
     this.technicalRecordService.viewableTechRecord$
       .pipe(
         map(techRecord => techRecord?.statusCode),
-        takeUntil(this.destroy$)
+        takeUntil(this.destroy$),
+        distinctUntilChanged()
       )
       .subscribe(statusCode => {
         statusCode !== StatusCodes.PROVISIONAL


### PR DESCRIPTION
## Ticket title

- When editing some records, the browser runs out of memory due to an infinite call

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
