### PR TITLE
fix(cb2-9046): current tech record VIN warnings

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -116,7 +116,7 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     if (this.isEditing) {
       this.technicalRecordService.techRecord$.pipe(takeUntil(this.destroy$), take(1)).subscribe((techRecord) => {
         if (techRecord) {
-          if(editingReason === ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED) {
+          if (editingReason === ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED) {
             this.technicalRecordService.updateEditingTechRecord({
               ...(techRecord as TechRecordType<'put'>),
               techRecord_statusCode: StatusCodes.PROVISIONAL,

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -113,13 +113,15 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy {
     this.isEditing && this.technicalRecordService.clearReasonForCreation();
 
     const editingReason = this.activatedRoute.snapshot.data['reason'];
-    if (this.isEditing && editingReason === ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED) {
+    if (this.isEditing) {
       this.technicalRecordService.techRecord$.pipe(takeUntil(this.destroy$), take(1)).subscribe((techRecord) => {
         if (techRecord) {
-          this.technicalRecordService.updateEditingTechRecord({
-            ...(techRecord as TechRecordType<'put'>),
-            techRecord_statusCode: StatusCodes.PROVISIONAL,
-          });
+          if(editingReason === ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED) {
+            this.technicalRecordService.updateEditingTechRecord({
+              ...(techRecord as TechRecordType<'put'>),
+              techRecord_statusCode: StatusCodes.PROVISIONAL,
+            });
+          }
 
           if (techRecord?.vin?.match('([IOQ])a*')) {
             const warnings: GlobalWarning[] = [];


### PR DESCRIPTION
## Ticket title

Fixed an issue where current VIN records were not displaying VIN warnings correctly on amendment
[CB2-9046](https://dvsa.atlassian.net/browse/CB2-9046)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
