### PR TITLE
fix(cb2-9195): fixes email validation for multiple-period domain addresses

### DIFF
--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -181,7 +181,7 @@ export class CustomValidators {
   }
 
   static email(): ValidatorFn {
-    return this.customPattern(['^[-\\w.\\+]+@[-\\w]+\\.[A-Za-z]{2,}$', 'Enter an email address in the correct format, like name@example.com']);
+    return this.customPattern(['^[\\w\\-\\.]+@([\\w-]+\\.)+[\\w-]{2,}$', 'Enter an email address in the correct format, like name@example.com']);
   }
 
   static customPattern([regEx, message]: string[]): ValidatorFn {

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -181,7 +181,7 @@ export class CustomValidators {
   }
 
   static email(): ValidatorFn {
-    return this.customPattern(['^[\\w\\-\\.]+@([\\w-]+\\.)+[\\w-]{2,}$', 'Enter an email address in the correct format, like name@example.com']);
+    return this.customPattern(['^[\\w\\-\\.\\+]+@([\\w-]+\\.)+[\\w-]{2,}$', 'Enter an email address in the correct format, like name@example.com']);
   }
 
   static customPattern([regEx, message]: string[]): ValidatorFn {


### PR DESCRIPTION
Fixes the email validation regex to allow domain names with multiple periods (e.g. `.co.uk`)

[CB2-9195](https://dvsa.atlassian.net/browse/CB2-9195)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Delete branch after merge
