### PR TITLE
Feature(CB2-8714): Auto calculate PSV laden weight

### DIFF
--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.html
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.html
@@ -4,6 +4,7 @@
   [type]="editTypes.AUTOCOMPLETE"
   name="techRecord_brakes_brakeCodeOriginal"
   label="Brake code"
+  [hint]="'If year of manufacture is 1988, check your brake code'"
   [isEditing]="isEditing"
   [width]="widths.L"
   [prefix]="brakeCodePrefix"

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
@@ -13,7 +13,7 @@ import { Store } from '@ngrx/store';
 import { ReferenceDataState, selectBrakeByCode } from '@store/reference-data';
 import { updateBrakeForces } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
-import { Observable, Subject, debounceTime, of, switchMap, takeUntil, withLatestFrom } from 'rxjs';
+import { debounceTime, Observable, of, Subject, switchMap, takeUntil, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-psv-brakes',
@@ -141,5 +141,22 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
 
   round(n: number): number {
     return Math.round(n);
+  }
+
+  calculateGrossLadenWeight(): number {
+    let kgAllowedPerPerson: number;
+
+    if (this.vehicleTechRecord?.techRecord_manufactureYear ?? 0 >= 1988) {
+      kgAllowedPerPerson = 65;
+    } else if (this.vehicleTechRecord?.techRecord_manufactureYear ?? 0 <= 1987) {
+      kgAllowedPerPerson = 63.5;
+    } else {
+      throw new Error('Invalid year of manufacture');
+    }
+
+    return (
+      ((this.vehicleTechRecord?.techRecord_seatsUpperDeck ?? this.vehicleTechRecord?.techRecord_seatsLowerDeck ?? 0) + 1) * kgAllowedPerPerson +
+      (this.vehicleTechRecord?.techRecord_grossKerbWeight ?? 0)
+    );
   }
 }

--- a/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
+++ b/src/app/forms/custom-sections/psv-brakes/psv-brakes.component.ts
@@ -142,21 +142,4 @@ export class PsvBrakesComponent implements OnInit, OnChanges, OnDestroy {
   round(n: number): number {
     return Math.round(n);
   }
-
-  calculateGrossLadenWeight(): number {
-    let kgAllowedPerPerson: number;
-
-    if (this.vehicleTechRecord?.techRecord_manufactureYear ?? 0 >= 1988) {
-      kgAllowedPerPerson = 65;
-    } else if (this.vehicleTechRecord?.techRecord_manufactureYear ?? 0 <= 1987) {
-      kgAllowedPerPerson = 63.5;
-    } else {
-      throw new Error('Invalid year of manufacture');
-    }
-
-    return (
-      ((this.vehicleTechRecord?.techRecord_seatsUpperDeck ?? this.vehicleTechRecord?.techRecord_seatsLowerDeck ?? 0) + 1) * kgAllowedPerPerson +
-      (this.vehicleTechRecord?.techRecord_grossKerbWeight ?? 0)
-    );
-  }
 }

--- a/src/app/forms/custom-sections/weights/weights.component.ts
+++ b/src/app/forms/custom-sections/weights/weights.component.ts
@@ -128,6 +128,6 @@ export class WeightsComponent implements OnInit, OnDestroy, OnChanges {
     const kgAllowedPerPerson = techRecord_manufactureYear >= 1988 ? 65 : 63.5;
 
     const totalPassengers = techRecord_seatsUpperDeck + techRecord_seatsLowerDeck + 1; // Add 1 for the driv
-    return (totalPassengers + 1) * kgAllowedPerPerson + techRecord_grossKerbWeight;
+    return totalPassengers * kgAllowedPerPerson + techRecord_grossKerbWeight;
   }
 }

--- a/src/app/forms/custom-sections/weights/weights.component.ts
+++ b/src/app/forms/custom-sections/weights/weights.component.ts
@@ -5,11 +5,11 @@ import { CustomFormArray, CustomFormGroup, FormNode, FormNodeEditTypes } from '@
 import { HgvWeight } from '@forms/templates/hgv/hgv-weight.template';
 import { PsvWeightsTemplate } from '@forms/templates/psv/psv-weight.template';
 import { TrlWeight } from '@forms/templates/trl/trl-weight.template';
-import { Axle, V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { Axle, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { addAxle, removeAxle, updateBrakeForces } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
-import { Subscription, debounceTime } from 'rxjs';
+import { debounceTime, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-weights[vehicleTechRecord]',
@@ -35,9 +35,11 @@ export class WeightsComponent implements OnInit, OnDestroy, OnChanges {
       if (event?.techRecord_axles) {
         event.techRecord_axles = (event.techRecord_axles as Axle[]).filter(axle => !!axle?.axleNumber);
       }
-
+      // Calculate the grossLadenWeight and update it in the form
+      if (this.isPsv) {
+        event.techRecord_grossLadenWeight = this.calculateGrossLadenWeight();
+      }
       this.formChange.emit(event);
-
       if (event.techRecord_grossLadenWeight || event.techRecord_grossKerbWeight) {
         this.store.dispatch(
           updateBrakeForces({ grossLadenWeight: event.techRecord_grossLadenWeight, grossKerbWeight: event.techRecord_grossKerbWeight })
@@ -48,7 +50,6 @@ export class WeightsComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     const { vehicleTechRecord } = changes;
-
     if (this.form && vehicleTechRecord?.currentValue && vehicleTechRecord.currentValue !== vehicleTechRecord.previousValue) {
       this.form?.patchValue(vehicleTechRecord.currentValue, { emitEvent: false });
     }
@@ -115,5 +116,18 @@ export class WeightsComponent implements OnInit, OnDestroy, OnChanges {
       this.isError = true;
       this.errorMessage = `Cannot have less than ${minLength} axles`;
     }
+  }
+
+  calculateGrossLadenWeight(): number {
+    const psvRecord = this.vehicleTechRecord as TechRecordType<'psv'>;
+    const techRecord_seatsUpperDeck = psvRecord?.techRecord_seatsUpperDeck ?? 0;
+    const techRecord_seatsLowerDeck = psvRecord?.techRecord_seatsLowerDeck ?? 0;
+    const techRecord_manufactureYear = psvRecord?.techRecord_manufactureYear ?? 0;
+    const techRecord_grossKerbWeight = psvRecord?.techRecord_grossKerbWeight ?? 0;
+
+    const kgAllowedPerPerson = techRecord_manufactureYear >= 1988 ? 65 : 63.5;
+
+    const totalPassengers = techRecord_seatsUpperDeck + techRecord_seatsLowerDeck + 1; // Add 1 for the driv
+    return (totalPassengers + 1) * kgAllowedPerPerson + techRecord_grossKerbWeight;
   }
 }


### PR DESCRIPTION
## Auto calculate PSV Brake Code (Weights)
This is to auto calculate the gross laden weight based on the manufacture year, total passengers and gross kerb weight

[CB2-8714](https://dvsa.atlassian.net/browse/CB2-8714)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
