### PR TITLE
fix(cb2-8806): updating hidden in vta on small trl removes number of axles

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.spec.ts
@@ -13,6 +13,7 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { SharedModule } from '@shared/shared.module';
 import { initialAppState } from '@store/index';
+import { selectRouteNestedParams } from '@store/router/selectors/router.selectors';
 import { updateTechRecord, updateTechRecordSuccess } from '@store/technical-records';
 import { of, ReplaySubject } from 'rxjs';
 import { AmendVinComponent } from './tech-record-amend-vin.component';
@@ -79,19 +80,16 @@ describe('TechRecordChangeVrmComponent', () => {
       component.techRecord = expectedTechRecord;
     });
     it('should dispatch the updateTechRecord action with the new vin', () => {
+      const createdTimestamp = '2022';
+      const systemNumber = '123456';
+      store.overrideSelector(selectRouteNestedParams, { createdTimestamp, systemNumber });
       const dispatchSpy = jest.spyOn(store, 'dispatch');
-      const payload = {
-        systemNumber: 'foo',
-        createdTimestamp: 'bar',
-        vin: 'myNewVin',
-        techRecord_reasonForCreation: 'Vin changed'
-      } as unknown as TechRecordType<'put'>;
 
       component.form.controls['vin'].setValue('myNewVin');
 
       component.handleSubmit();
 
-      expect(dispatchSpy).toHaveBeenCalledWith(updateTechRecord({ vehicleTechRecord: payload }));
+      expect(dispatchSpy).toHaveBeenCalledWith(updateTechRecord({ systemNumber, createdTimestamp }));
     });
   });
 

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, OnDestroy, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
@@ -13,13 +14,13 @@ import { WeightsComponent } from '@forms/custom-sections/weights/weights.compone
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormArray, CustomFormGroup, FormNode } from '@forms/services/dynamic-form.types';
 import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
