### PR TITLE
fix(cb2-8968): fixes display of psv brake code prefix

### DIFF
--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.html
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.html
@@ -10,15 +10,18 @@
   [propOptions$]="brakeCodeOptions$"
 ></app-switchable-input>
 
-<ng-template #view [formGroup]="brakesForm">
-  <app-read-only formControlName="brakeCode" name="brake-code" label="Brake code"></app-read-only>
+<ng-template #view>
+  <div>
+    <label class="govuk-label govuk-label--m" for="brake-code">Brake code</label>
+    <span class="govuk-body" id="brake-code">{{ brakeCode }}</span>
+  </div>
 </ng-template>
 
 <app-switchable-input
   [form]="brakesForm"
   [type]="editTypes.TEXT"
   name="dataTrBrakeOne"
-  label="Service *"
+  label="Service"
   [isEditing]="isEditing"
   [width]="widths.XL"
 ></app-switchable-input>
@@ -27,7 +30,7 @@
   [form]="brakesForm"
   [type]="editTypes.TEXT"
   name="dataTrBrakeTwo"
-  label="Secondary *"
+  label="Secondary"
   [isEditing]="isEditing"
   [width]="widths.XL"
 ></app-switchable-input>
@@ -36,7 +39,7 @@
   [form]="brakesForm"
   [type]="editTypes.TEXT"
   name="dataTrBrakeThree"
-  label="Parking *"
+  label="Parking"
   [isEditing]="isEditing"
   [width]="widths.XL"
 ></app-switchable-input>

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
@@ -12,7 +12,7 @@ import { Store } from '@ngrx/store';
 import { ReferenceDataState, selectBrakeByCode } from '@store/reference-data';
 import { updateBrakeForces } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
-import { debounceTime, mergeMap, Observable, of, Subject, takeUntil, withLatestFrom } from 'rxjs';
+import { Observable, Subject, debounceTime, mergeMap, of, takeUntil, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-psv-brakes',
@@ -54,6 +54,7 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
       .subscribe(([selectedBrake, event]: [Brake | undefined, any]) => {
         // Set the brake details automatically based selection
         if (selectedBrake && event?.brakes?.brakeCodeOriginal) {
+          event.brakes['brakeCode'] = `${this.brakeCodePrefix}${selectedBrake.resourceKey}`;
           event.brakes['dataTrBrakeOne'] = selectedBrake.service;
           event.brakes['dataTrBrakeTwo'] = selectedBrake.secondary;
           event.brakes['dataTrBrakeThree'] = selectedBrake.parking;
@@ -84,6 +85,10 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  get brakeCode(): string {
+    return `${this.brakeCodePrefix}${this.form.get('brakes.brakeCodeOriginal')?.value}`;
   }
 
   get brakesForm(): FormGroup {


### PR DESCRIPTION
## PSV Brake Codes

The PSV Brake Code Prefix is calculated based on the vehicle laden weight and is shown correctly when amending, but isn't updated or shown correctly when just viewing the record.
[CB2-8968](https://dvsa.atlassian.net/browse/CB2-8968)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Delete branch after merge
