### PR TITLE
Fix/cb2-8667: calculate noOfAxles

### DIFF
--- a/src/app/services/technical-record/technical-record.service.spec.ts
+++ b/src/app/services/technical-record/technical-record.service.spec.ts
@@ -9,6 +9,7 @@ import { State, initialAppState } from '@store/index';
 import { updateEditingTechRecord } from '@store/technical-records';
 import { environment } from '../../../environments/environment';
 import { TechnicalRecordService } from './technical-record.service';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 describe('TechnicalRecordService', () => {
   let service: TechnicalRecordService;
@@ -163,6 +164,21 @@ describe('TechnicalRecordService', () => {
         service.updateEditingTechRecord(mockVehicleRecord);
         expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenCalledWith(updateEditingTechRecord({ vehicleTechRecord: mockVehicleRecord }));
+      });
+
+      it('should update the number of axles based on the axles array', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+        const mockVehicleRecord = mockVehicleTechnicalRecord('trl');
+        mockVehicleRecord.techRecord_noOfAxles = 0;
+        mockVehicleRecord.techRecord_axles = [{}, {}];
+
+        service.updateEditingTechRecord(mockVehicleRecord as TechRecordType<'put'>);
+
+        expect(dispatchSpy).toHaveBeenCalledWith(
+          updateEditingTechRecord({
+            vehicleTechRecord: { ...mockVehicleRecord, techRecord_axles: [{}, {}], techRecord_noOfAxles: 2 } as TechRecordType<'put'>
+          })
+        );
       });
 
       it('override the editable tech record and dispatch the action to update the editing vehicle record with the full vehicle record', () => {

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -77,6 +77,9 @@ export class TechnicalRecordService {
   }
 
   updateEditingTechRecord(record: TechRecordType<'put'>): void {
+    if (record.techRecord_vehicleType === 'psv' || record.techRecord_vehicleType === 'hgv' || record.techRecord_vehicleType === 'trl') {
+      record.techRecord_noOfAxles = record.techRecord_axles && record.techRecord_axles.length > 0 ? record.techRecord_axles?.length : null;
+    }
     this.store.dispatch(updateEditingTechRecord({ vehicleTechRecord: record }));
   }
 


### PR DESCRIPTION
CB2-8667

currently if you fill in the details for the single axle a vehicle starts with on psv, trl and hgv the number of axles stays null. adding this to the updateEditingTechRecord method in the tech record service will add the number of axles when you input a value into one of the axle fields. 

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