-import { V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { ReasonForEditing, StatusCodes, V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { AxlesService } from '@services/axles/axles.service';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { RouterService } from '@services/router/router.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { cloneDeep, mergeWith } from 'lodash';
-import { Observable, Subject, map, takeUntil } from 'rxjs';
+import { Observable, Subject, map, take, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-tech-record-summary',
@@ -52,7 +53,8 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     private errorService: GlobalErrorService,
     private referenceDataService: ReferenceDataService,
     private technicalRecordService: TechnicalRecordService,
-    private routerService: RouterService
+    private routerService: RouterService,
+    private activatedRoute: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
@@ -64,7 +66,12 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
           }
           const techRecord = cloneDeep(record);
 
-          if (techRecord.techRecord_vehicleType === VehicleTypes.HGV || techRecord.techRecord_vehicleType === VehicleTypes.TRL) {
+          if (
+            techRecord.techRecord_vehicleType === VehicleTypes.HGV ||
+            (techRecord.techRecord_vehicleType === VehicleTypes.TRL &&
+              techRecord.techRecord_euVehicleCategory !== 'o1' &&
+              techRecord.techRecord_euVehicleCategory !== 'o2')
+          ) {
             const [axles, axleSpacing] = this.axlesService.normaliseAxles(
               techRecord.techRecord_axles ?? [],
               techRecord.techRecord_dimensions_axleSpacing
@@ -85,6 +92,18 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
         this.middleIndex = Math.floor(this.sectionTemplates.length / 2);
       });
     this.isEditing && this.technicalRecordService.clearReasonForCreation();
+
+    const editingReason = this.activatedRoute.snapshot.data['reason'];
+    if (this.isEditing && editingReason === ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED) {
+      this.technicalRecordService.techRecord$.pipe(takeUntil(this.destroy$), take(1)).subscribe(techRecord => {
+        if (techRecord) {
+          this.technicalRecordService.updateEditingTechRecord({
+            ...(techRecord as TechRecordType<'put'>),
+            techRecord_statusCode: StatusCodes.PROVISIONAL
+          });
+        }
+      });
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.spec.ts
@@ -1,15 +1,13 @@
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ApiModule } from '@api/test-results';
-import { TechRecordSearchSchema } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/search';
-import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { MultiOptionsService } from '@forms/services/multi-options.service';
-import { ReasonForEditing, StatusCodes, TechRecordModel, V3TechRecordModel } from '@models/vehicle-tech-record.model';
+import { StatusCodes, TechRecordModel, V3TechRecordModel } from '@models/vehicle-tech-record.model';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -17,7 +15,6 @@ import { TechnicalRecordService } from '@services/technical-record/technical-rec
 import { UserService } from '@services/user-service/user-service';
 import { SharedModule } from '@shared/shared.module';
 import { initialAppState, State } from '@store/index';
-import { updateTechRecord } from '@store/technical-records';
 import { of } from 'rxjs';
 import { EditTechRecordButtonComponent } from '../edit-tech-record-button/edit-tech-record-button.component';
 import { TechRecordHistoryComponent } from '../tech-record-history/tech-record-history.component';
@@ -100,56 +97,5 @@ describe('VehicleTechnicalRecordComponent', () => {
   it('should create', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
-  });
-
-  describe('handleSubmit', () => {
-    describe('correcting an error', () => {
-      beforeEach(() => {
-        component.editingReason = ReasonForEditing.CORRECTING_AN_ERROR;
-        fixture.detectChanges();
-        component.summary = TestBed.createComponent(TechRecordSummaryStubComponent).componentInstance as TechRecordSummaryComponent;
-        techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel;
-      });
-      it('should update the current for a valid form', fakeAsync(() => {
-        const storeSpy = jest.spyOn(store, 'select').mockReturnValue(of(techRecord));
-
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        tick();
-        component.handleSubmit();
-        expect(dispatchSpy).toHaveBeenCalledWith(updateTechRecord({ vehicleTechRecord: techRecord as TechRecordType<'put'> }));
-      }));
-    });
-    describe('notifiable alteration', () => {
-      beforeEach(() => {
-        component.editingReason = ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED;
-        fixture.detectChanges();
-        component.summary = TestBed.createComponent(TechRecordSummaryStubComponent).componentInstance as TechRecordSummaryComponent;
-        techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as V3TechRecordModel;
-      });
-      it('should dispatch updateTechRecords with editingTechRecord unchanged', fakeAsync(() => {
-        const storeSpy = jest.spyOn(store, 'select').mockReturnValue(of(techRecord));
-        component.recordHistory = [
-          { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_statusCode: StatusCodes.PROVISIONAL }
-        ] as TechRecordSearchSchema[];
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-        tick();
-        component.ngOnInit();
-        component.handleSubmit();
-        expect(dispatchSpy).toHaveBeenCalledWith(updateTechRecord({ vehicleTechRecord: techRecord as TechRecordType<'put'> }));
-      }));
-      it('should dispatch updateTechRecords to create a new provisional when one isnt present', fakeAsync(() => {
-        const storeSpy = jest.spyOn(store, 'select').mockReturnValue(of(techRecord));
-        component.recordHistory = [
-          { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin', techRecord_statusCode: StatusCodes.ARCHIVED }
-        ] as TechRecordSearchSchema[];
-        const dispatchSpy = jest.spyOn(store, 'dispatch');
-
-        tick();
-        component.handleSubmit();
-        expect(dispatchSpy).toHaveBeenCalledWith(
-          updateTechRecord({ vehicleTechRecord: { ...techRecord, techRecord_statusCode: StatusCodes.PROVISIONAL } as TechRecordType<'put'> })
-        );
-      }));
-    });
   });
 });

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -10,12 +10,13 @@ import { TestResultModel } from '@models/test-results/test-result.model';
 import { ReasonForEditing, StatusCodes, TechRecordModel, V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
+import { RouterService } from '@services/router/router.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { UserService } from '@services/user-service/user-service';
 import { editingTechRecord, updateTechRecord, updateTechRecordSuccess } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
-import { Observable, Subject, take, takeUntil } from 'rxjs';
+import { Observable, Subject, take, takeUntil, withLatestFrom } from 'rxjs';
 import { TechRecordSummaryComponent } from '../tech-record-summary/tech-record-summary.component';
 
 @Component({
@@ -30,7 +31,6 @@ export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
   testResults$: Observable<TestResultModel[]>;
   editingReason?: ReasonForEditing;
   recordHistory?: TechRecordSearchSchema[];
-  hasAProvisional: Boolean = false;
 
   isCurrent = false;
   isArchived = false;
@@ -51,7 +51,8 @@ export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
     private store: Store<TechnicalRecordServiceState>,
     private technicalRecordService: TechnicalRecordService,
     private actions$: Actions,
-    private viewportScroller: ViewportScroller
+    private viewportScroller: ViewportScroller,
+    private routerService: RouterService
   ) {
     this.testResults$ = testRecordService.testRecords$;
     this.isEditing = this.activatedRoute.snapshot.data['isEditing'] ?? false;
@@ -62,9 +63,6 @@ export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
   ngOnInit(): void {
-    this.hasAProvisional = this.recordHistory?.some(record => record.techRecord_statusCode === StatusCodes.PROVISIONAL) ?? false;
-    const isProvisionalUrl = this.router.url?.split('/').slice(-2)?.includes(StatusCodes.PROVISIONAL);
-
     this.actions$.pipe(ofType(updateTechRecordSuccess), takeUntil(this.destroy$)).subscribe(vehicleTechRecord => {
       this.router.navigate([
         `/tech-records/${vehicleTechRecord.vehicleTechRecord.systemNumber}/${vehicleTechRecord.vehicleTechRecord.createdTimestamp}`
@@ -72,10 +70,6 @@ export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
     });
     this.isArchived = this.techRecord?.techRecord_statusCode === StatusCodes.ARCHIVED;
     this.isCurrent = this.techRecord?.techRecord_statusCode === StatusCodes.CURRENT;
-
-    if (isProvisionalUrl && !this.hasAProvisional) {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    }
 
     this.userService.roles$.pipe(take(1)).subscribe(storedRoles => {
       this.hasTestResultAmend = storedRoles?.some(role => {
@@ -160,16 +154,13 @@ export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
     if (!this.isInvalid) {
       this.store
         .select(editingTechRecord)
-        .pipe(take(1))
-        .subscribe(record => {
-          if (record) {
-            if (this.editingReason === ReasonForEditing.CORRECTING_AN_ERROR) {
-              this.store.dispatch(updateTechRecord({ vehicleTechRecord: record }));
-            } else if (this.editingReason === ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED) {
-              this.hasAProvisional
-                ? this.store.dispatch(updateTechRecord({ vehicleTechRecord: record }))
-                : this.store.dispatch(updateTechRecord({ vehicleTechRecord: { ...record, techRecord_statusCode: StatusCodes.PROVISIONAL } }));
-            }
+        .pipe(
+          take(1),
+          withLatestFrom(this.routerService.getRouteNestedParam$('systemNumber'), this.routerService.getRouteNestedParam$('createdTimestamp'))
+        )
+        .subscribe(([record, systemNumber, createdTimestamp]) => {
+          if (record && systemNumber && createdTimestamp) {
+            this.store.dispatch(updateTechRecord({ systemNumber, createdTimestamp }));
           }
         });
     }

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.spec.ts
@@ -4,8 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
-import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -130,8 +129,8 @@ describe('BatchVehicleTemplateComponent', () => {
       jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
 
       batchOfVehicles = [
-        { vin: 'EXAMPLEVIN000001', trailerIdOrVrm: '1000001', systemNumber: '1' },
-        { vin: 'EXAMPLEVIN000002', trailerIdOrVrm: '1000002', systemNumber: '2' }
+        { vin: 'EXAMPLEVIN000001', trailerIdOrVrm: '1000001', systemNumber: '1', createdTimestamp: 'foobar' },
+        { vin: 'EXAMPLEVIN000002', trailerIdOrVrm: '1000002', systemNumber: '2', createdTimestamp: '2022' }
       ];
       jest.spyOn(mockBatchTechRecordService, 'batchVehicles$', 'get').mockReturnValue(of(batchOfVehicles));
 
@@ -146,28 +145,16 @@ describe('BatchVehicleTemplateComponent', () => {
       expect(dispatchSpy).toHaveBeenNthCalledWith(
         1,
         updateTechRecord({
-          vehicleTechRecord: {
-            systemNumber: '1',
-            createdTimestamp: undefined,
-            techRecord_statusCode: StatusCodes.CURRENT,
-            trailerId: undefined,
-            primaryVrm: '1000001',
-            vin: 'EXAMPLEVIN000001'
-          } as unknown as TechRecordType<'put'>
+          systemNumber: '1',
+          createdTimestamp: 'foobar'
         })
       );
 
       expect(dispatchSpy).toHaveBeenNthCalledWith(
         2,
         updateTechRecord({
-          vehicleTechRecord: {
-            systemNumber: '2',
-            createdTimeStamp: undefined,
-            trailerId: undefined,
-            primaryVrm: '1000002',
-            techRecord_statusCode: StatusCodes.CURRENT,
-            vin: 'EXAMPLEVIN000002'
-          } as unknown as TechRecordType<'put'>
+          systemNumber: '2',
+          createdTimestamp: '2022'
         })
       );
     }));
@@ -176,9 +163,9 @@ describe('BatchVehicleTemplateComponent', () => {
       jest.spyOn(router, 'navigate').mockImplementation(() => Promise.resolve(true));
 
       batchOfVehicles = [
-        { vin: 'EXAMPLEVIN000001', trailerIdOrVrm: '1000001', systemNumber: '1' },
+        { vin: 'EXAMPLEVIN000001', trailerIdOrVrm: '1000001', systemNumber: '1', createdTimestamp: '2022' },
         { vin: 'EXAMPLEVIN000002' },
-        { vin: 'EXAMPLEVIN000003', trailerIdOrVrm: '1000002', systemNumber: '3' },
+        { vin: 'EXAMPLEVIN000003', trailerIdOrVrm: '1000002', systemNumber: '3', createdTimestamp: '2023' },
         { vin: 'EXAMPLEVIN000004' },
         { vin: 'EXAMPLEVIN000005' }
       ];
@@ -194,28 +181,16 @@ describe('BatchVehicleTemplateComponent', () => {
       expect(dispatchSpy).toHaveBeenNthCalledWith(
         1,
         updateTechRecord({
-          vehicleTechRecord: {
-            systemNumber: '1',
-            techRecord_statusCode: StatusCodes.CURRENT,
-            vin: 'EXAMPLEVIN000001',
-            trailerId: undefined,
-            primaryVrm: '1000001',
-            createdTimestamp: undefined
-          } as unknown as TechRecordType<'put'>
+          systemNumber: '1',
+          createdTimestamp: '2022'
         })
       );
       expect(dispatchSpy).toHaveBeenNthCalledWith(2, createVehicleRecord({ vehicle: expect.anything() }));
       expect(dispatchSpy).toHaveBeenNthCalledWith(
         3,
         updateTechRecord({
-          vehicleTechRecord: {
-            systemNumber: '3',
-            techRecord_statusCode: StatusCodes.CURRENT,
-            vin: 'EXAMPLEVIN000003',
-            trailerId: undefined,
-            primaryVrm: '1000002',
-            createdTimestamp: undefined
-          } as unknown as TechRecordType<'put'>
+          systemNumber: '3',
+          createdTimestamp: '2023'
         })
       );
       expect(dispatchSpy).toHaveBeenNthCalledWith(4, createVehicleRecord({ vehicle: expect.anything() }));

--- a/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
+++ b/src/app/features/tech-record/create-batch/components/batch-vehicle-template/batch-vehicle-template.component.ts
@@ -121,10 +121,11 @@ export class BatchVehicleTemplateComponent {
         )
         .subscribe(vehicleList => {
           vehicleList.forEach(vehicle => {
-            if (!(vehicle as TechRecordType<'get'>).systemNumber) {
+            if (!vehicle.systemNumber) {
               this.store.dispatch(createVehicleRecord({ vehicle: vehicle as unknown as TechRecordType<'put'> }));
             } else {
-              this.store.dispatch(updateTechRecord({ vehicleTechRecord: vehicle as unknown as TechRecordType<'put'> }));
+              this.technicalRecordService.updateEditingTechRecord(vehicle);
+              this.store.dispatch(updateTechRecord({ systemNumber: vehicle.systemNumber, createdTimestamp: vehicle.createdTimestamp }));
             }
           });
           this.technicalRecordService.clearSectionTemplateStates();

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.html
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.html
@@ -77,30 +77,30 @@
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Service</th>
       <td class="govuk-table__cell" id="noWheelLockAddedServiceCell">
-        {{ round(((vehicleTechRecord.techRecord_grossLadenWeight || 0) * 16) / 100) }}
+        {{ round(((vehicleTechRecord?.techRecord_grossLadenWeight ?? 0) * 16) / 100) }}
       </td>
       <td class="govuk-table__cell" id="halfWheelsLockedServiceCell">
-        {{ round(((vehicleTechRecord.techRecord_grossKerbWeight || 0) * 16) / 100) }}
+        {{ round(((vehicleTechRecord?.techRecord_grossKerbWeight ?? 0) * 16) / 100) }}
       </td>
     </tr>
 
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Secondary</th>
       <td class="govuk-table__cell" id="noWheelLockAddedSecondaryCell">
-        {{ round(((vehicleTechRecord.techRecord_grossLadenWeight || 0) * 22.5) / 100) }}
+        {{ round(((vehicleTechRecord?.techRecord_grossLadenWeight ?? 0) * 22.5) / 100) }}
       </td>
       <td class="govuk-table__cell" id="halfWheelsLockedSecondaryCell">
-        {{ round(((vehicleTechRecord.techRecord_grossKerbWeight || 0) * 25) / 100) }}
+        {{ round(((vehicleTechRecord?.techRecord_grossKerbWeight ?? 0) * 25) / 100) }}
       </td>
     </tr>
 
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Parking</th>
       <td class="govuk-table__cell" id="noWheelLockAddedParkingCell">
-        {{ round(((vehicleTechRecord.techRecord_grossLadenWeight || 0) * 45) / 100) }}
+        {{ round(((vehicleTechRecord?.techRecord_grossLadenWeight ?? 0) * 45) / 100) }}
       </td>
       <td class="govuk-table__cell" id="halfWheelsLockedParkingCell">
-        {{ round(((vehicleTechRecord.techRecord_grossKerbWeight || 0) * 50) / 100) }}
+        {{ round(((vehicleTechRecord?.techRecord_grossKerbWeight ?? 0) * 50) / 100) }}
       </td>
     </tr>
   </tbody>

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.spec.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.spec.ts
@@ -2,15 +2,15 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { MultiOptionsService } from '@forms/services/multi-options.service';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialAppState } from '@store/index';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { UserService } from '@services/user-service/user-service';
+import { initialAppState } from '@store/index';
 import { PsvBrakesComponent } from './psv-brakes.component';
-import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
-import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 
 describe('PsvBrakesComponent', () => {
   let component: PsvBrakesComponent;
@@ -96,17 +96,17 @@ describe('PsvBrakesComponent', () => {
   });
   describe('The brake code value on this.form', () => {
     it('should match the corresponding values on vehicleTechRecord', () => {
-      expect(component.vehicleTechRecord.techRecord_brakes_brakeCode).toStrictEqual(component.form.value.techRecord_brakes_brakeCode);
+      expect(component.vehicleTechRecord?.techRecord_brakes_brakeCode).toStrictEqual(component.form.value.techRecord_brakes_brakeCode);
     });
   });
   describe('The dataTrBrakeOne value on this.form', () => {
     it('should match the corresponding values on vehicleTechRecord', () => {
-      expect(component.vehicleTechRecord.techRecord_brakes_retarderBrakeOne).toStrictEqual(component.form.value.techRecord_brakes_retarderBrakeOne);
+      expect(component.vehicleTechRecord?.techRecord_brakes_retarderBrakeOne).toStrictEqual(component.form.value.techRecord_brakes_retarderBrakeOne);
     });
   });
   describe('The brakeCodeOriginal value on this.form', () => {
     it('should match the corresponding values on vehicleTechRecord', () => {
-      expect(component.vehicleTechRecord.techRecord_brakes_brakeCodeOriginal).toStrictEqual(
+      expect(component.vehicleTechRecord?.techRecord_brakes_brakeCodeOriginal).toStrictEqual(
         component.form.controls['techRecord_brakes_brakeCodeOriginal']?.value
       );
     });
@@ -114,7 +114,7 @@ describe('PsvBrakesComponent', () => {
 
   describe('The axle value on this.form', () => {
     it('should match the corresponding values on vehicleTechRecord', () => {
-      expect(component.vehicleTechRecord.techRecord_axles![0]).toEqual(
+      expect(component.vehicleTechRecord?.techRecord_axles![0]).toEqual(
         expect.objectContaining(component.form.controls['techRecord_axles']?.value[0])
       );
     });

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
@@ -21,7 +21,7 @@ import { Observable, Subject, debounceTime, of, switchMap, takeUntil, withLatest
   styleUrls: ['./psv-brakes.component.scss']
 })
 export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() vehicleTechRecord!: TechRecordType<'psv'>;
+  @Input() vehicleTechRecord?: TechRecordType<'psv'>;
   @Input() isEditing = false;
 
   @Output() formChange = new EventEmitter();
@@ -122,7 +122,10 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   get brakeCodePrefix(): string {
-    const prefix = `${Math.round(this.vehicleTechRecord!.techRecord_grossLadenWeight! / 100)}`;
+    if (!this.vehicleTechRecord?.techRecord_grossLadenWeight) {
+      return '';
+    }
+    const prefix = `${Math.round(this.vehicleTechRecord.techRecord_grossLadenWeight / 100)}`;
 
     return prefix.length <= 2 ? '0' + prefix : prefix;
   }

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -21,6 +21,7 @@ export type NotTrailer =
 
 export type BatchUpdateVehicleModel = TechRecordType<'put'> & {
   createdTimestamp: string;
+  systemNumber?: string;
 };
 
 export interface PostNewVehicleModel extends Omit<VehicleTechRecordModel, 'vrms'> {

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -18,7 +18,7 @@ export class AxlesService {
 
     if (newAxles.length > newAxleSpacings.length + 1) {
       newAxleSpacings = this.generateAxleSpacing(newAxles.length, newAxleSpacings);
-    } else if (newAxles.length < newAxleSpacings.length + 1) {
+    } else if (newAxles.length < newAxleSpacings.length + 1 && newAxles.length) {
       newAxles = this.generateAxlesFromAxleSpacings(newAxleSpacings.length, newAxles);
     }
 

--- a/src/app/services/technical-record-http/technical-record-http.service.spec.ts
+++ b/src/app/services/technical-record-http/technical-record-http.service.spec.ts
@@ -1,14 +1,14 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
+import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { initialAppState, State } from '@store/index';
+import { State, initialAppState } from '@store/index';
+import { fetchSearchResult } from '@store/tech-record-search/actions/tech-record-search.actions';
 import { lastValueFrom, of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { SEARCH_TYPES, TechnicalRecordHttpService } from './technical-record-http.service';
-import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
-import { fetchSearchResult } from '@store/tech-record-search/actions/tech-record-search.actions';
 //TODO: need to include tests for search$, seachBy, getBySystemNumber, getRecordV3, AmendVrm, promoteTechRecord, generatePlate, generateLetter
 
 describe('TechnicalRecordService', () => {
@@ -74,6 +74,8 @@ describe('TechnicalRecordService', () => {
 
     describe('updateTechRecords', () => {
       it('should return a new tech record and updated status code', fakeAsync(() => {
+        const systemNumber = '123456';
+        const createdTimestamp = '2022';
         const expectedVehicle = {
           systemNumber: 'foo',
           createdTimestamp: 'bar',
@@ -82,18 +84,15 @@ describe('TechnicalRecordService', () => {
           techRecord_reasonForCreation: 'test',
           secondaryVrms: undefined
         } as TechRecordType<'get'>;
-        service.updateTechRecords$(expectedVehicle as TechRecordType<'put'>).subscribe();
+        service.updateTechRecords$(systemNumber, createdTimestamp, expectedVehicle as TechRecordType<'put'>).subscribe();
 
         // Check for correct requests: should have made one request to the PUT URL
-        const req = httpClient.expectOne(
-          `${environment.VTM_API_URI}/v3/technical-records/${expectedVehicle.systemNumber}/${expectedVehicle.createdTimestamp}`
-        );
+        const req = httpClient.expectOne(`${environment.VTM_API_URI}/v3/technical-records/${systemNumber}/${createdTimestamp}`);
         expect(req.request.method).toEqual('PATCH');
 
         // should format the vrms for the update payload
         expect(req.request.body).toHaveProperty('primaryVrm');
         expect(req.request.body).toHaveProperty('secondaryVrms');
-        expect(req.request.body).not.toHaveProperty('vrms');
       }));
     });
 

--- a/src/app/services/technical-record-http/technical-record-http.service.ts
+++ b/src/app/services/technical-record-http/technical-record-http.service.ts
@@ -53,12 +53,10 @@ export class TechnicalRecordHttpService {
     return this.http.post<TechRecordType<'get'>>(`${environment.VTM_API_URI}/v3/technical-records`, body);
   }
 
-  updateTechRecords$(techRecord: TechRecordType<'put'>): Observable<TechRecordType<'get'>> {
-    const body = { ...techRecord } as TechRecordType<'get'>;
+  updateTechRecords$(systemNumber: string, createdTimestamp: string, techRecord: TechRecordType<'put'>): Observable<TechRecordType<'get'>> {
+    const url = `${environment.VTM_API_URI}/v3/technical-records/${systemNumber}/${createdTimestamp}`;
 
-    const url = `${environment.VTM_API_URI}/v3/technical-records/${body.systemNumber}/${body.createdTimestamp}`;
-
-    return this.http.patch<TechRecordType<'get'>>(url, body, { responseType: 'json' });
+    return this.http.patch<TechRecordType<'get'>>(url, techRecord, { responseType: 'json' });
   }
 
   amendVrm$(newVrm: string, cherishedTransfer: boolean, systemNumber: string, createdTimestamp: string): Observable<TechRecordType<'get'>> {

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -76,7 +76,11 @@ export class TechnicalRecordService {
   }
 
   updateEditingTechRecord(record: TechRecordType<'put'>): void {
-    if (record.techRecord_vehicleType === 'psv' || record.techRecord_vehicleType === 'hgv' || record.techRecord_vehicleType === 'trl') {
+    if (
+      record.techRecord_vehicleType === 'psv' ||
+      record.techRecord_vehicleType === 'hgv' ||
+      (record.techRecord_vehicleType === 'trl' && record.techRecord_euVehicleCategory !== 'o1' && record.techRecord_euVehicleCategory !== 'o2')
+    ) {
       record.techRecord_noOfAxles = record.techRecord_axles && record.techRecord_axles.length > 0 ? record.techRecord_axles?.length : null;
     }
     this.store.dispatch(updateEditingTechRecord({ vehicleTechRecord: record }));
@@ -99,10 +103,10 @@ export class TechnicalRecordService {
     this.store.dispatch(createVehicle({ techRecord_vehicleType: vehicleType }));
   }
 
-  clearReasonForCreation(vehicleTechRecord?: TechRecordType<'put'>): void {
+  clearReasonForCreation(): void {
     this.techRecord$
       .pipe(
-        map(data => cloneDeep(data ?? vehicleTechRecord)),
+        map(data => cloneDeep(data)),
         take(1)
       )
       .subscribe(data => {

--- a/src/app/store/technical-records/actions/technical-record-service.actions.ts
+++ b/src/app/store/technical-records/actions/technical-record-service.actions.ts
@@ -20,7 +20,7 @@ export const createVehicleRecord = createAction(`${prefix} createVehicleRecord`,
 export const createVehicleRecordSuccess = createOutcomeAction('createVehicleRecord', true);
 export const createVehicleRecordFailure = createOutcomeAction('createVehicleRecord', false);
 
-export const updateTechRecord = createAction(`${prefix} updateTechRecords`, props<{ vehicleTechRecord: TechRecordType<'put'> }>());
+export const updateTechRecord = createAction(`${prefix} updateTechRecords`, props<{ systemNumber: string; createdTimestamp: string }>());
 export const updateTechRecordSuccess = createOutcomeAction('updateTechRecords', true);
 export const updateTechRecordFailure = createOutcomeAction('updateTechRecords', false);
 

--- a/src/app/store/technical-records/effects/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.spec.ts
@@ -100,6 +100,10 @@ describe('TechnicalRecordServiceEffects', () => {
   });
 
   describe('updateTechRecords$', () => {
+    beforeEach(() => {
+      store = TestBed.inject(MockStore);
+      store.overrideSelector(editingTechRecord, {} as unknown as TechRecordType<'put'>);
+    });
     it('should return a technical record on successful API call', () => {
       testScheduler.run(({ hot, cold, expectObservable }) => {
         const technicalRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as TechRecordType<'get'>;

--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -117,8 +117,12 @@ export class TechnicalRecordServiceEffects {
   updateTechRecord$ = createEffect(() =>
     this.actions$.pipe(
       ofType(updateTechRecord),
-      concatMap(({ vehicleTechRecord }) => {
-        return this.techRecordHttpService.updateTechRecords$(vehicleTechRecord).pipe(
+      withLatestFrom(this.store.pipe(select(editingTechRecord))),
+      concatMap(([{ systemNumber, createdTimestamp }, techRecord]) => {
+        if (!techRecord) {
+          return of(updateTechRecordFailure({ error: 'There is not technical record in edit' }));
+        }
+        return this.techRecordHttpService.updateTechRecords$(systemNumber, createdTimestamp, techRecord).pipe(
           map(vehicleTechRecord => updateTechRecordSuccess({ vehicleTechRecord })),
           catchError(error => of(updateTechRecordFailure({ error: this.getTechRecordErrorMessage(error, 'updateTechnicalRecord') })))
         );

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.spec.ts
@@ -126,9 +126,7 @@ describe('Vehicle Technical Record Reducer', () => {
         vehicleTechRecord: { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as TechRecordType<'get'>,
         loading: true
       };
-      const action = updateTechRecord({
-        vehicleTechRecord: { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVinNew' } as unknown as TechRecordType<'put'>
-      });
+      const action = updateTechRecord({ systemNumber: 'foo', createdTimestamp: 'bar' });
       const newState = vehicleTechRecordReducer(state, action);
 
       expect(newState).toEqual(state);


### PR DESCRIPTION
## Ticket title

Updating hidden in vta on small trl removes number of axles.

Update tech record action now uses `systemNumber` and `createdTimestamp` instead of whole record to dispatch action. This ensures callers of the action go trough `updateEditingTechRecord` method in technical record service.

Moved logic to determine whether to create a new provisional record into the summary component.

[CB2-8806](https://dvsa.atlassian.net/browse/CB2-8806)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
