### PR TITLE
fix(cb2-9269): iva test types missing for lgv and psv provisional tech records

### DIFF
--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.html
@@ -19,7 +19,7 @@
           [isEditing]="isEditing"
         ></app-test-record-summary>
 
-        <ng-container *ngIf="showCreateTestButton(techRecord.techRecord_vehicleType!)">
+        <ng-container *ngIf="showCreateTestButton()">
           <div class="govuk-button-group" *appRoleRequired="[roles.TestResultCreateContingency, roles.TestResultCreateDeskAssessment]">
             <a id="create-test" class="govuk-button" (click)="createTest(techRecord)">Create a test for this vehicle</a>
           </div>

--- a/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record/vehicle-technical-record.component.ts
@@ -133,11 +133,10 @@ export class VehicleTechnicalRecordComponent implements OnInit, OnDestroy {
     }
   }
 
-  showCreateTestButton(vehicleType: VehicleTypes | string): boolean {
+  showCreateTestButton(): boolean {
     return (
       !this.isArchived
       && !this.isEditing
-      && (this.isCurrent || vehicleType === VehicleTypes.TRL || vehicleType === VehicleTypes.HGV || vehicleType === VehicleTypes.PSV)
     );
   }
 


### PR DESCRIPTION
CB2-9269

remove vehicle type check from show test button the new list of tests needs it to show on provisionals for all types
[CB2-9269](https://dvsa.atlassian.net/browse/CB2-9269)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
