### PR TITLE
Chore/refactor the createMock functions

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.spec.ts
@@ -16,6 +16,7 @@ import { initialAppState } from '@store/index';
 import { updateTechRecord, updateTechRecordSuccess } from '@store/technical-records';
 import { of, ReplaySubject } from 'rxjs';
 import { AmendVinComponent } from './tech-record-amend-vin.component';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 const mockTechRecordService = {
   editableTechRecord$: of({}),
@@ -35,7 +36,7 @@ describe('TechRecordChangeVrmComponent', () => {
   let actions$ = new ReplaySubject<Action>();
   let component: AmendVinComponent;
   let errorService: GlobalErrorService;
-  let expectedTechRecord = {} as V3TechRecordModel;
+  let expectedTechRecord: V3TechRecordModel;
   let fixture: ComponentFixture<AmendVinComponent>;
   let route: ActivatedRoute;
   let router: Router;
@@ -75,14 +76,13 @@ describe('TechRecordChangeVrmComponent', () => {
 
   describe('handleSubmit', () => {
     beforeEach(() => {
-      expectedTechRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as unknown as TechRecordType<'put'>;
+      expectedTechRecord = mockVehicleTechnicalRecord('psv');
       component.techRecord = expectedTechRecord;
     });
     it('should dispatch the updateTechRecord action with the new vin', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const payload = {
-        systemNumber: 'foo',
-        createdTimestamp: 'bar',
+        ...expectedTechRecord,
         vin: 'myNewVin',
         techRecord_reasonForCreation: 'Vin changed'
       } as unknown as TechRecordType<'put'>;

--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.spec.ts
@@ -37,7 +37,7 @@ describe('TechRecordChangeVrmComponent', () => {
   let actions$ = new ReplaySubject<Action>();
   let component: AmendVrmComponent;
   let errorService: GlobalErrorService;
-  let expectedVehicle = {} as V3TechRecordModel;
+  let expectedVehicle: V3TechRecordModel;
   let fixture: ComponentFixture<AmendVrmComponent>;
   let route: ActivatedRoute;
   let router: Router;

--- a/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.spec.ts
@@ -17,6 +17,7 @@ import { initialAppState } from '@store/index';
 import { changeVehicleType } from '@store/technical-records';
 import { ReplaySubject, of } from 'rxjs';
 import { ChangeVehicleTypeComponent } from './tech-record-change-type.component';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 const mockTechRecordService = {
   get techRecord$() {
@@ -34,7 +35,7 @@ describe('TechRecordChangeTypeComponent', () => {
   let actions$ = new ReplaySubject<Action>();
   let component: ChangeVehicleTypeComponent;
   let errorService: GlobalErrorService;
-  let expectedTechRecord = {} as V3TechRecordModel;
+  let expectedTechRecord: V3TechRecordModel;
   let fixture: ComponentFixture<ChangeVehicleTypeComponent>;
   let route: ActivatedRoute;
   let router: Router;
@@ -62,14 +63,7 @@ describe('TechRecordChangeTypeComponent', () => {
     router = TestBed.inject(Router);
     store = TestBed.inject(MockStore);
     component = fixture.componentInstance;
-    expectedTechRecord = {
-      systemNumber: 'foo',
-      createdTimestamp: 'bar',
-      vin: 'testVin',
-      techRecord_vehicleType: VehicleTypes.PSV,
-      techRecord_chassisMake: 'test-make',
-      techRecord_chassisModel: 'test-model'
-    } as V3TechRecordModel;
+    expectedTechRecord = mockVehicleTechnicalRecord('psv');
   });
 
   it('should create', () => {

--- a/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-generate-plate/tech-record-generate-plate.component.spec.ts
@@ -17,6 +17,7 @@ import { initialAppState } from '@store/index';
 import { generatePlate, generatePlateSuccess } from '@store/technical-records';
 import { of, ReplaySubject } from 'rxjs';
 import { GeneratePlateComponent } from './tech-record-generate-plate.component';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 const mockDynamicFormService = {
   createForm: jest.fn()
@@ -69,9 +70,7 @@ describe('TechRecordGeneratePlateComponent', () => {
 
   describe('navigateBack', () => {
     beforeEach(() => {
-      jest
-        .spyOn(technicalRecordService, 'techRecord$', 'get')
-        .mockReturnValue(of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel));
+      jest.spyOn(technicalRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('hgv')));
     });
     it('should clear all errors', () => {
       jest.spyOn(router, 'navigate').mockImplementation();
@@ -108,9 +107,7 @@ describe('TechRecordGeneratePlateComponent', () => {
 
   describe('handleSubmit', () => {
     beforeEach(() => {
-      jest
-        .spyOn(technicalRecordService, 'techRecord$', 'get')
-        .mockReturnValue(of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel));
+      jest.spyOn(technicalRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('hgv')));
     });
     it('should add an error when the field is not filled out', () => {
       const addErrorSpy = jest.spyOn(errorService, 'addError');

--- a/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-history/tech-record-history.component.spec.ts
@@ -8,6 +8,7 @@ import { TechnicalRecordService } from '@services/technical-record/technical-rec
 import { SharedModule } from '@shared/shared.module';
 import { initialAppState } from '@store/index';
 import { TechRecordHistoryComponent } from './tech-record-history.component';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 describe('TechRecordHistoryComponent', () => {
   let component: TechRecordHistoryComponent;
@@ -28,7 +29,7 @@ describe('TechRecordHistoryComponent', () => {
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
     route = TestBed.inject(ActivatedRoute);
-    component.currentTechRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel;
+    component.currentTechRecord = mockVehicleTechnicalRecord('hgv');
     fixture.detectChanges();
   });
   it('should create', () => {

--- a/src/app/features/tech-record/components/tech-record-search-tyres/tech-record-search-tyres.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-search-tyres/tech-record-search-tyres.component.spec.ts
@@ -20,6 +20,7 @@ import { TechRecordSearchTyresComponent } from './tech-record-search-tyres.compo
 import { ReferenceDataResourceType, ReferenceDataTyre } from '@models/reference-data.model';
 import { V3TechRecordModel } from '@models/vehicle-tech-record.model';
 import { fetchReferenceDataByKeySearchSuccess } from '@store/reference-data';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 const mockGlobalErrorService = {
   addError: jest.fn(),
@@ -199,12 +200,10 @@ describe('TechRecordSearchTyresComponent', () => {
 
   describe('Getters', () => {
     it('should get the currentVrm', () => {
-      const mockVehicleRecord = {
-        primaryVrm: 'bar',
-        secondaryVrms: ['foo']
-      } as V3TechRecordModel;
+      const mockVehicleRecord = mockVehicleTechnicalRecord('psv');
+
       component.vehicleTechRecord = mockVehicleRecord;
-      expect(component.currentVrm).toEqual('bar');
+      expect(component.currentVrm).toEqual('KP01ABC');
     });
     it('should get the paginated fields', () => {
       component.searchResults = ['foo', 'bar', 'foobar'] as any;

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -83,7 +83,11 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show PSV record found without dimensions', () => {
       component.isEditing = false;
-      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv')));
+      const record = mockVehicleTechnicalRecord('psv') as TechRecordTypeByVehicle<'psv'>;
+      delete record.techRecord_dimensions_height;
+      delete record.techRecord_dimensions_width;
+      delete record.techRecord_dimensions_length;
+      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(record));
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -113,12 +117,9 @@ describe('TechRecordSummaryComponent', () => {
       const vehicle = mockVehicleTechnicalRecord('trl');
       jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(
         of({
-          systemNumber: 'foo',
-          createdTimestamp: 'bar',
-          vin: 'testVin',
-          techRecord_vehicleType: VehicleTypes.TRL,
+          ...vehicle,
           techRecord_euVehicleCategory: 'o2'
-        } as V3TechRecordModel)
+        })
       );
       fixture.detectChanges();
 
@@ -128,11 +129,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show TRL record found without dimensions', () => {
       component.isEditing = false;
-      jest
-        .spyOn(techRecordService, 'techRecord$', 'get')
-        .mockReturnValue(
-          of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_vehicleType: VehicleTypes.TRL } as V3TechRecordModel)
-        );
+      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('trl')));
       fixture.detectChanges();
 
       checkHeadingAndForm();

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.spec.ts
@@ -20,6 +20,7 @@ import { State, initialAppState } from '@store/index';
 import { updateEditingTechRecord } from '@store/technical-records';
 import { of } from 'rxjs';
 import { TechRecordSummaryComponent } from './tech-record-summary.component';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 describe('TechRecordSummaryComponent', () => {
   let component: TechRecordSummaryComponent;
@@ -74,11 +75,7 @@ describe('TechRecordSummaryComponent', () => {
   describe('TechRecordSummaryComponent View', () => {
     it('should show PSV record found', () => {
       component.isEditing = false;
-      jest
-        .spyOn(techRecordService, 'techRecord$', 'get')
-        .mockReturnValue(
-          of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_vehicleType: VehicleTypes.PSV } as V3TechRecordModel)
-        );
+      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv')));
       fixture.detectChanges();
       checkHeadingAndForm();
       expect(component.vehicleType).toEqual(VehicleTypes.PSV);
@@ -86,11 +83,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show PSV record found without dimensions', () => {
       component.isEditing = false;
-      jest
-        .spyOn(techRecordService, 'techRecord$', 'get')
-        .mockReturnValue(
-          of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_vehicleType: VehicleTypes.PSV } as V3TechRecordModel)
-        );
+      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv')));
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -99,11 +92,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show HGV record found', () => {
       component.isEditing = false;
-      jest
-        .spyOn(techRecordService, 'techRecord$', 'get')
-        .mockReturnValue(
-          of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_vehicleType: VehicleTypes.HGV } as V3TechRecordModel)
-        );
+      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('hgv')));
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -112,11 +101,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show HGV record found without dimensions', () => {
       component.isEditing = false;
-      jest
-        .spyOn(techRecordService, 'techRecord$', 'get')
-        .mockReturnValue(
-          of({ systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_vehicleType: VehicleTypes.HGV } as V3TechRecordModel)
-        );
+      jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('hgv')));
       fixture.detectChanges();
 
       checkHeadingAndForm();
@@ -125,6 +110,7 @@ describe('TechRecordSummaryComponent', () => {
 
     it('should show TRL record found', async () => {
       component.isEditing = false;
+      const vehicle = mockVehicleTechnicalRecord('trl');
       jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(
         of({
           systemNumber: 'foo',

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -95,7 +95,7 @@ describe('VehicleTechnicalRecordComponent', () => {
     store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(VehicleTechnicalRecordComponent);
     component = fixture.componentInstance;
-    component.techRecord = mockVehicleTechnicalRecord('psv') as V3TechRecordModel;
+    component.techRecord = mockVehicleTechnicalRecord('psv');
   });
 
   it('should create', () => {
@@ -109,7 +109,7 @@ describe('VehicleTechnicalRecordComponent', () => {
         component.editingReason = ReasonForEditing.CORRECTING_AN_ERROR;
         fixture.detectChanges();
         component.summary = TestBed.createComponent(TechRecordSummaryStubComponent).componentInstance as TechRecordSummaryComponent;
-        techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel;
+        techRecord = mockVehicleTechnicalRecord('psv');
       });
       it('should update the current for a valid form', fakeAsync(() => {
         const storeSpy = jest.spyOn(store, 'select').mockReturnValue(of(techRecord));
@@ -125,7 +125,7 @@ describe('VehicleTechnicalRecordComponent', () => {
         component.editingReason = ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED;
         fixture.detectChanges();
         component.summary = TestBed.createComponent(TechRecordSummaryStubComponent).componentInstance as TechRecordSummaryComponent;
-        techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel;
+        techRecord = mockVehicleTechnicalRecord('psv');
       });
       it('should dispatch updateTechRecords with editingTechRecord unchanged', fakeAsync(() => {
         const storeSpy = jest.spyOn(store, 'select').mockReturnValue(of(techRecord));

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -25,6 +25,7 @@ import { TechRecordSummaryComponent } from '../tech-record-summary/tech-record-s
 import { TechRecordTitleComponent } from '../tech-record-title/tech-record-title.component';
 import { TestRecordSummaryComponent } from '../test-record-summary/test-record-summary.component';
 import { VehicleTechnicalRecordComponent } from './vehicle-technical-record.component';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 
 describe('VehicleTechnicalRecordComponent', () => {
   let component: VehicleTechnicalRecordComponent;
@@ -94,7 +95,7 @@ describe('VehicleTechnicalRecordComponent', () => {
     store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(VehicleTechnicalRecordComponent);
     component = fixture.componentInstance;
-    component.techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel;
+    component.techRecord = mockVehicleTechnicalRecord('psv') as V3TechRecordModel;
   });
 
   it('should create', () => {

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.spec.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.spec.ts
@@ -11,6 +11,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { of } from 'rxjs';
 import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
+import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 
 const mockTechnicalRecordService = {
   get techRecord$() {
@@ -58,34 +59,27 @@ describe('VehicleHeaderComponent', () => {
   });
 
   it('should display the correct data based on vehicle type', () => {
-    const mockRecord = {
-      techRecord_vehicleConfiguration: VehicleConfigurations.RIGID,
-      techRecord_bodyMake: 'testBody',
-      techRecord_bodyModel: 'testBodyModel',
-      techRecord_chassisMake: 'testChassis',
-      techRecord_chassisModel: 'testChassisModel',
-      techRecord_make: 'testHGV',
-      techRecord_model: 'testHGVModel'
-    } as unknown as V3TechRecordModel;
+    const mockTrl = mockVehicleTechnicalRecord('trl');
+    const mockPsv = mockVehicleTechnicalRecord('psv');
+    const mockHgv = mockVehicleTechnicalRecord('hgv');
 
-    expect(component.getVehicleDescription(mockRecord, VehicleTypes.TRL)).toEqual('rigid');
-    expect(component.getVehicleDescription(mockRecord, VehicleTypes.PSV)).toEqual('testBody-testBodyModel');
-    expect(component.getVehicleDescription(mockRecord, VehicleTypes.HGV)).toEqual('testHGV-testHGVModel');
+    expect(component.getVehicleDescription(mockTrl, VehicleTypes.TRL)).toEqual('articulated');
+    expect(component.getVehicleDescription(mockPsv, VehicleTypes.PSV)).toEqual('Body make-Body model');
+    expect(component.getVehicleDescription(mockHgv, VehicleTypes.HGV)).toEqual('1234-1234');
   });
 
   it('should display an empty string if all required data cannot be retrieved', () => {
-    const mockRecord = {
-      techRecord_bodyMake: '',
-      techRecord_bodyModel: 'testBodyModel',
-      techRecord_chassisMake: '',
-      techRecord_chassisModel: 'testChassisModel',
-      techRecord_make: '',
-      techRecord_model: 'testHGVModel'
-    } as unknown as V3TechRecordModel;
+    const mockTrl = mockVehicleTechnicalRecord('trl');
+    const mockPsv = mockVehicleTechnicalRecord('psv');
+    const mockHgv = mockVehicleTechnicalRecord('hgv');
 
-    expect(component.getVehicleDescription(mockRecord, VehicleTypes.TRL)).toBeFalsy();
-    expect(component.getVehicleDescription(mockRecord, VehicleTypes.PSV)).toBeFalsy();
-    expect(component.getVehicleDescription(mockRecord, VehicleTypes.HGV)).toBeFalsy();
+    delete mockTrl.techRecord_vehicleConfiguration;
+    delete (mockPsv as TechRecordType<'psv'>).techRecord_bodyMake;
+    delete (mockHgv as TechRecordType<'hgv'>).techRecord_make;
+
+    expect(component.getVehicleDescription(mockTrl, VehicleTypes.TRL)).toBeFalsy();
+    expect(component.getVehicleDescription(mockPsv, VehicleTypes.PSV)).toBeFalsy();
+    expect(component.getVehicleDescription(mockHgv, VehicleTypes.HGV)).toBeFalsy();
   });
 
   it('should display "Unknown Vehicle Type" if vehicle type is unknown/undefined', () => {

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.spec.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.spec.ts
@@ -2,15 +2,15 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { MultiOptionsService } from '@forms/services/multi-options.service';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialAppState } from '@store/index';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { UserService } from '@services/user-service/user-service';
+import { initialAppState } from '@store/index';
 import { PsvBrakesComponent } from './psv-brakes.component';
-import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
-import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 
 describe('PsvBrakesComponent', () => {
   let component: PsvBrakesComponent;
@@ -34,59 +34,6 @@ describe('PsvBrakesComponent', () => {
     component = fixture.componentInstance;
 
     component.vehicleTechRecord = mockVehicleTechnicalRecord('psv') as TechRecordType<'psv'>;
-    component.vehicleTechRecord.techRecord_axles = [
-      {
-        axleNumber: 1,
-        tyres_tyreSize: '295/80-22.5',
-        tyres_speedCategorySymbol: 'p',
-        tyres_fitmentCode: 'double',
-        tyres_dataTrAxles: 0,
-        tyres_plyRating: 'A',
-        tyres_tyreCode: 456,
-        parkingBrakeMrk: false,
-
-        weights_kerbWeight: 1,
-        weights_ladenWeight: 2,
-        weights_gbWeight: 3,
-        // TODO: V3 2 eecweights in type package, which is this?
-        // weights_eecWeight: 4,
-        weights_designWeight: 5
-      },
-      {
-        axleNumber: 2,
-        parkingBrakeMrk: true,
-
-        tyres_tyreSize: '295/80-22.5',
-        tyres_speedCategorySymbol: 'p',
-        tyres_fitmentCode: 'double',
-        tyres_dataTrAxles: 0,
-        tyres_plyRating: 'A',
-        tyres_tyreCode: 456,
-
-        weights_kerbWeight: 1,
-        weights_ladenWeight: 2,
-        weights_gbWeight: 3,
-        // weights_eecWeight: 4,
-        weights_designWeight: 5
-      },
-      {
-        axleNumber: 3,
-        parkingBrakeMrk: true,
-
-        tyres_tyreSize: '295/80-22.5',
-        tyres_speedCategorySymbol: 'p',
-        tyres_fitmentCode: 'double',
-        tyres_dataTrAxles: 0,
-        tyres_plyRating: 'A',
-        tyres_tyreCode: 456,
-
-        weights_kerbWeight: 1,
-        weights_ladenWeight: 2,
-        weights_gbWeight: 3,
-        // weights_eecWeight: 4,
-        weights_designWeight: 5
-      }
-    ];
 
     fixture.detectChanges();
   });

--- a/src/app/forms/custom-sections/trl-brakes/trl-brakes.component.spec.ts
+++ b/src/app/forms/custom-sections/trl-brakes/trl-brakes.component.spec.ts
@@ -25,59 +25,7 @@ describe('BrakesComponent', () => {
     fixture = TestBed.createComponent(TrlBrakesComponent);
     component = fixture.componentInstance;
     component.vehicleTechRecord = mockVehicleTechnicalRecord('trl') as TechRecordType<'trl'>;
-    component.vehicleTechRecord.techRecord_axles = [
-      {
-        parkingBrakeMrk: true,
-        axleNumber: 1,
-        brakes_brakeActuator: 1,
-        brakes_leverLength: 1,
-        brakes_springBrakeParking: true,
-        weights_gbWeight: 1,
-        weights_designWeight: 2,
-        weights_ladenWeight: 3,
-        weights_kerbWeight: 4,
-        tyres_tyreCode: 1,
-        tyres_tyreSize: '2',
-        tyres_plyRating: '3',
-        tyres_fitmentCode: 'single',
-        tyres_dataTrAxles: 1,
-        tyres_speedCategorySymbol: 'a7'
-      },
-      {
-        parkingBrakeMrk: true,
-        axleNumber: 2,
-        brakes_brakeActuator: 1,
-        brakes_leverLength: 1,
-        brakes_springBrakeParking: false,
-        weights_gbWeight: 1,
-        weights_designWeight: 2,
-        weights_ladenWeight: 3,
-        weights_kerbWeight: 4,
-        tyres_tyreCode: 1,
-        tyres_tyreSize: '2',
-        tyres_plyRating: '3',
-        tyres_fitmentCode: 'single',
-        tyres_dataTrAxles: 1,
-        tyres_speedCategorySymbol: 'a7'
-      },
-      {
-        parkingBrakeMrk: false,
-        axleNumber: 3,
-        brakes_brakeActuator: 1,
-        brakes_leverLength: 1,
-        brakes_springBrakeParking: true,
-        weights_gbWeight: 1,
-        weights_designWeight: 2,
-        weights_ladenWeight: 3,
-        weights_kerbWeight: 4,
-        tyres_tyreCode: 1,
-        tyres_tyreSize: '2',
-        tyres_plyRating: '3',
-        tyres_fitmentCode: 'single',
-        tyres_dataTrAxles: 1,
-        tyres_speedCategorySymbol: 'a7'
-      }
-    ];
+
     fixture.detectChanges();
   });
 

--- a/src/app/forms/custom-sections/tyres/tyres.component.spec.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.spec.ts
@@ -32,60 +32,7 @@ describe('TyresComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TyresComponent);
     component = fixture.componentInstance;
-    (component.vehicleTechRecord = mockVehicleTechnicalRecord('psv')),
-      (component.vehicleTechRecord.techRecord_axles = [
-        {
-          axleNumber: 1,
-          tyres_tyreSize: '295/80-22.5',
-          tyres_speedCategorySymbol: 'p',
-          tyres_fitmentCode: 'double',
-          tyres_dataTrAxles: 0,
-          tyres_plyRating: 'A',
-          tyres_tyreCode: 456,
-          parkingBrakeMrk: false,
-
-          weights_kerbWeight: 1,
-          weights_ladenWeight: 2,
-          weights_gbWeight: 3,
-          // TODO: V3 2 eecweights in type package, which is this?
-          // weights_eecWeight: 4,
-          weights_designWeight: 5
-        },
-        {
-          axleNumber: 2,
-          parkingBrakeMrk: true,
-
-          tyres_tyreSize: '295/80-22.5',
-          tyres_speedCategorySymbol: 'p',
-          tyres_fitmentCode: 'double',
-          tyres_dataTrAxles: 0,
-          tyres_plyRating: 'A',
-          tyres_tyreCode: 456,
-
-          weights_kerbWeight: 1,
-          weights_ladenWeight: 2,
-          weights_gbWeight: 3,
-          // weights_eecWeight: 4,
-          weights_designWeight: 5
-        },
-        {
-          axleNumber: 3,
-          parkingBrakeMrk: true,
-
-          tyres_tyreSize: '295/80-22.5',
-          tyres_speedCategorySymbol: 'p',
-          tyres_fitmentCode: 'double',
-          tyres_dataTrAxles: 0,
-          tyres_plyRating: 'A',
-          tyres_tyreCode: 456,
-
-          weights_kerbWeight: 1,
-          weights_ladenWeight: 2,
-          weights_gbWeight: 3,
-          // weights_eecWeight: 4,
-          weights_designWeight: 5
-        }
-      ]);
+    component.vehicleTechRecord = mockVehicleTechnicalRecord('psv');
 
     fixture.detectChanges();
     spy = jest.spyOn(component, 'addTyreToTechRecord');

--- a/src/mocks/hgv-record.mock.ts
+++ b/src/mocks/hgv-record.mock.ts
@@ -1,94 +1,83 @@
-import {
-  StatusCodes,
-  VehicleTypes,
-  FuelTypes,
-  VehicleConfigurations,
-  EuVehicleCategories,
-  approvalType
-} from '../app/models/vehicle-tech-record.model';
+import { HGVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
-import { createMock } from 'ts-auto-mock';
 import { BodyTypeDescription } from '@models/body-type-enum';
-import { HGVAxles, HGVPlates, PlateReasonForIssue, VehicleClassDescription } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
+import { EuVehicleCategories, FuelTypes, StatusCodes, VehicleConfigurations, approvalType } from '../app/models/vehicle-tech-record.model';
 
-export const createMockHgv = (systemNumber: number): TechRecordType<'hgv'> =>
-  createMock<TechRecordType<'hgv'>>({
-    systemNumber: `HGV`,
-    vin: `XMGDE03FS0H0${12344 + systemNumber + 1}`,
-    primaryVrm: `KP${String(systemNumber + 1).padStart(2, '0')} ABC`,
-    secondaryVrms: null,
-    createdTimestamp: new Date().toISOString(),
-    techRecord_createdAt: new Date().toISOString() as string,
-    techRecord_createdByName: 'Nathan',
-    techRecord_statusCode: StatusCodes.CURRENT,
-    techRecord_vehicleType: 'hgv',
-    techRecord_regnDate: '1234',
-    techRecord_manufactureYear: 2022,
-    techRecord_noOfAxles: 2,
-    techRecord_brakes_dtpNumber: '1234',
-    techRecord_speedLimiterMrk: true,
-    techRecord_tachoExemptMrk: true,
-    techRecord_euroStandard: '123',
-    techRecord_roadFriendly: true,
-    techRecord_fuelPropulsionSystem: FuelTypes.HYBRID,
-    techRecord_drawbarCouplingFitted: true,
-    techRecord_vehicleClass_description: 'heavy goods vehicle' as VehicleClassDescription,
-    techRecord_vehicleClass_code: '1',
-    techRecord_vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-    techRecord_offRoad: true,
-    techRecord_euVehicleCategory: EuVehicleCategories.M1,
-    techRecord_emissionsLimit: 1234,
-    techRecord_departmentalVehicleMarker: true,
-    techRecord_reasonForCreation: 'Brake Failure',
-    techRecord_approvalType: approvalType.ECSSTA,
-    techRecord_approvalTypeNumber: 'approval123',
-    techRecord_axles: undefined,
-    techRecord_ntaNumber: 'nta789',
-    techRecord_variantNumber: 'variant123456',
-    techRecord_variantVersionNumber: 'variantversion123456',
-    techRecord_dimensions_length: 1,
-    techRecord_dimensions_width: 2,
-    techRecord_frontAxleToRearAxle: 3,
-    techRecord_frontVehicleTo5thWheelCouplingMin: 5,
-    techRecord_frontVehicleTo5thWheelCouplingMax: 6,
-    techRecord_frontAxleTo5thWheelMin: 7,
-    techRecord_frontAxleTo5thWheelMax: 8,
-    techRecord_plates: undefined,
-    techRecord_make: '1234',
-    techRecord_model: '1234',
-    techRecord_bodyType_description: BodyTypeDescription.OTHER,
-    techRecord_functionCode: '1',
-    techRecord_conversionRefNo: '1234',
-    techRecord_grossGbWeight: 2,
-    techRecord_grossEecWeight: 4,
-    techRecord_grossDesignWeight: 3,
-    techRecord_trainGbWeight: 3,
-    techRecord_trainEecWeight: 3,
-    techRecord_trainDesignWeight: 7
-  });
+export const createMockHgv = (systemNumber: number): TechRecordType<'hgv'> => ({
+  systemNumber: `HGV`,
+  vin: `XMGDE04FS0H0${12344 + systemNumber + 1}`,
+  primaryVrm: `KP${String(systemNumber + 1).padStart(2, '0')} ABC`,
+  secondaryVrms: ['secondVrm'],
+  createdTimestamp: new Date().toISOString(),
 
-// [
-//   {
-//     axleNumber: 1,
-//     parkingBrakeMrk: false
-//   } as HGVAxles,
-//   {
-//     axleNumber: 2,
-//     parkingBrakeMrk: true
-//   } as HGVAxles
-// ];
-
-// [
-//   {
-//     plateSerialNumber: '12345',
-//     plateIssueDate: new Date().toISOString() as string,
-//     reasonForIssue: "Replacement" as PlateReasonForIssue,
-//     plateIssuer: 'person'
-//   } as HGVPlates,
-//   {
-//     plateSerialNumber: '54321',
-//     plateIssueDate: new Date().toISOString() as string,
-//     reasonForIssue: "Replacement" as PlateReasonForIssue,
-//     plateIssuer: 'person 2'
-//   } as HGVPlates
-// ]
+  techRecord_createdAt: new Date().toISOString(),
+  techRecord_createdById: 'NathanId',
+  techRecord_createdByName: 'Nathan',
+  techRecord_reasonForCreation: 'Brake Failure',
+  techRecord_statusCode: StatusCodes.CURRENT,
+  techRecord_vehicleType: 'hgv',
+  techRecord_regnDate: '1234',
+  techRecord_manufactureYear: 2022,
+  techRecord_noOfAxles: 2,
+  techRecord_brakes_dtpNumber: '1234',
+  techRecord_speedLimiterMrk: true,
+  techRecord_tachoExemptMrk: true,
+  techRecord_euroStandard: '123',
+  techRecord_roadFriendly: true,
+  techRecord_fuelPropulsionSystem: FuelTypes.HYBRID,
+  techRecord_drawbarCouplingFitted: true,
+  techRecord_vehicleClass_description: 'heavy goods vehicle',
+  techRecord_vehicleClass_code: '1',
+  techRecord_vehicleConfiguration: VehicleConfigurations.ARTICULATED,
+  techRecord_offRoad: true,
+  techRecord_euVehicleCategory: EuVehicleCategories.M1,
+  techRecord_emissionsLimit: 1234,
+  techRecord_departmentalVehicleMarker: true,
+  techRecord_approvalType: approvalType.ECSSTA,
+  techRecord_approvalTypeNumber: 'approval123',
+  techRecord_ntaNumber: 'nta789',
+  techRecord_variantNumber: 'variant123456',
+  techRecord_variantVersionNumber: 'variantversion123456',
+  techRecord_dimensions_length: 1,
+  techRecord_dimensions_width: 2,
+  techRecord_frontAxleToRearAxle: 3,
+  techRecord_frontVehicleTo5thWheelCouplingMin: 5,
+  techRecord_frontVehicleTo5thWheelCouplingMax: 6,
+  techRecord_frontAxleTo5thWheelMin: 7,
+  techRecord_frontAxleTo5thWheelMax: 8,
+  techRecord_make: '1234',
+  techRecord_model: '1234',
+  techRecord_bodyType_description: BodyTypeDescription.OTHER,
+  techRecord_functionCode: '1',
+  techRecord_conversionRefNo: '1234',
+  techRecord_grossGbWeight: 2,
+  techRecord_grossEecWeight: 4,
+  techRecord_grossDesignWeight: 3,
+  techRecord_trainGbWeight: 3,
+  techRecord_trainEecWeight: 3,
+  techRecord_trainDesignWeight: 7,
+  techRecord_axles: [
+    {
+      axleNumber: 1,
+      parkingBrakeMrk: false
+    } as HGVAxles,
+    {
+      axleNumber: 2,
+      parkingBrakeMrk: true
+    } as HGVAxles
+  ],
+  techRecord_plates: [
+    {
+      plateSerialNumber: '12345',
+      plateIssueDate: new Date().toISOString() as string,
+      plateReasonForIssue: 'Replacement',
+      plateIssuer: 'person'
+    },
+    {
+      plateSerialNumber: '54321',
+      plateIssueDate: new Date().toISOString() as string,
+      plateReasonForIssue: 'Replacement',
+      plateIssuer: 'person 2'
+    }
+  ]
+});

--- a/src/mocks/psv-record.mock.ts
+++ b/src/mocks/psv-record.mock.ts
@@ -1,4 +1,3 @@
-import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { BodyTypeDescription } from '@models/body-type-enum';
 import {
@@ -15,7 +14,7 @@ export const createMockPsv = (systemNumber: number): TechRecordType<'psv'> => ({
   systemNumber: `PSV`,
   vin: `XMGDE02FS0H0${12344 + systemNumber + 1}`,
   primaryVrm: `KP01ABC`,
-  secondaryVrms: undefined,
+  secondaryVrms: ['secondaryVrm'],
   createdTimestamp: 'now',
   techRecord_createdAt: new Date().toISOString() as string,
   techRecord_createdByName: 'Nathan',
@@ -23,7 +22,6 @@ export const createMockPsv = (systemNumber: number): TechRecordType<'psv'> => ({
   techRecord_vehicleType: 'psv',
   techRecord_regnDate: '1234',
   techRecord_manufactureYear: 2022,
-  techRecord_axles: axles as unknown as PSVAxles[],
   techRecord_noOfAxles: 2,
   techRecord_brakes_dtpNumber: '1234',
   techRecord_brakes_brakeCode: '1234',
@@ -80,9 +78,9 @@ export const createMockPsv = (systemNumber: number): TechRecordType<'psv'> => ({
   techRecord_applicantDetails_telephoneNumber: '0121',
   techRecord_applicantDetails_emailAddress: 'test@email.com',
 
-  //techRecord_microfilmDocumentType: 'AAT - Trailer Annual Test',
-  //techRecord_microfilmRollNumber: 'nb123456',
-  //techRecord_microfilmSerialNumber: 'ser123456',
+  techRecord_microfilm_microfilmDocumentType: 'AAT - Trailer Annual Test',
+  techRecord_microfilm_microfilmRollNumber: 'nb123456',
+  techRecord_microfilm_microfilmSerialNumber: 'ser123456',
   techRecord_remarks: 'Some notes about the vehicle',
   techRecord_dispensations: 'reason given',
   techRecord_reasonForCreation: 'Brake Failure',
@@ -99,8 +97,7 @@ export const createMockPsv = (systemNumber: number): TechRecordType<'psv'> => ({
   techRecord_grossKerbWeight: 1,
   techRecord_grossLadenWeight: 2,
   techRecord_grossGbWeight: 3,
-  // TODO: missing from types package
-  // techRecord_grossEecWeight: 4,
+
   techRecord_grossDesignWeight: 5,
   techRecord_unladenWeight: 6,
 
@@ -118,10 +115,59 @@ export const createMockPsv = (systemNumber: number): TechRecordType<'psv'> => ({
   techRecord_dda_outswing: 'Anderson',
   techRecord_dda_ddaSchedules: 'dda',
   techRecord_dda_seatbeltsFitted: 51,
-  techRecord_dda_ddaNotes: 'This is a note'
+  techRecord_dda_ddaNotes: 'This is a note',
+  techRecord_axles: [
+    {
+      axleNumber: 1,
+      tyres_tyreSize: '295/80-22.5',
+      tyres_speedCategorySymbol: 'p',
+      tyres_fitmentCode: 'double',
+      tyres_dataTrAxles: 0,
+      tyres_plyRating: 'A',
+      tyres_tyreCode: 456,
+      parkingBrakeMrk: false,
+
+      weights_kerbWeight: 1,
+      weights_ladenWeight: 2,
+      weights_gbWeight: 3,
+      weights_designWeight: 5
+    },
+    {
+      axleNumber: 2,
+      parkingBrakeMrk: true,
+
+      tyres_tyreSize: '295/80-22.5',
+      tyres_speedCategorySymbol: 'p',
+      tyres_fitmentCode: 'double',
+      tyres_dataTrAxles: 0,
+      tyres_plyRating: 'A',
+      tyres_tyreCode: 456,
+
+      weights_kerbWeight: 1,
+      weights_ladenWeight: 2,
+      weights_gbWeight: 3,
+      weights_designWeight: 5
+    },
+    {
+      axleNumber: 3,
+      parkingBrakeMrk: true,
+
+      tyres_tyreSize: '295/80-22.5',
+      tyres_speedCategorySymbol: 'p',
+      tyres_fitmentCode: 'double',
+      tyres_dataTrAxles: 0,
+      tyres_plyRating: 'A',
+      tyres_tyreCode: 456,
+
+      weights_kerbWeight: 1,
+      weights_ladenWeight: 2,
+      weights_gbWeight: 3,
+      weights_designWeight: 5
+    }
+  ]
 });
 
-const axles: Array<any> = [
+[
   {
     axleNumber: 1,
     tyres_tyreSize: '295/80-22.5',
@@ -130,7 +176,7 @@ const axles: Array<any> = [
     tyres_dataTrAxles: 0,
     tyres_plyRating: 'A',
     tyres_tyreCode: 456,
-    parkingBrakeMrk: 'false',
+    parkingBrakeMrk: false,
 
     weights_kerbWeight: 1,
     weights_ladenWeight: 2,
@@ -141,7 +187,7 @@ const axles: Array<any> = [
   },
   {
     axleNumber: 2,
-    parkingBrakeMrk: 'true',
+    parkingBrakeMrk: true,
 
     tyres_tyreSize: '295/80-22.5',
     tyres_speedCategorySymbol: 'p',
@@ -158,7 +204,7 @@ const axles: Array<any> = [
   },
   {
     axleNumber: 3,
-    parkingBrakeMrk: 'true',
+    parkingBrakeMrk: true,
 
     tyres_tyreSize: '295/80-22.5',
     tyres_speedCategorySymbol: 'p',
@@ -174,486 +220,3 @@ const axles: Array<any> = [
     weights_designWeight: 5
   }
 ];
-
-// const provisionalTechRecord = {
-//   createdAt: new Date(),
-//   createdByName: 'Nathan',
-//   statusCode: StatusCodes.PROVISIONAL,
-//   vehicleType: VehicleTypes.PSV,
-//   regnDate: '1234',
-//   manufactureYear: 2022,
-//   noOfAxles: 2,
-//   brakes: {
-//     dtpNumber: '1234',
-//     brakeCode: '1234',
-//     dataTrBrakeOne: '12',
-//     dataTrBrakeTwo: '34',
-//     dataTrBrakeThree: '56',
-//     retarderBrakeOne: Retarders.ELECTRIC,
-//     retarderBrakeTwo: Retarders.ELECTRIC,
-//     brakeForceWheelsNotLocked: {
-//       parkingBrakeForceA: 1234,
-//       secondaryBrakeForceA: 1234,
-//       serviceBrakeForceA: 1234
-//     },
-//     brakeForceWheelsUpToHalfLocked: {
-//       parkingBrakeForceB: 1234,
-//       secondaryBrakeForceB: 1234,
-//       serviceBrakeForceB: 1234
-//     }
-//   },
-//   axles: [
-//     {
-//       axleNumber: 1,
-//       tyres: {
-//         tyreSize: '295/80-22.5',
-//         speedCategorySymbol: SpeedCategorySymbol.P,
-//         fitmentCode: FitmentCode.DOUBLE,
-//         dataTrAxles: 0,
-//         plyRating: 'A',
-//         tyreCode: 456
-//       },
-//       parkingBrakeMrk: false,
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     },
-//     {
-//       axleNumber: 2,
-//       parkingBrakeMrk: true,
-//       tyres: {
-//         tyreSize: '295/80-22.5',
-//         speedCategorySymbol: SpeedCategorySymbol.P,
-//         fitmentCode: FitmentCode.DOUBLE,
-//         dataTrAxles: 0,
-//         plyRating: 'A',
-//         tyreCode: 456
-//       },
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     },
-//     {
-//       axleNumber: 3,
-//       parkingBrakeMrk: true,
-//       tyres: {
-//         tyreSize: '295/80-22.5',
-//         speedCategorySymbol: SpeedCategorySymbol.P,
-//         fitmentCode: FitmentCode.DOUBLE,
-//         dataTrAxles: 0,
-//         plyRating: 'A',
-//         tyreCode: 456
-//       },
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     }
-//   ],
-//   speedLimiterMrk: true,
-//   speedRestriction: 54,
-//   tachoExemptMrk: true,
-//   euroStandard: '123',
-//   fuelPropulsionSystem: FuelTypes.HYBRID,
-//   vehicleClass: {
-//     description: 'Description',
-//     code: '1'
-//   },
-//   vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-//   euVehicleCategory: EuVehicleCategories.M1,
-//   emissionsLimit: 1234,
-//   seatsLowerDeck: 1234,
-//   seatsUpperDeck: 1234,
-//   standingCapacity: 1234,
-//   vehicleSize: VehicleSizes.SMALL,
-//   numberOfSeatbelts: '1234',
-//   seatbeltInstallationApprovalDate: '1234',
-//   departmentalVehicleMarker: true,
-//   dimensions: {
-//     height: 30000,
-//     length: 25000,
-//     width: 10000
-//   },
-//   frontAxleToRearAxle: 5000,
-//   approvalType: approvalType.ECSSTA,
-//   approvalTypeNumber: 'approval123',
-//   ntaNumber: 'nta789',
-//   coifSerialNumber: 'coifSerial123456',
-//   coifCertifierName: 'coifName',
-//   coifDate: new Date(),
-//   variantNumber: 'variant123456',
-//   variantVersionNumber: 'variantversion123456',
-//   applicantDetails: {
-//     name: 'Test',
-//     address1: 'address1',
-//     address2: 'address2',
-//     postTown: 'town',
-//     address3: 'address3',
-//     postCode: 'postCode',
-//     telephoneNumber: '0121',
-//     emailAddress: 'test@email.com'
-//   },
-//   microfilm: {
-//     microfilmDocumentType: MicrofilmDocumentType.AAT,
-//     microfilmRollNumber: 'nb123456',
-//     microfilmSerialNumber: 'ser123456'
-//   },
-//   remarks: 'Some notes about the vehicle',
-//   dispensations: 'reason given',
-//   reasonForCreation: 'Brake Failure',
-//   modelLiteral: 'Vehicle model',
-//   chassisMake: 'Chassis make',
-//   chassisModel: 'Chassis model',
-//   bodyMake: 'Body make',
-//   bodyModel: 'Body model',
-//   bodyType: {
-//     description: BodyTypeDescription.DOUBLE_DECKER
-//   },
-//   functionCode: 'r',
-//   conversionRefNo: '345345',
-
-//   // Gross vehicle weights
-//   grossKerbWeight: 1,
-//   grossLadenWeight: 2,
-//   grossGbWeight: 3,
-//   grossEecWeight: 4,
-//   grossDesignWeight: 5,
-//   unladenWeight: 6,
-
-//   // Train weights
-//   maxTrainGbWeight: 7,
-//   trainDesignWeight: 8,
-//   dda: {
-//     certificateIssued: true,
-//     wheelchairCapacity: 5,
-//     wheelchairFittings: 'data',
-//     wheelchairLiftPresent: false,
-//     wheelchairLiftInformation: 'more data',
-//     wheelchairRampPresent: true,
-//     wheelchairRampInformation: 'ramp data',
-//     minEmergencyExits: 3,
-//     outswing: 'Anderson',
-//     ddaSchedules: 'dda',
-//     seatbeltsFitted: 51,
-//     ddaNotes: 'This is a note'
-//   }
-// };
-
-// const archivedTechRecord = {
-//   createdAt: new Date(2018, 11),
-//   createdByName: 'Nathan',
-//   statusCode: StatusCodes.ARCHIVED,
-//   vehicleType: VehicleTypes.PSV,
-//   regnDate: '12345678',
-//   manufactureYear: 2022,
-//   noOfAxles: 2,
-//   brakes: {
-//     dtpNumber: '12345678',
-//     brakeCode: '1234',
-//     dataTrBrakeOne: '12',
-//     dataTrBrakeTwo: '34',
-//     dataTrBrakeThree: '56',
-//     retarderBrakeOne: Retarders.ELECTRIC,
-//     retarderBrakeTwo: Retarders.ELECTRIC,
-//     brakeForceWheelsNotLocked: {
-//       parkingBrakeForceA: 1234,
-//       secondaryBrakeForceA: 1234,
-//       serviceBrakeForceA: 1234
-//     },
-//     brakeForceWheelsUpToHalfLocked: {
-//       parkingBrakeForceB: 1234,
-//       secondaryBrakeForceB: 1234,
-//       serviceBrakeForceB: 1234
-//     }
-//   },
-//   axles: [
-//     {
-//       axleNumber: 1,
-//       parkingBrakeMrk: false,
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     },
-//     {
-//       axleNumber: 2,
-//       parkingBrakeMrk: true,
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     }
-//   ],
-//   speedLimiterMrk: true,
-//   tachoExemptMrk: true,
-//   euroStandard: '123',
-//   fuelPropulsionSystem: FuelTypes.HYBRID,
-//   vehicleClass: {
-//     description: 'Description',
-//     code: '2'
-//   },
-//   vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-//   euVehicleCategory: EuVehicleCategories.M1,
-//   emissionsLimit: 1234,
-//   seatsLowerDeck: 1234,
-//   seatsUpperDeck: 1234,
-//   standingCapacity: 1234,
-//   vehicleSize: VehicleSizes.SMALL,
-//   numberOfSeatbelts: '1234',
-//   seatbeltInstallationApprovalDate: '1234',
-//   departmentalVehicleMarker: true,
-//   dimensions: {
-//     height: 30000,
-//     length: 25000,
-//     width: 10000
-//   },
-//   frontAxleToRearAxle: 5000,
-//   approvalType: approvalType.ECSSTA,
-//   approvalTypeNumber: 'approval123',
-//   ntaNumber: 'nta789',
-//   coifSerialNumber: 'coifSerial123456',
-//   coifCertifierName: 'coifName',
-//   coifDate: new Date(),
-//   variantNumber: 'variant123456',
-//   variantVersionNumber: 'variantversion123456',
-//   applicantDetails: {
-//     name: 'Test',
-//     address1: 'address1',
-//     address2: 'address2',
-//     postTown: 'town',
-//     address3: 'address3',
-//     postCode: 'postCode',
-//     telephoneNumber: '0121',
-//     emailAddress: 'test@email.com'
-//   },
-//   microfilm: {
-//     microfilmDocumentType: MicrofilmDocumentType.AAT,
-//     microfilmRollNumber: 'nb123456',
-//     microfilmSerialNumber: 'ser123456'
-//   },
-//   remarks: 'Some notes about the vehicle',
-//   dispensations: 'reason given',
-//   reasonForCreation: 'COIF',
-//   modelLiteral: 'Vehicle model',
-//   chassisMake: 'Chassis make',
-//   chassisModel: 'Chassis model',
-//   bodyMake: 'Body make',
-//   bodyModel: 'Body model',
-//   bodyType: {
-//     description: BodyTypeDescription.DOUBLE_DECKER
-//   },
-//   functionCode: 'r',
-//   conversionRefNo: '345345',
-
-//   // Gross vehicle weights
-//   grossKerbWeight: 1,
-//   grossLadenWeight: 2,
-//   grossGbWeight: 3,
-//   grossEecWeight: 4,
-//   grossDesignWeight: 5,
-//   unladenWeight: 6,
-
-//   // Train weights
-//   maxTrainGbWeight: 7,
-//   trainDesignWeight: 8
-// };
-
-// const currentTechRecord = {
-//   recordCompleteness: 'complete',
-//   createdAt: new Date(2019, 11),
-//   createdByName: 'Nathan',
-//   statusCode: StatusCodes.CURRENT,
-//   vehicleType: VehicleTypes.PSV,
-//   regnDate: '12345678',
-//   manufactureYear: 2022,
-//   noOfAxles: 2,
-//   brakes: {
-//     dtpNumber: '987654321',
-//     brakeCode: '1234',
-//     dataTrBrakeOne: '12',
-//     dataTrBrakeTwo: '34',
-//     dataTrBrakeThree: '56',
-//     retarderBrakeOne: Retarders.ELECTRIC,
-//     retarderBrakeTwo: Retarders.ELECTRIC,
-//     brakeForceWheelsNotLocked: {
-//       parkingBrakeForceA: 1234,
-//       secondaryBrakeForceA: 1234,
-//       serviceBrakeForceA: 1234
-//     },
-//     brakeForceWheelsUpToHalfLocked: {
-//       parkingBrakeForceB: 1234,
-//       secondaryBrakeForceB: 1234,
-//       serviceBrakeForceB: 1234
-//     }
-//   },
-//   axles: [
-//     {
-//       axleNumber: 1,
-//       parkingBrakeMrk: false,
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     },
-//     {
-//       axleNumber: 2,
-//       parkingBrakeMrk: true,
-//       weights: {
-//         kerbWeight: 1,
-//         ladenWeight: 2,
-//         gbWeight: 3,
-//         eecWeight: 4,
-//         designWeight: 5
-//       }
-//     }
-//   ],
-//   speedLimiterMrk: true,
-//   tachoExemptMrk: true,
-//   euroStandard: '123',
-//   fuelPropulsionSystem: FuelTypes.HYBRID,
-//   vehicleClass: {
-//     description: 'Description',
-//     code: '3'
-//   },
-//   vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-//   euVehicleCategory: EuVehicleCategories.M1,
-//   emissionsLimit: 1234,
-//   seatsLowerDeck: 1234,
-//   seatsUpperDeck: 1234,
-//   standingCapacity: 1234,
-//   vehicleSize: VehicleSizes.SMALL,
-//   numberOfSeatbelts: '1234',
-//   seatbeltInstallationApprovalDate: '1234',
-//   departmentalVehicleMarker: true,
-//   dimensions: {
-//     height: 30000,
-//     length: 25000,
-//     width: 10000
-//   },
-//   frontAxleToRearAxle: 5000,
-//   approvalType: approvalType.ECSSTA,
-//   approvalTypeNumber: 'approval123',
-//   ntaNumber: 'nta789',
-//   coifSerialNumber: 'coifSerial123456',
-//   coifCertifierName: 'coifName',
-//   coifDate: '1233-12-31',
-//   variantNumber: 'variant123456',
-//   variantVersionNumber: 'variantversion123456',
-//   applicantDetails: {
-//     name: 'Test',
-//     address1: 'address1',
-//     address2: 'address2',
-//     postTown: 'town',
-//     address3: 'address3',
-//     postCode: 'postCode',
-//     telephoneNumber: '0121',
-//     emailAddress: 'test@email.com'
-//   },
-//   microfilm: {
-//     microfilmDocumentType: MicrofilmDocumentType.AAT,
-//     microfilmRollNumber: 'nb123456',
-//     microfilmSerialNumber: 'ser123456'
-//   },
-//   remarks: 'Some notes about the vehicle',
-//   dispensations: 'reason given',
-//   reasonForCreation: 'COIF',
-//   modelLiteral: 'Vehicle model',
-//   chassisMake: 'Chassis make',
-//   chassisModel: 'Chassis model',
-//   bodyMake: 'Body make',
-//   bodyModel: 'Body model',
-//   bodyType: {
-//     description: BodyTypeDescription.DOUBLE_DECKER
-//   },
-//   functionCode: 'r',
-//   conversionRefNo: '345345',
-
-//   // Gross vehicle weights
-//   grossKerbWeight: 1,
-//   grossLadenWeight: 2,
-//   grossGbWeight: 3,
-//   grossEecWeight: 4,
-//   grossDesignWeight: 5,
-//   unladenWeight: 6,
-
-//   // Train weights
-//   maxTrainGbWeight: 7,
-//   trainDesignWeight: 8
-// };
-
-// original axles
-
-// [{
-//   axleNumber: 1,
-//   tyres_tyreSize: '295/80-22.5',
-//   tyres_speedCategorySymbol: 'p',
-//   tyres_fitmentCode: 'double',
-//   tyres_dataTrAxles: 0,
-//   tyres_plyRating: 'A',
-//   tyres_tyreCode: 456,
-//   parkingBrakeMrk: false,
-
-//   weights_kerbWeight: 1,
-//   weights_ladenWeight: 2,
-//   weights_gbWeight: 3,
-//   // TODO: V3 2 eecweights in type package, which is this?
-//   // weights_eecWeight: 4,
-//   weights_designWeight: 5,
-// },
-// {
-//   axleNumber: 2,
-//   parkingBrakeMrk: true,
-
-//   tyres_tyreSize: '295/80-22.5',
-//   tyres_speedCategorySymbol: 'p',
-//   tyres_fitmentCode: 'double',
-//   tyres_dataTrAxles: 0,
-//   tyres_plyRating: 'A',
-//   tyres_tyreCode: 456,
-
-//   weights_kerbWeight: 1,
-//   weights_ladenWeight: 2,
-//   weights_gbWeight: 3,
-//   // weights_eecWeight: 4,
-//   weights_designWeight: 5
-
-// },
-// {
-//   axleNumber: 3,
-//   parkingBrakeMrk: true,
-
-//   tyres_tyreSize: '295/80-22.5',
-//   tyres_speedCategorySymbol: 'p',
-//   tyres_fitmentCode: 'double',
-//   tyres_dataTrAxles: 0,
-//   tyres_plyRating: 'A',
-//   tyres_tyreCode: 456,
-
-//   weights_kerbWeight: 1,
-//   weights_ladenWeight: 2,
-//   weights_gbWeight: 3,
-//   // weights_eecWeight: 4,
-//   weights_designWeight: 5
-
-// }
-// ]

--- a/src/mocks/trl-record.mock.ts
+++ b/src/mocks/trl-record.mock.ts
@@ -1,71 +1,100 @@
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
-import {
-  StatusCodes,
-  VehicleTypes,
-  VehicleConfigurations,
-  FrameDescriptions,
-  EuVehicleCategories,
-  approvalType
-} from '../app/models/vehicle-tech-record.model';
-import { createMock } from 'ts-auto-mock';
+import { EuVehicleCategories, FrameDescriptions, StatusCodes, VehicleConfigurations, approvalType } from '../app/models/vehicle-tech-record.model';
 
-export const createMockTrl = (systemNumber: number): TechRecordType<'trl'> =>
-  createMock<TechRecordType<'trl'>>({
-    systemNumber: `TRL`,
-    vin: `XMGDE04FS0H0${12344 + systemNumber + 1}`,
-    trailerId: 'TestId',
-    techRecord_createdAt: new Date().toISOString(),
-    techRecord_createdByName: 'Nathan',
-    techRecord_statusCode: StatusCodes.CURRENT,
-    techRecord_vehicleType: 'trl',
-    techRecord_regnDate: '1234',
-    techRecord_firstUseDate: '1234',
-    //techRecord_manufactureYear: '2022',
-    techRecord_noOfAxles: 2,
-    techRecord_brakes_dtpNumber: '1234',
-    techRecord_brakes_loadSensingValve: true,
-    techRecord_brakes_antilockBrakingSystem: true,
-    techRecord_axles: undefined,
-    // TODO: V3 height missing from types package
-    // techRecord_dimensions_height: 30000,
-    techRecord_dimensions_length: 25000,
-    techRecord_dimensions_width: 10000,
-    techRecord_suspensionType: '1',
-    techRecord_roadFriendly: true,
-    //techRecord_drawbarCouplingFitted: true,
+export const createMockTrl = (systemNumber: number): TechRecordType<'trl'> => ({
+  systemNumber: `TRL`,
+  vin: `XMGDE04FS0H0${12344 + systemNumber + 1}`,
+  trailerId: 'TestId',
+  techRecord_createdAt: new Date().toISOString(),
+  techRecord_createdByName: 'Nathan',
+  techRecord_statusCode: StatusCodes.CURRENT,
+  techRecord_vehicleType: 'trl',
+  techRecord_regnDate: '1234',
+  techRecord_firstUseDate: '1234',
+  techRecord_manufactureYear: 2022,
+  techRecord_noOfAxles: 2,
+  techRecord_brakes_dtpNumber: '1234',
+  techRecord_brakes_loadSensingValve: true,
+  techRecord_brakes_antilockBrakingSystem: true,
 
-    techRecord_vehicleClass_description: 'trailer',
-    techRecord_vehicleClass_code: '1',
-    techRecord_vehicleConfiguration: VehicleConfigurations.ARTICULATED,
-    techRecord_couplingType: '1',
-    techRecord_maxLoadOnCoupling: 1234,
-    techRecord_frameDescription: FrameDescriptions.FRAME_SECTION,
-    techRecord_euVehicleCategory: EuVehicleCategories.M1,
-    techRecord_departmentalVehicleMarker: true,
-    techRecord_reasonForCreation: 'Brake Failure',
-    techRecord_approvalType: approvalType.ECSSTA,
-    techRecord_approvalTypeNumber: 'approval123',
-    techRecord_ntaNumber: 'nta789',
-    techRecord_variantNumber: 'variant123456',
-    techRecord_variantVersionNumber: 'variantversion123456',
-    techRecord_plates: undefined
-  });
-// Axels array
-// [
-//   {
-//     parkingBrakeMrk: false
-//   },
-//   {
-//     parkingBrakeMrk: true
-//   }
-// ]
+  techRecord_dimensions_length: 25000,
+  techRecord_dimensions_width: 10000,
+  techRecord_suspensionType: '1',
+  techRecord_roadFriendly: true,
 
-// plates array:
-// [
-//   {
-//     plateSerialNumber: '12345',
-//     plateIssueDate: new Date().toISOString(),
-//     reasonForIssue: 'Replacement',
-//     plateIssuer: 'person'
-//   }
-// ]
+  techRecord_vehicleClass_description: 'trailer',
+  techRecord_vehicleClass_code: '1',
+  techRecord_vehicleConfiguration: VehicleConfigurations.ARTICULATED,
+  techRecord_couplingType: '1',
+  techRecord_maxLoadOnCoupling: 1234,
+  techRecord_frameDescription: FrameDescriptions.FRAME_SECTION,
+  techRecord_euVehicleCategory: EuVehicleCategories.M1,
+  techRecord_departmentalVehicleMarker: true,
+  techRecord_reasonForCreation: 'Brake Failure',
+  techRecord_approvalType: approvalType.ECSSTA,
+  techRecord_approvalTypeNumber: 'approval123',
+  techRecord_ntaNumber: 'nta789',
+  techRecord_variantNumber: 'variant123456',
+  techRecord_variantVersionNumber: 'variantversion123456',
+  techRecord_plates: [
+    {
+      plateSerialNumber: '12345',
+      plateIssueDate: new Date().toISOString(),
+      plateReasonForIssue: 'Replacement',
+      plateIssuer: 'person'
+    }
+  ],
+  techRecord_axles: [
+    {
+      parkingBrakeMrk: true,
+      axleNumber: 1,
+      brakes_brakeActuator: 1,
+      brakes_leverLength: 1,
+      brakes_springBrakeParking: true,
+      weights_gbWeight: 1,
+      weights_designWeight: 2,
+      weights_ladenWeight: 3,
+      weights_kerbWeight: 4,
+      tyres_tyreCode: 1,
+      tyres_tyreSize: '2',
+      tyres_plyRating: '3',
+      tyres_fitmentCode: 'single',
+      tyres_dataTrAxles: 1,
+      tyres_speedCategorySymbol: 'a7'
+    },
+    {
+      parkingBrakeMrk: true,
+      axleNumber: 2,
+      brakes_brakeActuator: 1,
+      brakes_leverLength: 1,
+      brakes_springBrakeParking: false,
+      weights_gbWeight: 1,
+      weights_designWeight: 2,
+      weights_ladenWeight: 3,
+      weights_kerbWeight: 4,
+      tyres_tyreCode: 1,
+      tyres_tyreSize: '2',
+      tyres_plyRating: '3',
+      tyres_fitmentCode: 'single',
+      tyres_dataTrAxles: 1,
+      tyres_speedCategorySymbol: 'a7'
+    },
+    {
+      parkingBrakeMrk: false,
+      axleNumber: 3,
+      brakes_brakeActuator: 1,
+      brakes_leverLength: 1,
+      brakes_springBrakeParking: true,
+      weights_gbWeight: 1,
+      weights_designWeight: 2,
+      weights_ladenWeight: 3,
+      weights_kerbWeight: 4,
+      tyres_tyreCode: 1,
+      tyres_tyreSize: '2',
+      tyres_plyRating: '3',
+      tyres_fitmentCode: 'single',
+      tyres_dataTrAxles: 1,
+      tyres_speedCategorySymbol: 'a7'
+    }
+  ]
+});


### PR DESCRIPTION
Chore: refactoring the createMock functions so they only include fields relevant to the vehicle type.

Also removed some of the mock objects used previously as they only had 3 fields and weren't ideal

