### PR TITLE
fix(cb2-9118): multiple error messages while operation processes

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
@@ -14,7 +14,7 @@ import { RouterService } from '@services/router/router.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { State } from '@store/index';
 import { updateTechRecord, updateTechRecordSuccess } from '@store/technical-records';
-import { Subject, takeUntil, withLatestFrom } from 'rxjs';
+import { Subject, take, takeUntil, withLatestFrom } from 'rxjs';
 
 @Component({
   selector: 'app-change-amend-vin',
@@ -106,7 +106,7 @@ export class AmendVinComponent implements OnDestroy, OnInit {
       this.technicalRecordService.updateEditingTechRecord({ ...record, techRecord_reasonForCreation: 'Vin changed' });
       this.routerService
         .getRouteNestedParam$('systemNumber')
-        .pipe(takeUntil(this.destroy$), withLatestFrom(this.routerService.getRouteNestedParam$('createdTimestamp')))
+        .pipe(take(1), takeUntil(this.destroy$), withLatestFrom(this.routerService.getRouteNestedParam$('createdTimestamp')))
         .subscribe(([systemNumber, createdTimestamp]) => {
           if (systemNumber && createdTimestamp) {
             this.store.dispatch(updateTechRecord({ systemNumber, createdTimestamp }));


### PR DESCRIPTION
multiple error messages while operation processes

adds a take(1) to the nestedRouteParams pipe so only the first set are taken and the dispatch is only fired off once. 
[CB2-9118](https://dvsa.atlassian.net/browse/CB2-9118)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
