### PR TITLE
fix(cb2-9119): allow space in conversion ref no

### DIFF
--- a/src/app/forms/custom-sections/body/body.component.html
+++ b/src/app/forms/custom-sections/body/body.component.html
@@ -134,6 +134,7 @@
   [form]="form"
   [type]="editTypes.TEXT"
   name="techRecord_conversionRefNo"
+  appTrimWhitespace
   label="Conversion reference number"
   [isEditing]="isEditing"
   [width]="widths.L"

--- a/src/app/forms/templates/general/hgv-trl-body.template.ts
+++ b/src/app/forms/templates/general/hgv-trl-body.template.ts
@@ -75,7 +75,7 @@ export const HgvAndTrlBodyTemplate: FormNode = {
       width: FormNodeWidth.L,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXT,
-      validators: [{ name: ValidatorNames.CustomPattern, args: ['^[A-Z0-9]{0,10}$', 'max length 10 uppercase letters or numbers'] }]
+      validators: [{ name: ValidatorNames.CustomPattern, args: ['^[A-Z0-9 ]{0,10}$', 'max length 10 uppercase letters or numbers'] }]
     }
   ]
 };

--- a/src/app/forms/templates/psv/psv-body.template.ts
+++ b/src/app/forms/templates/psv/psv-body.template.ts
@@ -81,7 +81,7 @@ export const PsvBodyTemplate: FormNode = {
       label: 'Conversion ref no',
       value: null,
       type: FormNodeTypes.CONTROL,
-      validators: [{ name: ValidatorNames.CustomPattern, args: ['^[A-Z0-9]{0,10}$', 'max length 10 uppercase letters or numbers'] }]
+      validators: [{ name: ValidatorNames.CustomPattern, args: ['^[A-Z0-9 ]{0,10}$', 'max length 10 uppercase letters or numbers'] }]
     },
     {
       name: 'techRecord_modelLiteral',


### PR DESCRIPTION
## PreProd: PSV Body Conversion Reference Number - error when amending if record has a space in this field already

Allow existing space and trim space when entering in the field.
[CB2-9119](https://dvsa.atlassian.net/browse/CB2-9119)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
