### PR TITLE
fix(cb2-9080): psv record brake rendering issue

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.html
@@ -18,114 +18,110 @@
 </section>
 
 <ng-template #accordion let-sectionName="sectionName" let-section="section">
-  <ng-container [ngSwitch]="sectionName">
-    <app-body
-      *ngSwitchCase="'bodySection'"
-      [techRecord]="techRecordCalculated"
-      [isEditing]="(isEditing$ | async) ?? false"
-      (formChange)="handleFormState($event)"
-    ></app-body>
-
-    <ng-container
-      *ngIf="
-        techRecordCalculated.techRecord_vehicleType === 'trl' ||
-        techRecordCalculated.techRecord_vehicleType === 'hgv' ||
-        techRecordCalculated.techRecord_vehicleType === 'psv'
-      "
-    >
-      <app-dimensions
-        *ngSwitchCase="'dimensionsSection'"
+  <ng-container *ngIf="techRecordCalculated">
+    <ng-container [ngSwitch]="sectionName">
+      <app-body
+        *ngSwitchCase="'bodySection'"
         [techRecord]="techRecordCalculated"
         [isEditing]="(isEditing$ | async) ?? false"
         (formChange)="handleFormState($event)"
-      ></app-dimensions>
-    </ng-container>
-    <ng-container
-      *ngIf="
-        techRecordCalculated.techRecord_vehicleType === 'trl' ||
-        techRecordCalculated.techRecord_vehicleType === 'hgv' ||
-        techRecordCalculated.techRecord_vehicleType === 'psv'
-      "
-    >
-      <app-approval-type
-        *ngSwitchCase="'approvalSection'"
-        [techRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-approval-type>
-    </ng-container>
+      ></app-body>
 
-    <ng-container *ngIf="techRecordCalculated.techRecord_vehicleType === 'psv'">
-      <app-psv-brakes
-        *ngSwitchCase="'psvBrakesSection'"
-        [vehicleTechRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-psv-brakes>
-    </ng-container>
+      <ng-container *ngSwitchCase="'dimensionsSection'">
+        <app-dimensions
+          *ngIf="
+            techRecordCalculated.techRecord_vehicleType === 'trl' ||
+            techRecordCalculated.techRecord_vehicleType === 'hgv' ||
+            techRecordCalculated.techRecord_vehicleType === 'psv'
+          "
+          [techRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-dimensions>
+      </ng-container>
 
-    <ng-container *ngIf="techRecordCalculated.techRecord_vehicleType === 'trl'">
-      <app-trl-brakes
-        *ngSwitchCase="'trlBrakesSection'"
-        [vehicleTechRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-trl-brakes>
-    </ng-container>
-    <ng-container
-      *ngIf="
-        techRecordCalculated.techRecord_vehicleType === 'trl' ||
-        techRecordCalculated.techRecord_vehicleType === 'hgv' ||
-        techRecordCalculated.techRecord_vehicleType === 'psv'
-      "
-    >
-      <app-tyres
-        *ngSwitchCase="'tyreSection'"
-        [vehicleTechRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-tyres>
-    </ng-container>
+      <ng-container *ngSwitchCase="'approvalSection'">
+        <app-approval-type
+          *ngIf="
+            techRecordCalculated.techRecord_vehicleType === 'trl' ||
+            techRecordCalculated.techRecord_vehicleType === 'hgv' ||
+            techRecordCalculated.techRecord_vehicleType === 'psv'
+          "
+          [techRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-approval-type>
+      </ng-container>
 
-    <ng-container
-      *ngIf="
-        techRecordCalculated.techRecord_vehicleType === 'trl' ||
-        techRecordCalculated.techRecord_vehicleType === 'hgv' ||
-        techRecordCalculated.techRecord_vehicleType === 'psv'
-      "
-    >
-      <app-weights
-        *ngSwitchCase="'weightsSection'"
-        [vehicleTechRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-weights>
-    </ng-container>
+      <ng-container *ngSwitchCase="'psvBrakesSection'">
+        <app-psv-brakes
+          *ngIf="techRecordCalculated.techRecord_vehicleType === 'psv'"
+          [vehicleTechRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-psv-brakes>
+      </ng-container>
 
-    <ng-container *ngIf="techRecordCalculated.techRecord_vehicleType === 'trl'">
-      <app-letters
-        *ngSwitchCase="'lettersSection'"
-        [techRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-letters>
-    </ng-container>
+      <ng-container *ngSwitchCase="'trlBrakesSection'">
+        <app-trl-brakes
+          *ngIf="techRecordCalculated.techRecord_vehicleType === 'trl'"
+          [vehicleTechRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-trl-brakes>
+      </ng-container>
 
-    <ng-container *ngIf="techRecordCalculated.techRecord_vehicleType === 'hgv' || techRecordCalculated.techRecord_vehicleType === 'trl'">
-      <app-plates
-        *ngSwitchCase="'platesSection'"
-        [techRecord]="techRecordCalculated"
-        [isEditing]="(isEditing$ | async) ?? false"
-        (formChange)="handleFormState($event)"
-      ></app-plates>
-    </ng-container>
+      <ng-container *ngSwitchCase="'tyreSection'">
+        <app-tyres
+          *ngIf="
+            techRecordCalculated.techRecord_vehicleType === 'trl' ||
+            techRecordCalculated.techRecord_vehicleType === 'hgv' ||
+            techRecordCalculated.techRecord_vehicleType === 'psv'
+          "
+          [vehicleTechRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-tyres>
+      </ng-container>
 
-    <app-dynamic-form-group
-      *ngSwitchDefault
-      [data]="techRecordCalculated"
-      [template]="section"
-      [edit]="(isEditing$ | async) ?? false"
-      (formChange)="handleFormState($event)"
-    ></app-dynamic-form-group>
+      <ng-container *ngSwitchCase="'weightsSection'">
+        <app-weights
+          *ngIf="
+            techRecordCalculated.techRecord_vehicleType === 'trl' ||
+            techRecordCalculated.techRecord_vehicleType === 'hgv' ||
+            techRecordCalculated.techRecord_vehicleType === 'psv'
+          "
+          [vehicleTechRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-weights>
+      </ng-container>
+
+      <ng-container *ngSwitchCase="'lettersSection'">
+        <app-letters
+          *ngIf="techRecordCalculated.techRecord_vehicleType === 'trl'"
+          [techRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-letters>
+      </ng-container>
+
+      <ng-container *ngSwitchCase="'platesSection'">
+        <app-plates
+          *ngIf="techRecordCalculated.techRecord_vehicleType === 'hgv' || techRecordCalculated.techRecord_vehicleType === 'trl'"
+          [techRecord]="techRecordCalculated"
+          [isEditing]="(isEditing$ | async) ?? false"
+          (formChange)="handleFormState($event)"
+        ></app-plates>
+      </ng-container>
+
+      <app-dynamic-form-group
+        *ngSwitchDefault
+        [data]="techRecordCalculated"
+        [template]="section"
+        [edit]="(isEditing$ | async) ?? false"
+        (formChange)="handleFormState($event)"
+      ></app-dynamic-form-group>
+    </ng-container>
   </ng-container>
 </ng-template>

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, OnDestroy, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/dynamic-form-group.component';
+import { ApprovalTypeComponent } from '@forms/custom-sections/approval-type/approval-type.component';
 import { BodyComponent } from '@forms/custom-sections/body/body.component';
 import { DimensionsComponent } from '@forms/custom-sections/dimensions/dimensions.component';
 import { LettersComponent } from '@forms/custom-sections/letters/letters.component';
@@ -20,8 +22,6 @@ import { RouterService } from '@services/router/router.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { cloneDeep, mergeWith } from 'lodash';
 import { Observable, Subject, map, take, takeUntil } from 'rxjs';
-import { ApprovalTypeComponent } from '@forms/custom-sections/approval-type/approval-type.component';
-import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-tech-record-summary',
@@ -43,7 +43,7 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
   @Output() isFormDirty = new EventEmitter<boolean>();
   @Output() isFormInvalid = new EventEmitter<boolean>();
 
-  techRecordCalculated!: V3TechRecordModel;
+  techRecordCalculated?: V3TechRecordModel;
   sectionTemplates: Array<FormNode> = [];
   middleIndex = 0;
   isEditing: boolean = false;
@@ -114,11 +114,14 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
   }
 
   get vehicleType() {
-    return this.technicalRecordService.getVehicleTypeWithSmallTrl(this.techRecordCalculated);
+    return this.techRecordCalculated ? this.technicalRecordService.getVehicleTypeWithSmallTrl(this.techRecordCalculated) : undefined;
   }
 
   get vehicleTemplates(): Array<FormNode> {
     this.isEditing$.pipe(takeUntil(this.destroy$)).subscribe(editing => (this.isEditing = editing));
+    if (!this.vehicleType) {
+      return [];
+    }
     return (
       vehicleTemplateMap.get(this.vehicleType)?.filter(template => template.name !== (this.isEditing ? 'audit' : 'reasonForCreationSection')) ?? []
     );


### PR DESCRIPTION
## Ticket title

fix psv record brake rendering issue.
- `*ngSwitchCase` needs to be the top-level conditional e.g. :

This does not work:
```html
<ng-container *ngIf="true">
  <div *ngSwitchCase="'string'"> Some field </div>
</ng-container>
```
But this does:
```html
<ng-container *ngSwitchCase="'string'">
  <div *ngIf="true"> Some field </div>
</ng-container>
```
- Also made `techRecordCalculated` potentially undefined as it is `undefined` at constructor time.

[CB2-9080](https://dvsa.atlassian.net/browse/CB2-9080)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
