### PR TITLE
fix(cb2-9893): cannot change vehicle type to small trailer

### DIFF
--- a/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.spec.ts
@@ -18,12 +18,15 @@ import { changeVehicleType } from '@store/technical-records';
 import { ReplaySubject, of } from 'rxjs';
 import { ChangeVehicleTypeComponent } from './tech-record-change-type.component';
 
+const mockGetVehicleType = jest.fn();
+
 const mockTechRecordService = {
   get techRecord$() {
     return of({});
   },
   getMakeAndModel: jest.fn(),
   clearReasonForCreation: jest.fn(),
+  getVehicleTypeWithSmallTrl: mockGetVehicleType,
 };
 
 const mockDynamicFormService = {
@@ -100,6 +103,7 @@ describe('TechRecordChangeTypeComponent', () => {
   describe('vehicleTypeOptions', () => {
     it('should return all types except for the current one', () => {
       component.techRecord = expectedTechRecord;
+      mockGetVehicleType.mockReturnValue('psv');
       const expectedOptions = getOptionsFromEnumAcronym(VehicleTypes).filter((type) => type.value !== VehicleTypes.PSV);
       expect(component.vehicleTypeOptions).toStrictEqual(expectedOptions);
     });

--- a/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.ts
+++ b/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.ts
@@ -62,7 +62,7 @@ export class ChangeVehicleTypeComponent implements OnInit {
   }
 
   get vehicleTypeOptions(): MultiOptions {
-    return getOptionsFromEnumAcronym(VehicleTypes).filter((type) => type.value !== this.techRecord?.techRecord_vehicleType);
+    return getOptionsFromEnumAcronym(VehicleTypes).filter((type) => type.value !== this.vehicleType);
   }
 
   get currentVrm() {

--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -188,11 +188,10 @@ export class TechnicalRecordServiceEffects {
 
           if (techRecord_vehicleType === VehicleTypes.SMALL_TRL) {
             techRecord.techRecord_vehicleType = VehicleTypes.TRL;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (techRecord as any).euVehicleCategory = EUVehicleCategory.O1;
+            (techRecord as TechRecordGETTRL).techRecord_euVehicleCategory = EUVehicleCategory.O1;
           }
           if (techRecord.techRecord_vehicleType === VehicleTypes.HGV || techRecord.techRecord_vehicleType === VehicleTypes.PSV) {
-            (techRecord as any).techRecord_vehicleConfiguration = null;
+            (techRecord as TechRecordGETHGV | TechRecordGETPSV).techRecord_vehicleConfiguration = null;
           }
           if (techRecord_vehicleType === VehicleTypes.HGV) {
             (techRecord as TechRecordGETHGV).techRecord_vehicleClass_description = VehicleClassDescription.HeavyGoodsVehicle;
@@ -224,8 +223,7 @@ export class TechnicalRecordServiceEffects {
 
           if (techRecord_vehicleType === VehicleTypes.SMALL_TRL) {
             techRecord.techRecord_vehicleType = VehicleTypes.TRL;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (techRecord as any).euVehicleCategory = EUVehicleCategory.O1;
+            (techRecord as TechRecordGETTRL).techRecord_euVehicleCategory = EUVehicleCategory.O1;
           }
 
           if (techRecord_vehicleType === VehicleTypes.HGV || techRecord_vehicleType === VehicleTypes.PSV) {
@@ -238,10 +236,10 @@ export class TechnicalRecordServiceEffects {
           }
           if (techRecord_vehicleType === VehicleTypes.TRL) {
             (techRecord as TechRecordGETTRL).techRecord_vehicleClass_description = VehicleClassDescription.Trailer;
+            (techRecord as any).euVehicleCategory = null;
           }
 
           const techRecordTemplate = vehicleTemplateMap.get(techRecord_vehicleType) || [];
-
           return of(
             techRecordTemplate.reduce((mergedNodes, formNode) => {
               const form = this.dfs.createForm(formNode, techRecord);


### PR DESCRIPTION
CB2-9893: Users were unable to change a vehicle to a small trailer as we were not setting the eu vehicle category properly. The options for the select are now generated based on the get vehicleType as this will allow users to pick trl if the vehicle is a small trl.

_One line description_
[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
