### PR TITLE
feat(cb2-9639): replace deprecated Resolver class

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,12 +7,12 @@ import { PageNotFoundComponent } from '@core/components/page-not-found/page-not-
 import { ServerErrorComponent } from '@core/components/server-error/server-error.component';
 import { CancelEditTechGuard } from '@guards/cancel-edit-tech/cancel-edit-tech.guard';
 import { techRecordViewResolver } from './resolvers/tech-record-view/tech-record-view.resolver';
-import { TitleResolver } from './resolvers/title/title.resolver';
+import { titleResolver } from './resolvers/title/title.resolver';
 
 const routes: Routes = [
   {
     path: '',
-    resolve: { title: TitleResolver },
+    resolve: { title: titleResolver },
     children: [
       {
         path: '',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ import { Roles } from '@models/roles.enum';
 import { PageNotFoundComponent } from '@core/components/page-not-found/page-not-found.component';
 import { ServerErrorComponent } from '@core/components/server-error/server-error.component';
 import { CancelEditTechGuard } from '@guards/cancel-edit-tech/cancel-edit-tech.guard';
-import { TechRecordViewResolver } from './resolvers/tech-record-view/tech-record-view.resolver';
+import { techRecordViewResolver } from './resolvers/tech-record-view/tech-record-view.resolver';
 import { TitleResolver } from './resolvers/title/title.resolver';
 
 const routes: Routes = [
@@ -44,7 +44,7 @@ const routes: Routes = [
         path: 'test-records/:systemNumber/test-result/:testResultId/:testNumber',
         data: { title: 'Test Result', roles: Roles.TestResultView },
         canActivate: [MsalGuard, RoleGuard],
-        resolve: { techRecord: TechRecordViewResolver },
+        resolve: { techRecord: techRecordViewResolver },
         loadChildren: () => import('./features/test-records/amend/amend-test-records.module').then((m) => m.AmendTestRecordsModule),
       },
       {

--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -5,7 +5,7 @@ import { CancelEditTechGuard } from '@guards/cancel-edit-tech/cancel-edit-tech.g
 import { RoleGuard } from '@guards/role-guard/roles.guard';
 import { Roles } from '@models/roles.enum';
 import { ReasonForEditing } from '@models/vehicle-tech-record.model';
-import { TechRecordViewResolver } from 'src/app/resolvers/tech-record-view/tech-record-view.resolver';
+import { techRecordViewResolver } from 'src/app/resolvers/tech-record-view/tech-record-view.resolver';
 import { TechRecordAmendReasonComponent } from './components/tech-record-amend-reason/tech-record-amend-reason.component';
 import { AmendVinComponent } from './components/tech-record-amend-vin/tech-record-amend-vin.component';
 import { AmendVrmReasonComponent } from './components/tech-record-amend-vrm-reason/tech-record-amend-vrm-reason.component';
@@ -28,7 +28,7 @@ const routes: Routes = [
     data: { roles: Roles.TechRecordView, isCustomLayout: true },
     canActivateChild: [MsalGuard, RoleGuard],
     canActivate: [CancelEditTechGuard],
-    resolve: { load: TechRecordViewResolver },
+    resolve: { load: techRecordViewResolver },
   },
   {
     path: 'correcting-an-error',
@@ -40,7 +40,7 @@ const routes: Routes = [
       isCustomLayout: true,
     },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
   },
   {
     path: 'notifiable-alteration-needed',
@@ -52,7 +52,7 @@ const routes: Routes = [
       isCustomLayout: true,
     },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
   },
 
   {
@@ -78,14 +78,14 @@ const routes: Routes = [
     component: GeneratePlateComponent,
     data: { title: 'Generate plate', roles: Roles.TechRecordAmend },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { load: TechRecordViewResolver },
+    resolve: { load: techRecordViewResolver },
   },
   {
     path: 'generate-letter',
     component: GenerateLetterComponent,
     data: { title: 'Generate letter', roles: Roles.TechRecordAmend },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { load: TechRecordViewResolver },
+    resolve: { load: techRecordViewResolver },
   },
   {
     path: 'amend-reason',
@@ -98,28 +98,28 @@ const routes: Routes = [
     component: TechRecordChangeStatusComponent,
     data: { title: 'Promote or Archive Tech Record', roles: Roles.TechRecordArchive },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { load: TechRecordViewResolver },
+    resolve: { load: techRecordViewResolver },
   },
   {
     path: 'unarchive-record',
     component: TechRecordUnarchiveComponent,
     data: { title: 'Unarchive Record', roles: Roles.TechRecordUnarchive },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { load: TechRecordViewResolver },
+    resolve: { load: techRecordViewResolver },
   },
   {
     path: 'change-vehicle-type',
     component: ChangeVehicleTypeComponent,
     data: { title: 'Change vehicle type', roles: Roles.TechRecordAmend, isEditing: true },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
   },
   {
     path: 'change-vta-visibility',
     component: TechRecordChangeVisibilityComponent,
     data: { roles: Roles.TechRecordAmend },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
   },
   {
     path: 'correcting-an-error/tyre-search/:axleNumber',
@@ -131,7 +131,7 @@ const routes: Routes = [
       reason: ReasonForEditing.CORRECTING_AN_ERROR,
     },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
   },
   {
     path: 'correcting-an-error/change-summary',
@@ -155,20 +155,20 @@ const routes: Routes = [
       reason: ReasonForEditing.NOTIFIABLE_ALTERATION_NEEDED,
     },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
   },
   {
     path: 'test-records/test-result/:testResultId/:testNumber',
     data: { title: 'Test record', roles: Roles.TestResultView },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
     loadChildren: () => import('../test-records/amend/amend-test-records.module').then((m) => m.AmendTestRecordsModule),
   },
   {
     path: 'test-records/create-test',
     data: { title: 'Create Contingency test', roles: Roles.TestResultCreateContingency },
     canActivate: [MsalGuard, RoleGuard],
-    resolve: { techRecord: TechRecordViewResolver },
+    resolve: { techRecord: techRecordViewResolver },
     loadChildren: () => import('../test-records/create/create-test-records.module').then((m) => m.CreateTestRecordsModule),
   },
 ];

--- a/src/app/features/test-records/amend/amend-test-records-routing.module.ts
+++ b/src/app/features/test-records/amend/amend-test-records-routing.module.ts
@@ -5,9 +5,9 @@ import { DefectComponent } from '@forms/custom-sections/defect/defect.component'
 import { CancelEditTestGuard } from '@guards/cancel-edit-test/cancel-edit-test.guard';
 import { RoleGuard } from '@guards/role-guard/roles.guard';
 import { Roles } from '@models/roles.enum';
-import { DefectsTaxonomyResolver } from 'src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver';
-import { TestResultResolver } from 'src/app/resolvers/test-result/test-result.resolver';
-import { TestTypeTaxonomyResolver } from 'src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver';
+import { defectsTaxonomyResolver } from 'src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver';
+import { testResultResolver } from 'src/app/resolvers/test-result/test-result.resolver';
+import { testTypeTaxonomyResolver } from 'src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver';
 import { AmendedTestRecordComponent } from './views/amended-test-record/amended-test-record.component';
 import { ConfirmCancellationComponent } from './views/confirm-cancellation/confirm-cancellation.component';
 import { TestAmendReasonComponent } from './views/test-amend-reason/test-amend-reason.component';
@@ -20,7 +20,7 @@ const routes: Routes = [
   {
     path: '',
     component: TestRouterOutletComponent,
-    resolve: { load: TestResultResolver, testTypeTaxonomy: TestTypeTaxonomyResolver },
+    resolve: { load: testResultResolver, testTypeTaxonomy: testTypeTaxonomyResolver },
     children: [
       {
         path: '',
@@ -40,7 +40,7 @@ const routes: Routes = [
             path: 'incorrect-test-type',
             component: TestRouterOutletComponent,
             data: { title: 'Select a test type', roles: Roles.TestResultAmend },
-            resolve: { testTypeTaxonomy: TestTypeTaxonomyResolver },
+            resolve: { testTypeTaxonomy: testTypeTaxonomyResolver },
             canActivate: [RoleGuard],
             children: [
               {
@@ -53,7 +53,7 @@ const routes: Routes = [
             path: 'amend-test-details',
             component: TestRouterOutletComponent,
             data: { title: 'Test details', roles: Roles.TestResultAmend },
-            resolve: { load: TestResultResolver, testTypeTaxonomy: TestTypeTaxonomyResolver, defectTaxonomy: DefectsTaxonomyResolver },
+            resolve: { load: testResultResolver, testTypeTaxonomy: testTypeTaxonomyResolver, defectTaxonomy: defectsTaxonomyResolver },
             canActivate: [RoleGuard],
             canDeactivate: [CancelEditTestGuard],
             children: [
@@ -106,7 +106,7 @@ const routes: Routes = [
         path: 'defect/:defectIndex',
         component: DefectComponent,
         data: { title: 'Defect', roles: Roles.TestResultView, isEditing: false },
-        resolve: { load: TestResultResolver },
+        resolve: { load: testResultResolver },
         canActivate: [RoleGuard],
       },
     ],

--- a/src/app/features/test-records/create/create-test-records-routing.module.ts
+++ b/src/app/features/test-records/create/create-test-records-routing.module.ts
@@ -4,10 +4,10 @@ import { DefectSelectComponent } from '@forms/components/defect-select/defect-se
 import { DefectComponent } from '@forms/custom-sections/defect/defect.component';
 import { RoleGuard } from '@guards/role-guard/roles.guard';
 import { Roles } from '@models/roles.enum';
-import { ContingencyTestResolver } from 'src/app/resolvers/contingency-test/contingency-test.resolver';
-import { DefectsTaxonomyResolver } from 'src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver';
-import { TestStationsResolver } from 'src/app/resolvers/test-stations/test-stations.resolver';
-import { TestTypeTaxonomyResolver } from 'src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver';
+import { contingencyTestResolver } from 'src/app/resolvers/contingency-test/contingency-test.resolver';
+import { defectsTaxonomyResolver } from 'src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver';
+import { testStationsResolver } from 'src/app/resolvers/test-stations/test-stations.resolver';
+import { testTypeTaxonomyResolver } from 'src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver';
 import { CreateTestRecordComponent } from './views/create-test-record/create-test-record.component';
 import { CreateTestTypeComponent } from './views/create-test-type/create-test-type.component';
 import { TestRouterOutletComponent } from './views/test-router-outlet/test-router-outlet.component';
@@ -16,7 +16,7 @@ const routes: Routes = [
   {
     path: '',
     component: TestRouterOutletComponent,
-    resolve: { contingencyTest: ContingencyTestResolver },
+    resolve: { contingencyTest: contingencyTestResolver },
     children: [
       {
         path: '',
@@ -25,12 +25,12 @@ const routes: Routes = [
       {
         path: 'type',
         component: CreateTestTypeComponent,
-        resolve: { testTypeTaxonomy: TestTypeTaxonomyResolver, contingencyTest: ContingencyTestResolver },
+        resolve: { testTypeTaxonomy: testTypeTaxonomyResolver, contingencyTest: contingencyTestResolver },
       },
       {
         path: 'test-details',
         component: TestRouterOutletComponent,
-        resolve: { testTypeTaxonomy: TestTypeTaxonomyResolver, defectTaxonomy: DefectsTaxonomyResolver, testStations: TestStationsResolver },
+        resolve: { TestTypeTaxonomy: testTypeTaxonomyResolver, defectTaxonomy: defectsTaxonomyResolver, testStations: testStationsResolver },
         data: { title: 'Test details', roles: Roles.TestResultCreateContingency, breadcrumbPreserveQueryParams: true },
         canActivate: [RoleGuard],
         children: [
@@ -47,7 +47,7 @@ const routes: Routes = [
           {
             path: 'selectDefect',
             component: TestRouterOutletComponent,
-            data: { title: 'Select Defect', roles: Roles.TestResultCreateContingency },
+            data: { title: 'Select defect', roles: Roles.TestResultCreateContingency },
             children: [
               {
                 path: '',

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
@@ -17,8 +17,8 @@ import {
   of,
   throwError,
 } from 'rxjs';
-import { contingencyTestResolver } from './contingency-test.resolver';
 import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { contingencyTestResolver } from './contingency-test.resolver';
 
 describe('ContingencyTestResolver', () => {
   let resolver: ResolveFn<boolean>;
@@ -44,7 +44,7 @@ describe('ContingencyTestResolver', () => {
       ],
     });
     resolver = (...resolverParameters) =>
-    TestBed.runInInjectionContext(() => contingencyTestResolver(...resolverParameters));
+      TestBed.runInInjectionContext(() => contingencyTestResolver(...resolverParameters));
     store = TestBed.inject(MockStore);
     techRecordService = TestBed.inject(TechnicalRecordService);
   });
@@ -57,7 +57,8 @@ describe('ContingencyTestResolver', () => {
     const dispatchSpy = jest.spyOn(store, 'dispatch');
     jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv') as TechRecordType<'psv'>));
     const result = TestBed.runInInjectionContext(
-      () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+      () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    ) as Observable<boolean>;
     const resolveResult = await firstValueFrom(result);
 
     expect(resolveResult).toBe(true);
@@ -69,7 +70,8 @@ describe('ContingencyTestResolver', () => {
     jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv') as TechRecordType<'psv'>));
     jest.spyOn(MockUserService, 'user$', 'get').mockImplementationOnce(() => throwError(() => new Error('foo')));
     const result = TestBed.runInInjectionContext(
-      () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+      () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    ) as Observable<boolean>;
     const resolveResult = await firstValueFrom(result);
     expect(resolveResult).toBe(false);
   });

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
@@ -17,10 +17,11 @@ import {
   of,
   throwError,
 } from 'rxjs';
-import { ContingencyTestResolver } from './contingency-test.resolver';
+import { contingencyTestResolver } from './contingency-test.resolver';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 
 describe('ContingencyTestResolver', () => {
-  let resolver: ContingencyTestResolver;
+  let resolver: ResolveFn<boolean>;
   const actions$ = new ReplaySubject<Action>();
   let store: MockStore<State>;
   let techRecordService: TechnicalRecordService;
@@ -42,7 +43,8 @@ describe('ContingencyTestResolver', () => {
         { provide: UserService, useValue: MockUserService },
       ],
     });
-    resolver = TestBed.inject(ContingencyTestResolver);
+    resolver = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() => contingencyTestResolver(...resolverParameters));
     store = TestBed.inject(MockStore);
     techRecordService = TestBed.inject(TechnicalRecordService);
   });
@@ -54,8 +56,9 @@ describe('ContingencyTestResolver', () => {
   it('should return true and dispatch the initial contingency test action', async () => {
     const dispatchSpy = jest.spyOn(store, 'dispatch');
     jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv') as TechRecordType<'psv'>));
-
-    const resolveResult = await firstValueFrom(resolver.resolve());
+    const result = TestBed.runInInjectionContext(
+      () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+    const resolveResult = await firstValueFrom(result);
 
     expect(resolveResult).toBe(true);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
@@ -65,7 +68,9 @@ describe('ContingencyTestResolver', () => {
   it('should return false if there is an error', async () => {
     jest.spyOn(techRecordService, 'techRecord$', 'get').mockReturnValue(of(mockVehicleTechnicalRecord('psv') as TechRecordType<'psv'>));
     jest.spyOn(MockUserService, 'user$', 'get').mockImplementationOnce(() => throwError(() => new Error('foo')));
-    const resolveResult = await firstValueFrom(resolver.resolve());
+    const result = TestBed.runInInjectionContext(
+      () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+    const resolveResult = await firstValueFrom(result);
     expect(resolveResult).toBe(false);
   });
 });

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { ResolveFn } from '@angular/router';
 import { TechRecordType as VehicleType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { TestResultModel } from '@models/test-results/test-result.model';
@@ -23,7 +23,7 @@ import {
 } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-export const contingencyTestResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const contingencyTestResolver: ResolveFn<boolean> = () => {
   const store: Store<State> = inject(Store<State>);
   const action$: Actions = inject(Actions);
   const techRecordService: TechnicalRecordService = inject(TechnicalRecordService);

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.ts
@@ -1,11 +1,10 @@
-import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { TechRecordType as VehicleType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { TypeOfTest } from '@models/test-results/typeOfTest.enum';
 import { TestType } from '@models/test-types/test-type.model';
-import { DescriptionEnum, VehicleClass } from '@models/vehicle-class.model';
 import { Actions } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -16,7 +15,6 @@ import { initialContingencyTest } from '@store/test-records';
 import {
   catchError,
   map,
-  Observable,
   of,
   switchMap,
   take,
@@ -25,39 +23,32 @@ import {
 } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class ContingencyTestResolver implements Resolve<boolean> {
-  constructor(
-    private store: Store<State>,
-    private action$: Actions,
-    private techRecordService: TechnicalRecordService,
-    private userService: UserService,
-  ) {}
-
-  resolve(): Observable<boolean> {
-    return this.techRecordService.techRecord$.pipe(
-      switchMap((techRecord) => {
-        const { vin, systemNumber } = techRecord as TechRecordType<'get'>;
-        const vrm = techRecord?.techRecord_vehicleType !== 'trl' ? techRecord?.primaryVrm : undefined;
-        const trailerId = techRecord?.techRecord_vehicleType === 'trl' ? techRecord.trailerId : undefined;
-        return this.store.select(selectTechRecord).pipe(
-          withLatestFrom(this.userService.user$),
-          map(([viewableTechRecord, user]) => {
-            const now = new Date();
-            return {
-              vin,
-              vrm,
-              trailerId,
-              systemNumber,
-              vehicleType: viewableTechRecord?.techRecord_vehicleType,
-              statusCode: viewableTechRecord?.techRecord_statusCode,
-              testResultId: uuidv4(),
-              euVehicleCategory: (viewableTechRecord as TechRecordType<'get'>)?.techRecord_euVehicleCategory ?? null,
-              vehicleSize: viewableTechRecord?.techRecord_vehicleType === 'psv' ? viewableTechRecord?.techRecord_vehicleSize : undefined,
-              vehicleConfiguration: (viewableTechRecord as TechRecordType<'get'>)?.techRecord_vehicleConfiguration ?? null,
-              vehicleClass:
+export const contingencyTestResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+  const store: Store<State> = inject(Store<State>);
+  const action$: Actions = inject(Actions);
+  const techRecordService: TechnicalRecordService = inject(TechnicalRecordService);
+  const userService: UserService = inject(UserService);
+  return techRecordService.techRecord$.pipe(
+    switchMap((techRecord) => {
+      const { vin, systemNumber } = techRecord as TechRecordType<'get'>;
+      const vrm = techRecord?.techRecord_vehicleType !== 'trl' ? techRecord?.primaryVrm : undefined;
+      const trailerId = techRecord?.techRecord_vehicleType === 'trl' ? techRecord.trailerId : undefined;
+      return store.select(selectTechRecord).pipe(
+        withLatestFrom(userService.user$),
+        map(([viewableTechRecord, user]) => {
+          const now = new Date();
+          return {
+            vin,
+            vrm,
+            trailerId,
+            systemNumber,
+            vehicleType: viewableTechRecord?.techRecord_vehicleType,
+            statusCode: viewableTechRecord?.techRecord_statusCode,
+            testResultId: uuidv4(),
+            euVehicleCategory: (viewableTechRecord as TechRecordType<'get'>)?.techRecord_euVehicleCategory ?? null,
+            vehicleSize: viewableTechRecord?.techRecord_vehicleType === 'psv' ? viewableTechRecord?.techRecord_vehicleSize : undefined,
+            vehicleConfiguration: (viewableTechRecord as TechRecordType<'get'>)?.techRecord_vehicleConfiguration ?? null,
+            vehicleClass:
                 (viewableTechRecord?.techRecord_vehicleType === 'psv'
                 || viewableTechRecord?.techRecord_vehicleType === 'trl'
                 || viewableTechRecord?.techRecord_vehicleType === 'hgv'
@@ -68,49 +59,48 @@ export class ContingencyTestResolver implements Resolve<boolean> {
                     description: viewableTechRecord?.techRecord_vehicleClass_description,
                   }
                   : null,
-              vehicleSubclass:
+            vehicleSubclass:
                 viewableTechRecord && 'techRecord_vehicleSubclass' in viewableTechRecord ? viewableTechRecord.techRecord_vehicleSubclass : null,
-              noOfAxles: viewableTechRecord?.techRecord_noOfAxles ?? 0,
-              numberOfWheelsDriven:
+            noOfAxles: viewableTechRecord?.techRecord_noOfAxles ?? 0,
+            numberOfWheelsDriven:
                 viewableTechRecord && 'techRecord_numberOfWheelsDriven' in viewableTechRecord
                   ? viewableTechRecord.techRecord_numberOfWheelsDriven
                   : null,
-              testStatus: 'submitted',
-              regnDate: viewableTechRecord?.techRecord_regnDate,
-              numberOfSeats:
+            testStatus: 'submitted',
+            regnDate: viewableTechRecord?.techRecord_regnDate,
+            numberOfSeats:
                 ((viewableTechRecord as VehicleType<'psv'>)?.techRecord_seatsLowerDeck ?? 0)
               + ((viewableTechRecord as VehicleType<'psv'>)?.techRecord_seatsUpperDeck ?? 0),
-              reasonForCancellation: '',
-              createdAt: now.toISOString(),
-              lastUpdatedAt: now.toISOString(),
-              firstUseDate: viewableTechRecord?.techRecord_vehicleType === 'trl' ? viewableTechRecord?.techRecord_firstUseDate : null,
-              createdByName: user.name,
-              createdById: user.oid,
-              lastUpdatedByName: user.name,
-              lastUpdatedById: user.oid,
-              typeOfTest: TypeOfTest.CONTINGENCY,
-              source: 'vtm',
-              testTypes: [
-                {
-                  testResult: 'pass',
-                  prohibitionIssued: null,
-                  additionalCommentsForAbandon: null,
-                } as TestType,
-              ],
-            } as Partial<TestResultModel>;
-          }),
-        );
-      }),
-      tap((testResult) => {
-        this.store.dispatch(initialContingencyTest({ testResult }));
-      }),
-      take(1),
-      map(() => {
-        return true;
-      }),
-      catchError(() => {
-        return of(false);
-      }),
-    );
-  }
-}
+            reasonForCancellation: '',
+            createdAt: now.toISOString(),
+            lastUpdatedAt: now.toISOString(),
+            firstUseDate: viewableTechRecord?.techRecord_vehicleType === 'trl' ? viewableTechRecord?.techRecord_firstUseDate : null,
+            createdByName: user.name,
+            createdById: user.oid,
+            lastUpdatedByName: user.name,
+            lastUpdatedById: user.oid,
+            typeOfTest: TypeOfTest.CONTINGENCY,
+            source: 'vtm',
+            testTypes: [
+              {
+                testResult: 'pass',
+                prohibitionIssued: null,
+                additionalCommentsForAbandon: null,
+              } as TestType,
+            ],
+          } as Partial<TestResultModel>;
+        }),
+      );
+    }),
+    tap((testResult) => {
+      store.dispatch(initialContingencyTest({ testResult }));
+    }),
+    take(1),
+    map(() => {
+      return true;
+    }),
+    catchError(() => {
+      return of(false);
+    }),
+  );
+};

--- a/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.spec.ts
+++ b/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.spec.ts
@@ -6,8 +6,8 @@ import { initialAppState, State } from '@store/.';
 import { fetchDefects, fetchDefectsFailed, fetchDefectsSuccess } from '@store/defects';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { defectsTaxonomyResolver } from './defects-taxonomy.resolver';
 import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { defectsTaxonomyResolver } from './defects-taxonomy.resolver';
 
 describe('DefectsTaxonomyResolver', () => {
   let resolver: ResolveFn<boolean>;
@@ -20,7 +20,7 @@ describe('DefectsTaxonomyResolver', () => {
       providers: [provideMockStore({ initialState: initialAppState }), provideMockActions(() => actions$)],
     });
     resolver = (...resolverParameters) =>
-    TestBed.runInInjectionContext(() => defectsTaxonomyResolver(...resolverParameters));
+      TestBed.runInInjectionContext(() => defectsTaxonomyResolver(...resolverParameters));
     store = TestBed.inject(MockStore);
   });
 
@@ -38,7 +38,8 @@ describe('DefectsTaxonomyResolver', () => {
     it('should resolve to true when all actions are success type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchDefectsSuccess });
         expectObservable(result).toBe('-(b|)', {
@@ -52,7 +53,8 @@ describe('DefectsTaxonomyResolver', () => {
     it('should resolve to false when one or more actions are of failure type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchDefectsFailed });
         expectObservable(result).toBe('-(b|)', {

--- a/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.spec.ts
+++ b/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.spec.ts
@@ -6,10 +6,11 @@ import { initialAppState, State } from '@store/.';
 import { fetchDefects, fetchDefectsFailed, fetchDefectsSuccess } from '@store/defects';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { DefectsTaxonomyResolver } from './defects-taxonomy.resolver';
+import { defectsTaxonomyResolver } from './defects-taxonomy.resolver';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 
 describe('DefectsTaxonomyResolver', () => {
-  let resolver: DefectsTaxonomyResolver;
+  let resolver: ResolveFn<boolean>;
   let actions$ = new Observable<Action>();
   let testScheduler: TestScheduler;
   let store: MockStore<State>;
@@ -18,7 +19,8 @@ describe('DefectsTaxonomyResolver', () => {
     TestBed.configureTestingModule({
       providers: [provideMockStore({ initialState: initialAppState }), provideMockActions(() => actions$)],
     });
-    resolver = TestBed.inject(DefectsTaxonomyResolver);
+    resolver = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() => defectsTaxonomyResolver(...resolverParameters));
     store = TestBed.inject(MockStore);
   });
 
@@ -35,9 +37,11 @@ describe('DefectsTaxonomyResolver', () => {
   describe('fetch test types', () => {
     it('should resolve to true when all actions are success type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchDefectsSuccess });
-        expectObservable(resolver.resolve()).toBe('-(b|)', {
+        expectObservable(result).toBe('-(b|)', {
           b: true,
         });
       });
@@ -47,9 +51,11 @@ describe('DefectsTaxonomyResolver', () => {
 
     it('should resolve to false when one or more actions are of failure type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchDefectsFailed });
-        expectObservable(resolver.resolve()).toBe('-(b|)', {
+        expectObservable(result).toBe('-(b|)', {
           b: false,
         });
       });

--- a/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.ts
+++ b/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import {
@@ -8,21 +8,16 @@ import {
   fetchDefectsFailed,
   fetchDefectsSuccess,
 } from '@store/defects';
-import { map, Observable, take } from 'rxjs';
+import { map, take } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class DefectsTaxonomyResolver implements Resolve<boolean> {
-  constructor(private store: Store<DefectsState>, private action$: Actions) {}
+export const defectsTaxonomyResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+  const store: Store<DefectsState> = inject(Store<DefectsState>);
+  const action$: Actions = inject(Actions);
+  store.dispatch(fetchDefects());
 
-  resolve(): Observable<boolean> {
-    this.store.dispatch(fetchDefects());
-
-    return this.action$.pipe(
-      ofType(fetchDefectsSuccess, fetchDefectsFailed),
-      take(1),
-      map((action) => action.type === fetchDefectsSuccess.type),
-    );
-  }
-}
+  return action$.pipe(
+    ofType(fetchDefectsSuccess, fetchDefectsFailed),
+    take(1),
+    map((action) => action.type === fetchDefectsSuccess.type),
+  );
+};

--- a/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.ts
+++ b/src/app/resolvers/defects-taxonomy/defects-taxonomy.resolver.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { ResolveFn } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import {
@@ -10,7 +10,7 @@ import {
 } from '@store/defects';
 import { map, take } from 'rxjs';
 
-export const defectsTaxonomyResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const defectsTaxonomyResolver: ResolveFn<boolean> = () => {
   const store: Store<DefectsState> = inject(Store<DefectsState>);
   const action$: Actions = inject(Actions);
   store.dispatch(fetchDefects());

--- a/src/app/resolvers/tech-record-view/tech-record-view.resolver.spec.ts
+++ b/src/app/resolvers/tech-record-view/tech-record-view.resolver.spec.ts
@@ -28,7 +28,7 @@ describe('TechRecordViewResolver', () => {
     });
     store = TestBed.inject(MockStore);
     resolver = (...resolverParameters) =>
-  TestBed.runInInjectionContext(() => techRecordViewResolver(...resolverParameters));
+      TestBed.runInInjectionContext(() => techRecordViewResolver(...resolverParameters));
   });
 
   beforeEach(() => {
@@ -45,7 +45,8 @@ describe('TechRecordViewResolver', () => {
     it('should resolved to true when both success actions are triggered', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
@@ -61,7 +62,8 @@ describe('TechRecordViewResolver', () => {
     it('should resolve to false if \'getTechRecordV3Failure\' action if dispatched', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
@@ -77,7 +79,8 @@ describe('TechRecordViewResolver', () => {
     it('should resolved to false if \'fetchTestResultsBySystemNumberFailed\' action is dipatched', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
@@ -93,7 +96,8 @@ describe('TechRecordViewResolver', () => {
     it('should resolved to false if \'fetchTestResultsBySystemNumberFailed\' and \'getTechRecordV3Failure\' action are dipatched', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {

--- a/src/app/resolvers/tech-record-view/tech-record-view.resolver.spec.ts
+++ b/src/app/resolvers/tech-record-view/tech-record-view.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -9,10 +9,10 @@ import { getTechRecordV3Failure, getTechRecordV3Success } from '@store/technical
 import { fetchTestResultsBySystemNumberFailed, fetchTestResultsBySystemNumberSuccess } from '@store/test-records';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { TechRecordViewResolver } from './tech-record-view.resolver';
+import { techRecordViewResolver } from './tech-record-view.resolver';
 
 describe('TechRecordViewResolver', () => {
-  let resolver: TechRecordViewResolver;
+  let resolver: ResolveFn<boolean>;
   let actions$ = new Observable<Action>();
   let testScheduler: TestScheduler;
   const mockSnapshot: any = jest.fn;
@@ -21,14 +21,14 @@ describe('TechRecordViewResolver', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        TechRecordViewResolver,
         provideMockStore({ initialState: initialAppState }),
         provideMockActions(() => actions$),
         { provide: RouterStateSnapshot, useValue: mockSnapshot },
       ],
     });
     store = TestBed.inject(MockStore);
-    resolver = TestBed.inject(TechRecordViewResolver);
+    resolver = (...resolverParameters) =>
+  TestBed.runInInjectionContext(() => techRecordViewResolver(...resolverParameters));
   });
 
   beforeEach(() => {
@@ -44,11 +44,13 @@ describe('TechRecordViewResolver', () => {
   describe('fetch tech record result', () => {
     it('should resolved to true when both success actions are triggered', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a-b-', { a: getTechRecordV3Success, b: fetchTestResultsBySystemNumberSuccess });
-        expectObservable(resolver.resolve()).toBe('---(c|)', {
+        expectObservable(result).toBe('---(c|)', {
           c: true,
         });
       });
@@ -58,11 +60,13 @@ describe('TechRecordViewResolver', () => {
 
     it('should resolve to false if \'getTechRecordV3Failure\' action if dispatched', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a-b-', { a: getTechRecordV3Failure, b: fetchTestResultsBySystemNumberSuccess });
-        expectObservable(resolver.resolve()).toBe('---(c|)', {
+        expectObservable(result).toBe('---(c|)', {
           c: false,
         });
       });
@@ -72,11 +76,13 @@ describe('TechRecordViewResolver', () => {
 
     it('should resolved to false if \'fetchTestResultsBySystemNumberFailed\' action is dipatched', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a-b-', { a: getTechRecordV3Success, b: fetchTestResultsBySystemNumberFailed });
-        expectObservable(resolver.resolve()).toBe('---(c|)', {
+        expectObservable(result).toBe('---(c|)', {
           c: false,
         });
       });
@@ -86,11 +92,13 @@ describe('TechRecordViewResolver', () => {
 
     it('should resolved to false if \'fetchTestResultsBySystemNumberFailed\' and \'getTechRecordV3Failure\' action are dipatched', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       store.overrideSelector(selectRouteParam('systemNumber'), undefined);
       store.overrideSelector(selectRouteParam('createdTimestamp'), undefined);
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a-b-', { a: getTechRecordV3Failure, b: fetchTestResultsBySystemNumberFailed });
-        expectObservable(resolver.resolve()).toBe('---(c|)', {
+        expectObservable(result).toBe('---(c|)', {
           c: false,
         });
       });

--- a/src/app/resolvers/tech-record-view/tech-record-view.resolver.ts
+++ b/src/app/resolvers/tech-record-view/tech-record-view.resolver.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { ResolveFn } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { State } from '@store/.';
@@ -12,7 +12,7 @@ import {
   take,
 } from 'rxjs';
 
-export const techRecordViewResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const techRecordViewResolver: ResolveFn<boolean> = () => {
   const store: Store<State> = inject(Store<State>);
   const action$: Actions = inject(Actions);
   store.pipe(select(selectRouteNestedParams), take(1)).subscribe(({ systemNumber, createdTimestamp }) => {

--- a/src/app/resolvers/test-result/test-result.resolver.ts
+++ b/src/app/resolvers/test-result/test-result.resolver.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { State } from '@store/.';
@@ -9,24 +9,19 @@ import {
   fetchSelectedTestResultFailed,
   fetchSelectedTestResultSuccess,
 } from '@store/test-records';
-import { map, Observable, take } from 'rxjs';
+import { map, take } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class TestResultResolver implements Resolve<boolean> {
-  constructor(private store: Store<State>, private action$: Actions) {}
+export const testResultResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+  const store: Store<State> = inject(Store<State>);
+  const action$: Actions = inject(Actions);
+  store.dispatch(fetchSelectedTestResult());
+  store.dispatch(cancelEditingTestResult());
 
-  resolve(): Observable<boolean> {
-    this.store.dispatch(fetchSelectedTestResult());
-    this.store.dispatch(cancelEditingTestResult());
-
-    return this.action$.pipe(
-      ofType(fetchSelectedTestResultSuccess, fetchSelectedTestResultFailed),
-      take(1),
-      map((action) => {
-        return action.type === fetchSelectedTestResultSuccess.type;
-      }),
-    );
-  }
-}
+  return action$.pipe(
+    ofType(fetchSelectedTestResultSuccess, fetchSelectedTestResultFailed),
+    take(1),
+    map((action) => {
+      return action.type === fetchSelectedTestResultSuccess.type;
+    }),
+  );
+};

--- a/src/app/resolvers/test-result/test-result.resolver.ts
+++ b/src/app/resolvers/test-result/test-result.resolver.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { ResolveFn } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { State } from '@store/.';
@@ -11,7 +11,7 @@ import {
 } from '@store/test-records';
 import { map, take } from 'rxjs';
 
-export const testResultResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const testResultResolver: ResolveFn<boolean> = () => {
   const store: Store<State> = inject(Store<State>);
   const action$: Actions = inject(Actions);
   store.dispatch(fetchSelectedTestResult());

--- a/src/app/resolvers/test-stations/test-stations.resolver.spec.ts
+++ b/src/app/resolvers/test-stations/test-stations.resolver.spec.ts
@@ -1,15 +1,16 @@
 import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { initialAppState, State } from '@store/.';
+import { State, initialAppState } from '@store/.';
 import { fetchTestStations, fetchTestStationsFailed, fetchTestStationsSuccess } from '@store/test-stations';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { TestStationsResolver } from './test-stations.resolver';
+import { testStationsResolver } from './test-stations.resolver';
 
 describe('TestTypeTaxonomyResolver', () => {
-  let resolver: TestStationsResolver;
+  let resolver: ResolveFn<boolean>;
   let actions$ = new Observable<Action>();
   let testScheduler: TestScheduler;
   let store: MockStore<State>;
@@ -18,8 +19,9 @@ describe('TestTypeTaxonomyResolver', () => {
     TestBed.configureTestingModule({
       providers: [provideMockStore({ initialState: initialAppState }), provideMockActions(() => actions$)],
     });
-    resolver = TestBed.inject(TestStationsResolver);
     store = TestBed.inject(MockStore);
+    resolver = (...resolverParameters) =>
+      TestBed.runInInjectionContext(() => testStationsResolver(...resolverParameters));
   });
 
   beforeEach(() => {
@@ -35,9 +37,13 @@ describe('TestTypeTaxonomyResolver', () => {
   describe('fetch test stations', () => {
     it('should resolve to true when all actions are success type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchTestStationsSuccess });
-        expectObservable(resolver.resolve()).toBe('-(b|)', {
+
+        expectObservable(result).toBe('-(b|)', {
           b: true,
         });
       });
@@ -47,9 +53,12 @@ describe('TestTypeTaxonomyResolver', () => {
 
     it('should resolve to false when one or more actions are of failure type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchTestStationsFailed });
-        expectObservable(resolver.resolve()).toBe('-(b|)', {
+        expectObservable(result).toBe('-(b|)', {
           b: false,
         });
       });

--- a/src/app/resolvers/test-stations/test-stations.resolver.ts
+++ b/src/app/resolvers/test-stations/test-stations.resolver.ts
@@ -1,24 +1,19 @@
-import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { State } from '@store/.';
 import { fetchTestStations, fetchTestStationsFailed, fetchTestStationsSuccess } from '@store/test-stations';
-import { map, Observable, take } from 'rxjs';
+import { map, take } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class TestStationsResolver implements Resolve<boolean> {
-  constructor(private store: Store<State>, private action$: Actions) {}
+export const testStationsResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+  const store: Store<State> = inject(Store<State>);
+  const action$: Actions = inject(Actions);
+  store.dispatch(fetchTestStations());
 
-  resolve(): Observable<boolean> {
-    this.store.dispatch(fetchTestStations());
-
-    return this.action$.pipe(
-      ofType(fetchTestStationsSuccess, fetchTestStationsFailed),
-      take(1),
-      map((action) => action.type === fetchTestStationsSuccess.type),
-    );
-  }
-}
+  return action$.pipe(
+    ofType(fetchTestStationsSuccess, fetchTestStationsFailed),
+    take(1),
+    map((action) => action.type === fetchTestStationsSuccess.type),
+  );
+};

--- a/src/app/resolvers/test-stations/test-stations.resolver.ts
+++ b/src/app/resolvers/test-stations/test-stations.resolver.ts
@@ -1,12 +1,12 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { ResolveFn } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { State } from '@store/.';
 import { fetchTestStations, fetchTestStationsFailed, fetchTestStationsSuccess } from '@store/test-stations';
 import { map, take } from 'rxjs';
 
-export const testStationsResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const testStationsResolver: ResolveFn<boolean> = () => {
   const store: Store<State> = inject(Store<State>);
   const action$: Actions = inject(Actions);
   store.dispatch(fetchTestStations());

--- a/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.spec.ts
+++ b/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.spec.ts
@@ -6,8 +6,8 @@ import { initialAppState, State } from '@store/.';
 import { fetchTestTypes, fetchTestTypesFailed, fetchTestTypesSuccess } from '@store/test-types/actions/test-types.actions';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { testTypeTaxonomyResolver } from './test-type-taxonomy.resolver';
 import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { testTypeTaxonomyResolver } from './test-type-taxonomy.resolver';
 
 describe('TestTypeTaxonomyResolver', () => {
   let resolver: ResolveFn<boolean>;
@@ -20,7 +20,7 @@ describe('TestTypeTaxonomyResolver', () => {
       providers: [provideMockStore({ initialState: initialAppState }), provideMockActions(() => actions$)],
     });
     resolver = (...resolverParameters) =>
-    TestBed.runInInjectionContext(() => testTypeTaxonomyResolver(...resolverParameters));
+      TestBed.runInInjectionContext(() => testTypeTaxonomyResolver(...resolverParameters));
     store = TestBed.inject(MockStore);
   });
 
@@ -38,7 +38,8 @@ describe('TestTypeTaxonomyResolver', () => {
     it('should resolve to true when all actions are success type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchTestTypesSuccess });
         expectObservable(result).toBe('-(b|)', {
@@ -52,7 +53,8 @@ describe('TestTypeTaxonomyResolver', () => {
     it('should resolve to false when one or more actions are of failure type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
       const result = TestBed.runInInjectionContext(
-        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
+        () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+      ) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchTestTypesFailed });
         expectObservable(result).toBe('-(b|)', {

--- a/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.spec.ts
+++ b/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.spec.ts
@@ -6,10 +6,11 @@ import { initialAppState, State } from '@store/.';
 import { fetchTestTypes, fetchTestTypesFailed, fetchTestTypesSuccess } from '@store/test-types/actions/test-types.actions';
 import { Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { TestTypeTaxonomyResolver } from './test-type-taxonomy.resolver';
+import { testTypeTaxonomyResolver } from './test-type-taxonomy.resolver';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 
 describe('TestTypeTaxonomyResolver', () => {
-  let resolver: TestTypeTaxonomyResolver;
+  let resolver: ResolveFn<boolean>;
   let actions$ = new Observable<Action>();
   let testScheduler: TestScheduler;
   let store: MockStore<State>;
@@ -18,7 +19,8 @@ describe('TestTypeTaxonomyResolver', () => {
     TestBed.configureTestingModule({
       providers: [provideMockStore({ initialState: initialAppState }), provideMockActions(() => actions$)],
     });
-    resolver = TestBed.inject(TestTypeTaxonomyResolver);
+    resolver = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() => testTypeTaxonomyResolver(...resolverParameters));
     store = TestBed.inject(MockStore);
   });
 
@@ -35,9 +37,11 @@ describe('TestTypeTaxonomyResolver', () => {
   describe('fetch test types', () => {
     it('should resolve to true when all actions are success type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchTestTypesSuccess });
-        expectObservable(resolver.resolve()).toBe('-(b|)', {
+        expectObservable(result).toBe('-(b|)', {
           b: true,
         });
       });
@@ -47,9 +51,11 @@ describe('TestTypeTaxonomyResolver', () => {
 
     it('should resolve to false when one or more actions are of failure type', () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
+      const result = TestBed.runInInjectionContext(
+        () => resolver({} as ActivatedRouteSnapshot,{} as RouterStateSnapshot)) as Observable<boolean>;
       testScheduler.run(({ hot, expectObservable }) => {
         actions$ = hot('-a', { a: fetchTestTypesFailed });
-        expectObservable(resolver.resolve()).toBe('-(b|)', {
+        expectObservable(result).toBe('-(b|)', {
           b: false,
         });
       });

--- a/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.ts
+++ b/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.ts
@@ -6,9 +6,7 @@ import { State } from '@store/.';
 import { fetchTestTypes, fetchTestTypesFailed, fetchTestTypesSuccess } from '@store/test-types/actions/test-types.actions';
 import { map, take } from 'rxjs';
 
-
-export const testTypeTaxonomyResolver: ResolveFn<boolean> =
-(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const testTypeTaxonomyResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
   const store: Store<State> = inject(Store<State>);
   const action$: Actions = inject(Actions);
   store.dispatch(fetchTestTypes());
@@ -18,4 +16,4 @@ export const testTypeTaxonomyResolver: ResolveFn<boolean> =
     take(1),
     map((action) => action.type === fetchTestTypesSuccess.type),
   );
-}
+};

--- a/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.ts
+++ b/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.ts
@@ -1,24 +1,21 @@
-import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { State } from '@store/.';
 import { fetchTestTypes, fetchTestTypesFailed, fetchTestTypesSuccess } from '@store/test-types/actions/test-types.actions';
-import { map, Observable, take } from 'rxjs';
+import { map, take } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class TestTypeTaxonomyResolver implements Resolve<boolean> {
-  constructor(private store: Store<State>, private action$: Actions) {}
 
-  resolve(): Observable<boolean> {
-    this.store.dispatch(fetchTestTypes());
+export const testTypeTaxonomyResolver: ResolveFn<boolean> =
+(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+  const store: Store<State> = inject(Store<State>);
+  const action$: Actions = inject(Actions);
+  store.dispatch(fetchTestTypes());
 
-    return this.action$.pipe(
-      ofType(fetchTestTypesSuccess, fetchTestTypesFailed),
-      take(1),
-      map((action) => action.type === fetchTestTypesSuccess.type),
-    );
-  }
+  return action$.pipe(
+    ofType(fetchTestTypesSuccess, fetchTestTypesFailed),
+    take(1),
+    map((action) => action.type === fetchTestTypesSuccess.type),
+  );
 }

--- a/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.ts
+++ b/src/app/resolvers/test-type-taxonomy/test-type-taxonomy.resolver.ts
@@ -1,12 +1,12 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { ResolveFn } from '@angular/router';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { State } from '@store/.';
 import { fetchTestTypes, fetchTestTypesFailed, fetchTestTypesSuccess } from '@store/test-types/actions/test-types.actions';
 import { map, take } from 'rxjs';
 
-export const testTypeTaxonomyResolver: ResolveFn<boolean> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const testTypeTaxonomyResolver: ResolveFn<boolean> = () => {
   const store: Store<State> = inject(Store<State>);
   const action$: Actions = inject(Actions);
   store.dispatch(fetchTestTypes());

--- a/src/app/resolvers/title/title.resolver.spec.ts
+++ b/src/app/resolvers/title/title.resolver.spec.ts
@@ -3,20 +3,22 @@ import { Title } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { initialAppState, State } from '@store/.';
-import { TitleResolver } from './title.resolver';
+import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { titleResolver } from './title.resolver';
 
 describe('TitleResolver', () => {
-  let resolver: TitleResolver;
+  let resolver: ResolveFn<boolean>;
   let titleService: Title;
   let store: MockStore<State>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      providers: [TitleResolver, Title, provideMockStore({ initialState: initialAppState })],
+      providers: [Title, provideMockStore({ initialState: initialAppState })],
     });
 
-    resolver = TestBed.inject(TitleResolver);
+    resolver = (...resolverParameters) =>
+      TestBed.runInInjectionContext(() => titleResolver(...resolverParameters));
     titleService = TestBed.inject(Title);
     store = TestBed.inject(MockStore);
   });
@@ -27,6 +29,9 @@ describe('TitleResolver', () => {
 
   it('should set title using Title service', () => {
     const titleServiceSpy = jest.spyOn(titleService, 'setTitle');
+    const result = TestBed.runInInjectionContext(
+      () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    ) as Promise<boolean>;
     store.setState({
       ...initialAppState,
       router: {
@@ -56,7 +61,7 @@ describe('TitleResolver', () => {
         navigationId: 1,
       },
     });
-    const resolved = resolver.resolve();
+    const resolved = result;
     expect(resolved).toBeTruthy();
     expect(titleServiceSpy).toHaveBeenCalledWith('Vehicle Testing Management - Test Results');
   });

--- a/src/app/resolvers/title/title.resolver.ts
+++ b/src/app/resolvers/title/title.resolver.ts
@@ -1,24 +1,20 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { Resolve } from '@angular/router';
+import { Resolve, ResolveFn } from '@angular/router';
 import { select, Store } from '@ngrx/store';
 import { State } from '@store/.';
 import { selectRouteData } from '@store/router/selectors/router.selectors';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class TitleResolver implements Resolve<boolean> {
-  constructor(private titleService: Title, private store: Store<State>) {}
-  resolve(): Promise<boolean> {
-    return new Promise((resolve) => {
-      this.store.pipe(select(selectRouteData)).subscribe((navigationData) => {
-        const { title } = navigationData;
-        if (title) {
-          this.titleService.setTitle(`Vehicle Testing Management - ${title as string}`);
-        }
-      });
-      resolve(true);
+export const titleResolver: ResolveFn<boolean> = () => {
+  const store: Store<State> = inject(Store<State>);
+  const titleService: Title = inject(Title);
+  return new Promise((resolve) => {
+    store.pipe(select(selectRouteData)).subscribe((navigationData) => {
+      const { title } = navigationData;
+      if (title) {
+        titleService.setTitle(`Vehicle Testing Management - ${title as string}`);
+      }
     });
-  }
-}
+    resolve(true);
+  });
+};


### PR DESCRIPTION
## TechDebt: Replace resolvers which is being deprecated in angular 17

IMPORTANT: 

The resolver class are being deprecated in the following angular version. All of the resolvers have been replaced by the functional route resolver " ResolveFn".
[CB2-9639](https://dvsa.atlassian.net/browse/CB2-9639)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
