### PR TITLE
CB2-8591: validation on vin

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 
 .PHONY: all help init install build run lint test e2e plan deploy versioncheck
 all: #help Full check
-	lint test run 
+	lint test run
 help:
 	@echo "-- HELP --"
 	@grep '#[h]elp' makefile | sed s/#[h]elp//g

--- a/src/app/features/tech-record/create/create-tech-record.component.html
+++ b/src/app/features/tech-record/create/create-tech-record.component.html
@@ -8,6 +8,7 @@
     appToUppercase
     appNoSpace
     appTrimWhitespace
+    hint="VIN should usually be 17 characters long."
     [width]="30"
     (ngModelChange)="ngOnChanges()"
   ></app-text-input>

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -85,14 +85,6 @@ export class CreateTechRecordComponent implements OnChanges {
     this.isVinUniqueCheckComplete = false;
   }
 
-  validateVin() {
-    console.log('validating vin...');
-    this.techRecord.vin = this.form.value.vin;
-    console.log(this.techRecord.vin);
-    const pattern = /[oiq]/i;
-    return this.techRecord?.vin ? pattern.test(this.techRecord.vin) : false;
-  }
-
   get isFormValid(): boolean {
     const errors: GlobalError[] = [];
 

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -15,6 +15,7 @@ import { SEARCH_TYPES } from '@services/technical-record-http/technical-record-h
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { setSpinnerState } from '@store/spinner/actions/spinner.actions';
 import { firstValueFrom } from 'rxjs';
+import { BaseControlComponent } from '@forms/components/base-control/base-control.component';
 
 @Component({
   selector: 'app-create',
@@ -35,6 +36,7 @@ export class CreateTechRecordComponent implements OnChanges {
     {
       vin: new CustomFormControl({ name: 'input-vin', label: 'Vin', type: FormNodeTypes.CONTROL }, '', [
         CustomValidators.alphanumeric(),
+        CustomValidators.validateVinCharacters(),
         Validators.minLength(3),
         Validators.maxLength(21),
         Validators.required
@@ -81,6 +83,14 @@ export class CreateTechRecordComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.isVinUniqueCheckComplete = false;
+  }
+
+  validateVin() {
+    console.log('validating vin...');
+    this.techRecord.vin = this.form.value.vin;
+    console.log(this.techRecord.vin);
+    const pattern = /[oiq]/i;
+    return this.techRecord?.vin ? pattern.test(this.techRecord.vin) : false;
   }
 
   get isFormValid(): boolean {

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -169,6 +169,9 @@ export class CustomValidators {
     };
   };
 
+  static validateVinCharacters() {
+    return this.customPattern(['^(?!.*[OIQ]).*$', 'VIN should not contain O, I and Q']);
+  }
   static alphanumeric(): ValidatorFn {
     return this.customPattern(['^[a-zA-Z0-9]*$', 'must be alphanumeric']);
   }


### PR DESCRIPTION
## Create vehicle VIN validation

receive an error message if trying to create a new Technical Record with an O, I or Q in the VIN: ‘VIN should not contain O, I and Q’ Provide a hint for the VIN, letting users know it should be 17 characters long: ‘VIN should usually be 17 characters long.’
[CB2-8591](https://dvsa.atlassian.net/browse/CB2-8591)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
