### PR TITLE
fix(cb2-9679): add font-family to autocomplete options

### DIFF
--- a/src/app/forms/components/autocomplete/autocomplete.component.scss
+++ b/src/app/forms/components/autocomplete/autocomplete.component.scss
@@ -1,5 +1,6 @@
 .autocomplete__wrapper {
   z-index: 0;
+  font-family: 'GDS Transport', arial, sans-serif;
 }
 
 .extra-margin {


### PR DESCRIPTION
## Incorrect font in autocomplete field options

[CB2-9679](https://dvsa.atlassian.net/browse/CB2-9679)

## Checklist

- [x] Branch is rebased against the latest develop/common
- [x] Code and UI has been tested manually after the additional changes
- [x] PR title includes the JIRA ticket number
- [x] Squashed commits contain the JIRA ticket number
- [x] Delete branch after merge
