### PR TITLE
fix(cb2-9937): review screen is broken

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
@@ -28,7 +28,6 @@ import {
   updateTechRecord,
   updateTechRecordSuccess,
 } from '@store/technical-records';
-import { isEmpty } from 'lodash';
 import {
   Subject, combineLatest, map, take, takeUntil,
 } from 'rxjs';

--- a/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
@@ -88,6 +88,7 @@ export class TechRecordSummaryChangesComponent implements OnInit, OnDestroy {
       .select(editingTechRecord)
       .pipe(take(1), takeUntil(this.destroy$))
       .subscribe((data) => {
+        if (!data) this.cancel();
         this.techRecordEdited = data;
       });
 
@@ -96,6 +97,10 @@ export class TechRecordSummaryChangesComponent implements OnInit, OnDestroy {
       .pipe(take(1), takeUntil(this.destroy$))
       .subscribe((changes) => {
         this.techRecordChanges = changes;
+        if (this.vehicleType === VehicleTypes.PSV || this.vehicleType === VehicleTypes.HGV) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (this.techRecordChanges as any).techRecord_numberOfWheelsDriven;
+        }
         this.techRecordChangesKeys = this.getTechRecordChangesKeys();
         this.sectionsWhitelist = this.getSectionsWhitelist();
       });
@@ -163,7 +168,7 @@ export class TechRecordSummaryChangesComponent implements OnInit, OnDestroy {
 
   getTechRecordChangesKeys(): string[] {
     const entries = Object.entries(this.techRecordChanges ?? {});
-    const filter = entries.filter(([, value]) => isEmpty(value));
+    const filter = entries.filter(([, value]) => this.isNotEmpty(value));
     const changeMap = filter.map(([key]) => key);
     return changeMap;
   }
@@ -206,5 +211,11 @@ export class TechRecordSummaryChangesComponent implements OnInit, OnDestroy {
 
   toVisibleFormNode(node: FormNode): FormNode {
     return { ...node, viewType: node.viewType === FormNodeViewTypes.HIDDEN ? FormNodeViewTypes.STRING : node.viewType };
+  }
+
+  isNotEmpty(value: unknown): boolean {
+    if (value === '' || value === undefined) return false;
+    if (typeof value === 'object' && value !== null) return Object.values(value).length > 0;
+    return true;
   }
 }

--- a/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
@@ -97,8 +97,7 @@ export class TechRecordSummaryChangesComponent implements OnInit, OnDestroy {
       .subscribe((changes) => {
         this.techRecordChanges = changes;
         if (this.vehicleType === VehicleTypes.PSV || this.vehicleType === VehicleTypes.HGV) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          delete (this.techRecordChanges as any).techRecord_numberOfWheelsDriven;
+          delete (this.techRecordChanges as Partial<TechRecordGETPSV | TechRecordGETHGV>).techRecord_numberOfWheelsDriven;
         }
         this.techRecordChangesKeys = this.getTechRecordChangesKeys();
         this.sectionsWhitelist = this.getSectionsWhitelist();

--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -45,8 +45,8 @@ const routes: Routes = [
     canActivate: [MsalGuard, RoleGuard],
     resolve: {
       techRecord: techRecordViewResolver,
-      clean: techRecordCleanResolver,
       load: techRecordValidateResolver,
+      clean: techRecordCleanResolver,
     },
   },
   {
@@ -61,8 +61,8 @@ const routes: Routes = [
     canActivate: [MsalGuard, RoleGuard],
     resolve: {
       techRecord: techRecordViewResolver,
-      clean: techRecordCleanResolver,
       load: techRecordValidateResolver,
+      clean: techRecordCleanResolver,
     },
   },
 

--- a/src/app/forms/templates/car/car-tech-record.template.ts
+++ b/src/app/forms/templates/car/car-tech-record.template.ts
@@ -26,6 +26,7 @@ export const CarTechRecord: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -26,6 +26,7 @@ export const HgvTechRecord: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/forms/templates/lgv/lgv-tech-record.template.ts
+++ b/src/app/forms/templates/lgv/lgv-tech-record.template.ts
@@ -26,6 +26,7 @@ export const LgvTechRecord: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
+++ b/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
@@ -25,6 +25,7 @@ export const MotorcycleTechRecord: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -27,6 +27,7 @@ export const PsvTechRecord: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -26,6 +26,7 @@ export const SmallTrailerTechRecord: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -26,6 +26,7 @@ export const TrlTechRecordTemplate: FormNode = {
     },
     {
       name: 'techRecord_statusCode',
+      label: 'Record status',
       value: '',
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,


### PR DESCRIPTION
CB2-9937:

The addition of the lodash isEmpty function broke the summary of changes page. This PR reverts that change and changes the orders of the resolvers on the route to summary changes, this was because on a refresh the page was loading as a blank page, rather than navigating back as it used to. 

## Ticket title

_One line description_
[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
