### PR TITLE
feat(cb2-9595): Update EU Vehicle Category options

### DIFF
--- a/src/app/forms/templates/car/car-tech-record.template.ts
+++ b/src/app/forms/templates/car/car-tech-record.template.ts
@@ -4,8 +4,9 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
-import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
+import { VehicleSubclass } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const CarTechRecord: FormNode = {
   name: 'techRecordSummary',
@@ -86,7 +87,7 @@ export const CarTechRecord: FormNode = {
       value: null,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       width: FormNodeWidth.S,
     },
   ],

--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -1,9 +1,10 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { EmissionStandard } from '@models/test-types/emissions.enum';
-import { HgvPsvVehicleConfiguration, VehicleConfiguration } from '@models/vehicle-configuration.enum';
-import { EuVehicleCategories, FuelTypes } from '@models/vehicle-tech-record.model';
+import { HgvPsvVehicleConfiguration } from '@models/vehicle-configuration.enum';
+import { FuelTypes } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryHgv.enum.js';
 import {
   FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth, TagTypeLabels,
 } from '../../services/dynamic-form.types';
@@ -178,7 +179,7 @@ export const HgvTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [],
     },
     {

--- a/src/app/forms/templates/lgv/lgv-tech-record.template.ts
+++ b/src/app/forms/templates/lgv/lgv-tech-record.template.ts
@@ -4,8 +4,9 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
-import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
+import { VehicleSubclass } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const LgvTechRecord: FormNode = {
   name: 'techRecordSummary',
@@ -89,7 +90,7 @@ export const LgvTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [],
     },
   ],

