### PR TITLE
fix(cb2-10211): correctly display tank details part 2 section in both edit mode and read mode

### DIFF
--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -449,7 +449,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['productList', 'statement_select', 'dangerous_goods'],
+      groups: ['productList', 'statement_select', 'tank_details', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -131,7 +131,7 @@ export const AdrTemplate: FormNode = {
           name: ValidatorNames.HideGroupsWhenExcludes,
           args: {
             values: Object.values(ADRBodyType).filter((value) => value.includes('battery') || value.includes('tank')) as string[],
-            groups: ['tank_details'],
+            groups: ['tank_details', 'tank_details_hide'],
           },
         },
         {
@@ -374,8 +374,8 @@ export const AdrTemplate: FormNode = {
         {
           name: ValidatorNames.HideGroupsWhenEqualTo,
           args: {
-            values: [ADRTankStatementSubstancePermitted.UNDER_TANK_CODE],
-            groups: ['statement_select'],
+            values: [ADRTankStatementSubstancePermitted.UNDER_TANK_CODE, null, undefined],
+            groups: ['statement_select', 'statement_select_hide'],
           },
         },
       ],
@@ -386,7 +386,7 @@ export const AdrTemplate: FormNode = {
       width: FormNodeWidth.XS,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
-      groups: ['statement_select', 'tank_details', 'dangerous_goods'],
+      groups: ['statement_select', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
       options: getOptionsFromEnum(ADRTankDetailsTankStatementSelect),
       validators: [
@@ -431,7 +431,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_statement',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['statement', 'statement_select', 'tank_details', 'dangerous_goods'],
+      groups: ['statement', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number is required when selecting Statement',
       validators: [
@@ -449,7 +449,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['productList', 'statement_select', 'tank_details', 'dangerous_goods'],
+      groups: ['productList', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [
@@ -469,7 +469,7 @@ export const AdrTemplate: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CUSTOM,
       component: AdrTankStatementUnNumberComponent,
-      groups: ['productList', 'statement_select', 'tank_details', 'dangerous_goods'],
+      groups: ['productList', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [
@@ -484,7 +484,7 @@ export const AdrTemplate: FormNode = {
       label: 'Additional Details',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXTAREA,
-      groups: ['productList', 'statement_select', 'tank_details', 'dangerous_goods'],
+      groups: ['productList', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
       validators: [
         { name: ValidatorNames.MaxLength, args: 1500 },

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -431,7 +431,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_statement',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['statement_select', 'statement', 'tank_details', 'dangerous_goods'],
+      groups: ['statement', 'statement_select', 'tank_details', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number is required when selecting Statement',
       validators: [
@@ -449,7 +449,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['statement_select', 'productList', 'tank_details', 'dangerous_goods'],
+      groups: ['productList', 'statement_select', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [
@@ -469,7 +469,7 @@ export const AdrTemplate: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CUSTOM,
       component: AdrTankStatementUnNumberComponent,
-      groups: ['statement_select', 'productList', 'tank_details', 'dangerous_goods'],
+      groups: ['productList', 'statement_select', 'tank_details', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [
@@ -484,7 +484,7 @@ export const AdrTemplate: FormNode = {
       label: 'Additional Details',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXTAREA,
-      groups: ['statement_select', 'productList', 'tank_details', 'dangerous_goods'],
+      groups: ['productList', 'statement_select', 'tank_details', 'dangerous_goods'],
       hide: true,
       validators: [
         { name: ValidatorNames.MaxLength, args: 1500 },
@@ -499,7 +499,7 @@ export const AdrTemplate: FormNode = {
       validators: [
         { name: ValidatorNames.MaxLength, args: 1024 },
       ],
-      groups: ['dangerous_goods', 'battery_list'],
+      groups: ['dangerous_goods', 'tank_details'],
     },
     {
       name: 'tankInspectionsSectionTitle',

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -364,6 +364,20 @@ export const AdrTemplate: FormNode = {
             value: Object.values(ADRBodyType).filter((value) => value.includes('battery') || value.includes('tank')) as string[],
           },
         },
+        {
+          name: ValidatorNames.ShowGroupsWhenEqualTo,
+          args: {
+            values: [ADRTankStatementSubstancePermitted.UNDER_UN_NUMBER],
+            groups: ['statement_select'],
+          },
+        },
+        {
+          name: ValidatorNames.HideGroupsWhenEqualTo,
+          args: {
+            values: [ADRTankStatementSubstancePermitted.UNDER_TANK_CODE],
+            groups: ['statement_select'],
+          },
+        },
       ],
     },
     {
@@ -372,7 +386,7 @@ export const AdrTemplate: FormNode = {
       width: FormNodeWidth.XS,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.RADIO,
-      groups: ['tank_details', 'dangerous_goods'],
+      groups: ['statement_select', 'tank_details', 'dangerous_goods'],
       hide: true,
       options: getOptionsFromEnum(ADRTankDetailsTankStatementSelect),
       validators: [
@@ -417,7 +431,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_statement',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['statement', 'tank_details', 'dangerous_goods'],
+      groups: ['statement_select', 'statement', 'tank_details', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number is required when selecting Statement',
       validators: [
@@ -435,7 +449,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo',
       label: 'Reference number',
       type: FormNodeTypes.CONTROL,
-      groups: ['productList', 'tank_details', 'dangerous_goods'],
+      groups: ['statement_select', 'productList', 'tank_details', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [
@@ -455,7 +469,7 @@ export const AdrTemplate: FormNode = {
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CUSTOM,
       component: AdrTankStatementUnNumberComponent,
-      groups: ['productList', 'tank_details', 'dangerous_goods'],
+      groups: ['statement_select', 'productList', 'tank_details', 'dangerous_goods'],
       hide: true,
       customErrorMessage: 'Reference number or UN number is required when selecting Product List',
       validators: [
@@ -470,7 +484,7 @@ export const AdrTemplate: FormNode = {
       label: 'Additional Details',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.TEXTAREA,
-      groups: ['productList', 'tank_details', 'dangerous_goods'],
+      groups: ['statement_select', 'productList', 'tank_details', 'dangerous_goods'],
       hide: true,
       validators: [
         { name: ValidatorNames.MaxLength, args: 1500 },

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -399,7 +399,6 @@ export class CustomValidators {
     return (control: AbstractControl): ValidationErrors | null => {
       if (values && !values.some((value) => control.value?.includes(value))) return null;
       this.setHidePropertyForGroups(control, groups, false);
-
       return null;
     };
   };

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -1,6 +1,7 @@
 import { ADRBodyType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrBodyType.enum.js';
 import { ADRDangerousGood } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrDangerousGood.enum.js';
 import { ADRTankDetailsTankStatementSelect } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrTankDetailsTankStatementSelect.enum.js';
+import { ADRTankStatementSubstancePermitted } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrTankStatementSubstancePermitted.js';
 import { TechRecordSearchSchema } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/search';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { BodyTypeCode, vehicleBodyTypeCodeMap } from '@models/body-type-enum';
@@ -385,6 +386,12 @@ function handleClearADRDetails(state: TechnicalRecordServiceState) {
         techRecord_adrDetails_tank_tankDetails_tankStatement_productList: null,
       };
 
+      const nulledSubstancesPermittedUNNumber = {
+        techRecord_adrDetails_tank_tankDetails_tankStatement_select: null,
+        ...nulledTankStatementStatement,
+        ...nulledTankStatementProductList,
+      };
+
       const nulledBatteryListNumber = {
         techRecord_adrDetails_batteryListNumber: null,
       };
@@ -457,6 +464,12 @@ function handleClearADRDetails(state: TechnicalRecordServiceState) {
       // If tank details 'product list' selected, null statement reference no.
       if (select === ADRTankDetailsTankStatementSelect.PRODUCT_LIST) {
         sanitisedEditingTechRecord = { ...sanitisedEditingTechRecord, ...nulledTankStatementStatement };
+      }
+
+      // If tank details 'substances permitted' has 'tank code' option selected, null UN and product list reference no.
+      const { techRecord_adrDetails_tank_tankDetails_tankStatement_substancesPermitted: substancesPermitted } = sanitisedEditingTechRecord;
+      if (substancesPermitted === ADRTankStatementSubstancePermitted.UNDER_TANK_CODE) {
+        sanitisedEditingTechRecord = { ...sanitisedEditingTechRecord, ...nulledSubstancesPermittedUNNumber };
       }
 
       // If battery list applicable is no, null the battery list number


### PR DESCRIPTION
## ADR Tank Details- View mode- When Statement is selected, fields related to statement should only be displayed

Don't ask why this works, it just does.
[CB2-10211](https://dvsa.atlassian.net/browse/CB2-10211)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
