### PR TITLE
fix(cb2-10174): ensure prefetched data is provided for all dependent routes

### DIFF
--- a/src/app/features/tech-record/tech-record-routing.module.ts
+++ b/src/app/features/tech-record/tech-record-routing.module.ts
@@ -6,6 +6,7 @@ import { RoleGuard } from '@guards/role-guard/roles.guard';
 import { Roles } from '@models/roles.enum';
 import { ReasonForEditing } from '@models/vehicle-tech-record.model';
 import { techRecordCleanResolver } from 'src/app/resolvers/tech-record-clean/tech-record-clean.resolver';
+import { techRecordDataResolver } from 'src/app/resolvers/tech-record-data/tech-record-data.resolver';
 import { techRecordValidateResolver } from 'src/app/resolvers/tech-record-validate/tech-record-validate.resolver';
 import { techRecordViewResolver } from 'src/app/resolvers/tech-record-view/tech-record-view.resolver';
 import { TechRecordAmendReasonComponent } from './components/tech-record-amend-reason/tech-record-amend-reason.component';
@@ -31,6 +32,7 @@ const routes: Routes = [
     canActivate: [CancelEditTechGuard],
     resolve: {
       load: techRecordViewResolver,
+      data: techRecordDataResolver,
     },
   },
   {

--- a/src/app/forms/custom-sections/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.ts
@@ -23,17 +23,18 @@ import {
   Axle, FitmentCode, ReasonForEditing, SpeedCategorySymbol, Tyre, Tyres, VehicleTypes,
 } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
+import { ReferenceDataService } from '@services/reference-data/reference-data.service';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { selectAllReferenceDataByResourceType } from '@store/reference-data';
 import { addAxle, removeAxle, updateScrollPosition } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
 import { cloneDeep } from 'lodash';
 import {
+  Observable,
   ReplaySubject,
   filter,
-  takeUntil, Observable,
+  takeUntil,
 } from 'rxjs';
-import { ReferenceDataService } from '@services/reference-data/reference-data.service';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 
 @Component({
   selector: 'app-tyres',
@@ -82,7 +83,6 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
       .pipe(takeUntil(this.destroy$), filter(Boolean)).subscribe(((data) => {
         this.tyresReferenceData = data as ReferenceDataTyre[];
       }));
-    this.referenceDataService.loadReferenceData(ReferenceDataResourceType.TyreLoadIndex);
 
     this.loadIndex$.pipe(takeUntil(this.destroy$)).subscribe((value): void => {
       this.loadIndexValues = value;

--- a/src/app/resolvers/tech-record-data/tech-record-data.resolver.ts
+++ b/src/app/resolvers/tech-record-data/tech-record-data.resolver.ts
@@ -6,6 +6,7 @@ import { ReferenceDataService } from '@services/reference-data/reference-data.se
 export const techRecordDataResolver: ResolveFn<boolean> = () => {
   const referenceDataService = inject(ReferenceDataService);
   referenceDataService.loadReferenceData(ReferenceDataResourceType.Tyres);
+  referenceDataService.loadReferenceData(ReferenceDataResourceType.TyreLoadIndex);
 
   return true;
 };


### PR DESCRIPTION
## Tyre Code not getting filled manually

This was an issue due to the changes with adding additional validation to tyres and weights. Originally we were making a network request EVERY TIME we added an axle to fetch the specific reference data - and would have need to do so in order to run validation for tyre weights. This ran into cold starts for lambdas and the inherent overhead of making several, albeit smaller, network requests. To 10x the speed of this we now moved the prefetching of reference data to a resolver to guarantee is availability when on the tech-record page which now uses the cached version. 

This worked, but a a later patch to the validation also required tyre reference as well as load index which wasn't being pulled in when amending as this route was missing the resolver. This wouldn't be noticed if you had created a tech record prior as this would load the data into state.

This PR now ensures VTM loads all the necessary tyre data for dependant routes.

[CB2-10174](https://dvsa.atlassian.net/browse/CB2-10174)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