--- a/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
+++ b/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
@@ -4,8 +4,8 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const MotorcycleTechRecord: FormNode = {
   name: 'techRecordSummary',
@@ -104,7 +104,7 @@ export const MotorcycleTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [],
     },
     {

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -1,10 +1,11 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { EmissionStandard } from '@models/test-types/emissions.enum';
-import { HgvPsvVehicleConfiguration, VehicleConfiguration } from '@models/vehicle-configuration.enum';
+import { HgvPsvVehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { VehicleSize } from '@models/vehicle-size.enum';
-import { EuVehicleCategories, FuelTypes } from '@models/vehicle-tech-record.model';
+import { FuelTypes } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryPsv.enum.js';
 import {
   FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth, TagTypeLabels,
 } from '../../services/dynamic-form.types';
@@ -131,7 +132,7 @@ export const PsvTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [],
     },
     {

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
-import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
+import { VehicleSubclass } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
 import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
@@ -97,7 +97,7 @@ export const SmallTrailerTechRecord: FormNode = {
     {
       name: 'techRecord_euVehicleCategory',
       label: 'EU vehicle category',
-      value: EuVehicleCategories.O1,
+      value: EUVehicleCategory.O1,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -6,6 +6,7 @@ import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { EuVehicleCategories, VehicleSubclass } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const SmallTrailerTechRecord: FormNode = {
   name: 'techRecordSummary',
@@ -100,16 +101,9 @@ export const SmallTrailerTechRecord: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: [
-        {
-          label: 'O1',
-          value: EuVehicleCategories.O1,
-        },
-        {
-          label: 'O2',
-          value: EuVehicleCategories.O2,
-        },
-      ],
+      options: getOptionsFromEnum(EUVehicleCategory).filter(
+        (option) => option.value === EUVehicleCategory.O1 || option.value === EUVehicleCategory.O2,
+      ),
       customTags: [{ colour: TagType.RED, label: TagTypeLabels.REQUIRED }],
     },
   ],

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-psv-hgv-light-vehicle-section.template.ts
@@ -5,7 +5,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const ContingencyVehicleSectionDefaultPsvHgvLight: FormNode = {
   name: 'vehicleSection',
@@ -48,7 +48,7 @@ export const ContingencyVehicleSectionDefaultPsvHgvLight: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-default-trl-vehicle-section.template.ts
@@ -5,7 +5,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const ContingencyVehicleSectionDefaultTrl: FormNode = {
   name: 'vehicleSection',
@@ -49,7 +49,7 @@ export const ContingencyVehicleSectionDefaultTrl: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-psv-hgv-light-vehicle-section.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const VehicleSectionDefaultPsvHgvLight: FormNode = {
   name: 'vehicleSection',
@@ -47,7 +47,7 @@ export const VehicleSectionDefaultPsvHgvLight: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/default-trl-vehicle-section.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const VehicleSectionDefaultTrl: FormNode = {
   name: 'vehicleSection',
@@ -49,7 +49,7 @@ export const VehicleSectionDefaultTrl: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
   name: 'vehicleSection',
@@ -44,7 +44,7 @@ export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
   name: 'vehicleSection',
@@ -46,7 +46,7 @@ export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
   name: 'vehicleSection',
@@ -44,7 +44,7 @@ export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group4-lgv.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group4-lgv.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionGroup4LGV: FormNode = {
   name: 'vehicleSection',
@@ -44,7 +44,7 @@ export const DeskBasedVehicleSectionGroup4LGV: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
     },
     {
       name: 'odometerReading',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group5-lgv.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group5-lgv.template.ts
@@ -3,7 +3,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionGroup5Lgv: FormNode = {
   name: 'vehicleSection',
@@ -43,7 +43,7 @@ export const DeskBasedVehicleSectionGroup5Lgv: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
     },
     {
       name: 'odometerReading',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/group-3-light-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/group-3-light-vehicle-section.template.ts
@@ -4,7 +4,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EuVehicleCategories } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const VehicleSectionGroup3: FormNode = {
   name: 'vehicleSection',
@@ -39,7 +39,7 @@ export const VehicleSectionGroup3: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
       width: FormNodeWidth.S,
-      options: getOptionsFromEnum(EuVehicleCategories),
+      options: getOptionsFromEnum(EUVehicleCategory),
       validators: [{ name: ValidatorNames.Required }],
     },
     {

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -1,9 +1,10 @@
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { CouplingTypeOptions } from '@models/coupling-type-enum';
-import { TrlVehicleConfiguration, VehicleConfiguration } from '@models/vehicle-configuration.enum';
-import { EuVehicleCategories, FrameDescriptions } from '@models/vehicle-tech-record.model';
+import { TrlVehicleConfiguration } from '@models/vehicle-configuration.enum';
+import { FrameDescriptions } from '@models/vehicle-tech-record.model';
 import { TagType } from '@shared/components/tag/tag.component';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import {
   FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth, TagTypeLabels,
 } from '../../services/dynamic-form.types';
@@ -175,8 +176,8 @@ export const TrlTechRecordTemplate: FormNode = {
       value: null,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
-      options: getOptionsFromEnum(EuVehicleCategories).filter(
-        (option) => option.value !== EuVehicleCategories.O1 && option.value !== EuVehicleCategories.O2,
+      options: getOptionsFromEnum(EUVehicleCategory).filter(
+        (option) => option.value !== EUVehicleCategory.O1 && option.value !== EUVehicleCategory.O2,
       ),
       width: FormNodeWidth.S,
     },

--- a/src/app/models/test-results/test-result.model.ts
+++ b/src/app/models/test-results/test-result.model.ts
@@ -1,11 +1,11 @@
 import { TestStationType } from '@models/test-stations/test-station-type.enum';
-import { EuVehicleCategory } from '@models/test-types/eu-vehicle-category.enum';
 import { OdometerReadingUnits } from '@models/test-types/odometer-unit.enum';
 import { TestType } from '@models/test-types/test-type.model';
 import { VehicleClass } from '@models/vehicle-class.model';
 import { VehicleConfiguration } from '@models/vehicle-configuration.enum';
 import { VehicleSize } from '@models/vehicle-size.enum';
 import { StatusCodes, VehicleSubclass, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { TestResultStatus } from './test-result-status.enum';
 import { TestCodes } from './testCodes.enum';
 import { TypeOfTest } from './typeOfTest.enum';
@@ -25,7 +25,7 @@ export interface TestResultModel {
 
   trailerId: string;
   countryOfRegistration: string;
-  euVehicleCategory: EuVehicleCategory | null;
+  euVehicleCategory: EUVehicleCategory | null;
   odometerReading: number;
   odometerReadingUnits: OdometerReadingUnits;
   preparerName: string;

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -1,6 +1,7 @@
 import { ParagraphIds } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType as TechRecordTypeByVehicle } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { BodyTypeCode, BodyTypeDescription } from './body-type-enum';
 
 export interface VehicleTechRecordModel {
@@ -99,27 +100,6 @@ export enum FrameDescriptions {
   INTEGRAL = 'integral',
   BOX_SECTION = 'Box section',
   U_SECTION = 'U section',
-}
-
-export enum EuVehicleCategories {
-  M1 = 'm1',
-  M2 = 'm2',
-  M3 = 'm3',
-  N1 = 'n1',
-  N2 = 'n2',
-  N3 = 'n3',
-  O1 = 'o1',
-  O2 = 'o2',
-  O3 = 'o3',
-  O4 = 'o4',
-  L1E_A = 'l1e-a',
-  L1E = 'l1e',
-  L2E = 'l2e',
-  L3E = 'l3e',
-  L4E = 'l4e',
-  L5E = 'l5e',
-  L6E = 'l6e',
-  L7E = 'l7e',
 }
 
 export enum VehicleSizes {
@@ -296,7 +276,7 @@ export interface TechRecordModel {
   frameDescription?: FrameDescriptions;
   offRoad?: boolean;
   numberOfWheelsDriven?: number;
-  euVehicleCategory?: EuVehicleCategories;
+  euVehicleCategory?: EUVehicleCategory;
   emissionsLimit?: number;
   seatsLowerDeck?: number;
   seatsUpperDeck?: number;

--- a/src/app/resolvers/tech-record-validate/tech-record-validate.resolver.spec.ts
+++ b/src/app/resolvers/tech-record-validate/tech-record-validate.resolver.spec.ts
@@ -34,7 +34,11 @@ describe('TechRecordViewResolver', () => {
   describe('fetch tech record result', () => {
     it('should dispatch a tech record with null if hgv vehicle configuration invalid', async () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
-      jest.spyOn(store, 'select').mockReturnValue(of({ techRecord_vehicleType: 'hgv', techRecord_vehicleConfiguration: 'semi-trailer' }));
+      jest.spyOn(store, 'select').mockReturnValue(of({
+        techRecord_vehicleType: 'hgv',
+        techRecord_vehicleConfiguration: 'semi-trailer',
+        techRecord_euVehicleCategory: 'o1',
+      }));
       const result = TestBed.runInInjectionContext(
         () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
       ) as Observable<boolean>;
@@ -47,12 +51,17 @@ describe('TechRecordViewResolver', () => {
           techRecord_vehicleType: 'hgv',
           techRecord_vehicleConfiguration: null,
           techRecord_vehicleClass_description: 'heavy goods vehicle',
+          techRecord_euVehicleCategory: null,
         },
       }));
     });
     it('should dispatch a tech record with null if psv vehicle configuration invalid', async () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
-      jest.spyOn(store, 'select').mockReturnValue(of({ techRecord_vehicleType: 'psv', techRecord_vehicleConfiguration: 'semi-trailer' }));
+      jest.spyOn(store, 'select').mockReturnValue(of({
+        techRecord_vehicleType: 'psv',
+        techRecord_vehicleConfiguration: 'semi-trailer',
+        techRecord_euVehicleCategory: 'o1',
+      }));
       const result = TestBed.runInInjectionContext(
         () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
       ) as Observable<boolean>;
@@ -61,7 +70,11 @@ describe('TechRecordViewResolver', () => {
       expect(resolveResult).toBe(true);
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({
-        vehicleTechRecord: { techRecord_vehicleType: 'psv', techRecord_vehicleConfiguration: null },
+        vehicleTechRecord: {
+          techRecord_vehicleType: 'psv',
+          techRecord_vehicleConfiguration: null,
+          techRecord_euVehicleCategory: null,
+        },
       }));
     });
     it('should dispatch a tech record with null if psv vehicle class is invalid', async () => {
@@ -80,7 +93,10 @@ describe('TechRecordViewResolver', () => {
     });
     it('should dispatch a tech record with null if trl vehicle configuration invalid', async () => {
       const dispatchSpy = jest.spyOn(store, 'dispatch');
-      jest.spyOn(store, 'select').mockReturnValue(of({ techRecord_vehicleType: 'trl', techRecord_vehicleConfiguration: 'rigid' }));
+      jest.spyOn(store, 'select').mockReturnValue(of({
+        techRecord_vehicleType: 'trl',
+        techRecord_vehicleConfiguration: 'rigid',
+      }));
       const result = TestBed.runInInjectionContext(
         () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
       ) as Observable<boolean>;
@@ -89,7 +105,11 @@ describe('TechRecordViewResolver', () => {
       expect(resolveResult).toBe(true);
       expect(dispatchSpy).toHaveBeenCalledTimes(1);
       expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({
-        vehicleTechRecord: { techRecord_vehicleType: 'trl', techRecord_vehicleConfiguration: null, techRecord_vehicleClass_description: 'trailer' },
+        vehicleTechRecord: {
+          techRecord_vehicleType: 'trl',
+          techRecord_vehicleConfiguration: null,
+          techRecord_vehicleClass_description: 'trailer',
+        },
       }));
     });
     it('should not dispatch a tech record with trl vehicle configuration is valid', async () => {
@@ -98,6 +118,7 @@ describe('TechRecordViewResolver', () => {
         techRecord_vehicleType: 'trl',
         techRecord_vehicleConfiguration: 'semi-trailer',
         techRecord_vehicleClass_description: 'trailer',
+        techRecord_euVehicleCategory: 'o1',
       }));
       const result = TestBed.runInInjectionContext(
         () => resolver({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),

--- a/src/app/resolvers/tech-record-validate/tech-record-validate.resolver.ts
+++ b/src/app/resolvers/tech-record-validate/tech-record-validate.resolver.ts
@@ -18,6 +18,9 @@ import {
   of,
   take,
 } from 'rxjs';
+import { EUVehicleCategory as EUVehicleCategoryPsv } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryPsv.enum.js';
+import { EUVehicleCategory as EUVehicleCategoryHgv } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryHgv.enum.js';
+import { EUVehicleCategory as EUVehicleCategoryTrl } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const techRecordValidateResolver: ResolveFn<boolean> = () => {
   const store: Store<State> = inject(Store<State>);
@@ -63,6 +66,7 @@ const handlePsv = (record: TechRecordVehicleType<'psv'>) => {
   const checks: any = {
     techRecord_vehicleConfiguration: HgvPsvVehicleConfiguration,
     techRecord_vehicleClass_description: VehicleClassDescriptionPSV,
+    techRecord_euVehicleCategory: EUVehicleCategoryPsv,
   } as const;
 
   Object.keys(checks).forEach((key: string) => {
@@ -84,6 +88,7 @@ const handleTrl = (record: TechRecordVehicleType<'trl'>) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const checks: any = {
     techRecord_vehicleConfiguration: TrlVehicleConfiguration,
+    techRecord_euVehicleCategory: EUVehicleCategoryTrl,
   };
 
   Object.keys(checks).forEach((key: string) => {
@@ -105,6 +110,7 @@ const handleHgv = (record: TechRecordVehicleType<'hgv'>) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const checks: any = {
     techRecord_vehicleConfiguration: HgvPsvVehicleConfiguration,
+    techRecord_euVehicleCategory: EUVehicleCategoryHgv,
   };
 
   Object.keys(checks).forEach((key: string) => {

--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -4,7 +4,7 @@ import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/
 import { TechRecordGETHGV, TechRecordGETTRL } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb-vehicle-type';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
-import { EuVehicleCategories, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
@@ -16,6 +16,7 @@ import { cloneDeep, merge } from 'lodash';
 import {
   catchError, concatMap, map, mergeMap, of, switchMap, tap, withLatestFrom,
 } from 'rxjs';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import {
   amendVrm,
   amendVrmFailure,
@@ -188,7 +189,7 @@ export class TechnicalRecordServiceEffects {
           if (techRecord_vehicleType === VehicleTypes.SMALL_TRL) {
             techRecord.techRecord_vehicleType = VehicleTypes.TRL;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (techRecord as any).euVehicleCategory = EuVehicleCategories.O1;
+            (techRecord as any).euVehicleCategory = EUVehicleCategory.O1;
           }
           if (techRecord.techRecord_vehicleType === VehicleTypes.HGV || techRecord.techRecord_vehicleType === VehicleTypes.PSV) {
             (techRecord as any).techRecord_vehicleConfiguration = null;
@@ -224,7 +225,7 @@ export class TechnicalRecordServiceEffects {
           if (techRecord_vehicleType === VehicleTypes.SMALL_TRL) {
             techRecord.techRecord_vehicleType = VehicleTypes.TRL;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (techRecord as any).euVehicleCategory = EuVehicleCategories.O1;
+            (techRecord as any).euVehicleCategory = EUVehicleCategory.O1;
           }
 
           if (techRecord_vehicleType === VehicleTypes.HGV || techRecord_vehicleType === VehicleTypes.PSV) {

--- a/src/app/store/test-records/effects/test-records.effects.spec.ts
+++ b/src/app/store/test-records/effects/test-records.effects.spec.ts
@@ -10,7 +10,6 @@ import { FormNode, FormNodeTypes } from '@forms/services/dynamic-form.types';
 import { contingencyTestTemplates } from '@forms/templates/test-records/create-master.template';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { TypeOfTest } from '@models/test-results/typeOfTest.enum';
-import { EuVehicleCategory } from '@models/test-types/eu-vehicle-category.enum';
 import { OdometerReadingUnits } from '@models/test-types/odometer-unit.enum';
 import { resultOfTestEnum, TestType } from '@models/test-types/test-type.model';
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
@@ -25,6 +24,7 @@ import { selectQueryParams, selectRouteNestedParams } from '@store/router/select
 import { Observable, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { createMock, createMockList } from 'ts-auto-mock';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryPsv.enum.js';
 import { mockTestResult, mockTestResultList } from '../../../../mocks/mock-test-result';
 import { masterTpl } from '../../../forms/templates/test-records/master.template';
 import {
@@ -470,7 +470,7 @@ describe('TestResultsEffects', () => {
               countryOfRegistration: '',
               createdById: undefined,
               createdByName: undefined,
-              euVehicleCategory: EuVehicleCategory.M1,
+              euVehicleCategory: EUVehicleCategory.M1,
               firstUseDate: null,
               lastUpdatedAt: undefined,
               lastUpdatedById: undefined,

--- a/src/mocks/mock-test-result.ts
+++ b/src/mocks/mock-test-result.ts
@@ -1,12 +1,12 @@
 import { TestResultStatus } from '@models/test-results/test-result-status.enum';
 import { TestResultModel } from '@models/test-results/test-result.model';
 import { TestStationType } from '@models/test-stations/test-station-type.enum';
-import { EuVehicleCategory } from '@models/test-types/eu-vehicle-category.enum';
 import { OdometerReadingUnits } from '@models/test-types/odometer-unit.enum';
 import { TestType, resultOfTestEnum } from '@models/test-types/test-type.model';
 // disable linting error as this util function is only used in tests and should, therefore, be a devDependency
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createMock, createMockList } from 'ts-auto-mock';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryPsv.enum.js';
 import * as Emissions from '../app/models/test-types/emissions.enum';
 import { VehicleTypes } from '../app/models/vehicle-tech-record.model';
 import { mockDefectList } from './mock-defects';
@@ -75,7 +75,7 @@ export const mockTestResult = (i = 0, vehicleType: VehicleTypes = VehicleTypes.P
 
     trailerId: `C${String(i + 1).padStart(5, '0')}`,
     countryOfRegistration: 'gb',
-    euVehicleCategory: EuVehicleCategory.M3,
+    euVehicleCategory: EUVehicleCategory.M3,
     odometerReading: 100,
     odometerReadingUnits: OdometerReadingUnits.KILOMETRES,
     reasonForCreation: 'mock test result data',
@@ -117,7 +117,7 @@ export const mockTestResultArchived = (
     createdByName: `Person ${i}`,
     trailerId: `C${String(i + 1).padStart(5, '0')}`,
     countryOfRegistration: 'gb',
-    euVehicleCategory: EuVehicleCategory.M3,
+    euVehicleCategory: EUVehicleCategory.M3,
     odometerReading: 100,
     odometerReadingUnits: OdometerReadingUnits.KILOMETRES,
     reasonForCreation: `reason ${i}`,

--- a/src/mocks/trl-record.mock.ts
+++ b/src/mocks/trl-record.mock.ts
@@ -1,12 +1,14 @@
-import { ApprovalType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/approvalTypeHgvOrPsv.enum.js';
-import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 // disable linting error as this util function is only used in tests and should, therefore, be a devDependency
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createMock } from 'ts-auto-mock';
 import {
-  FrameDescriptions, StatusCodes, VehicleConfigurations,
-} from '../app/models/vehicle-tech-record.model';
+  StatusCodes,
+  VehicleConfigurations,
+  FrameDescriptions,
+} from '@models/vehicle-tech-record.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
+import { ApprovalType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/approvalType.enum.js';
 
 export const createMockTrl = (systemNumber: number): TechRecordType<'trl'> =>
   createMock<TechRecordType<'trl'>>({


### PR DESCRIPTION
## Ticket title

Implemented the enums available from the types package within VTM allowing only valid options for PSV and HGV to be selected.
[CB2-9595](https://dvsa.atlassian.net/browse/CB2-9595)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
