### PR TITLE
fix(cb2-9199): fix the Overlapping CSS in Record type bug

### DIFF
--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.html
@@ -119,13 +119,16 @@
             >
           </div>
         </dd>
-        <dd *appRoleRequired="roles.TechRecordUnarchive" class="govuk-summary-list__actions">
-          <div class="govuk-summary-list__actions--flex">
-            <app-button *ngIf="queryableActions.includes('unarchive')" design="link" id="unarchive-link" (clicked)="navigateTo('unarchive-record')">
-              Unarchive
-            </app-button>
-          </div>
-        </dd>
+        <ng-container *ngIf="queryableActions.includes('unarchive')">
+          <dd *appRoleRequired="roles.TechRecordUnarchive" class="govuk-summary-list__actions">
+            <div class="govuk-summary-list__actions--flex">
+              <app-button  design="link" id="unarchive-link" (clicked)="navigateTo('unarchive-record')">
+                Unarchive
+              </app-button>
+            </div>
+          </dd>
+        </ng-container> 
+
       </ng-container>
     </div>
 


### PR DESCRIPTION
##  ‘Provisional’ and ‘Archive' overlapped bug fix

Fix the bug when create a provisional Tech record and observe that ‘Provisional’ and ‘Archive' are overlapped.


[CB2-9199](https://dvsa.atlassian.net/browse/CB2-9199)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
