### PR TITLE
fix(cb2-8968): adds psv brakeCode fix to root of the techRecord

### DIFF
--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
@@ -57,6 +57,7 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
       .subscribe(([selectedBrake, event]) => {
         // Set the brake details automatically based selection
         if (selectedBrake && event?.techRecord_brakes_brakeCodeOriginal) {
+          event.techRecord_brakeCode = `${this.brakeCodePrefix}${selectedBrake.resourceKey}`;
           event.techRecord_brakes_brakeCode = `${this.brakeCodePrefix}${selectedBrake.resourceKey}`;
           event.techRecord_brakes_dataTrBrakeOne = selectedBrake.service;
           event.techRecord_brakes_dataTrBrakeTwo = selectedBrake.secondary;


### PR DESCRIPTION
Adds the updated brakeCode to the root of the `techRecord`, as well as within the `brakes` object.

Related to the previous fix: [CB2-8968](https://dvsa.atlassian.net/browse/CB2-8968)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [X] Delete branch after merge
