### PR TITLE
fix(cb2-8121): general improvements to the type system

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vrm-reason/tech-record-amend-vrm-reason.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm-reason/tech-record-amend-vrm-reason.component.ts
@@ -7,7 +7,7 @@ import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import {
   CustomFormControl, FormNodeOption, FormNodeTypes, FormNodeWidth,
 } from '@forms/services/dynamic-form.types';
-import { NotVehicle, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { VehicleTypes, VehiclesOtherThan } from '@models/vehicle-tech-record.model';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { Subject, take, takeUntil } from 'rxjs';
 
@@ -17,7 +17,7 @@ import { Subject, take, takeUntil } from 'rxjs';
   styleUrls: ['./tech-record-amend-vrm-reason.component.scss'],
 })
 export class AmendVrmReasonComponent implements OnDestroy, OnInit {
-  techRecord?: NotVehicle<'trl'>;
+  techRecord?: VehiclesOtherThan<'trl'>;
   makeAndModel?: string;
 
   form = new FormGroup({
@@ -43,7 +43,7 @@ export class AmendVrmReasonComponent implements OnDestroy, OnInit {
       if (record?.techRecord_statusCode === 'archived' || !record) {
         return this.navigateBack();
       }
-      this.techRecord = record as NotVehicle<'trl'>;
+      this.techRecord = record as VehiclesOtherThan<'trl'>;
       this.makeAndModel = this.technicalRecordService.getMakeAndModel(record);
     });
   }

--- a/src/app/features/tech-record/components/tech-record-amend-vrm-reason/tech-record-amend-vrm-reason.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm-reason/tech-record-amend-vrm-reason.component.ts
@@ -7,7 +7,7 @@ import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import {
   CustomFormControl, FormNodeOption, FormNodeTypes, FormNodeWidth,
 } from '@forms/services/dynamic-form.types';
-import { NotTrailer, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { NotVehicle, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { Subject, take, takeUntil } from 'rxjs';
 
@@ -17,7 +17,7 @@ import { Subject, take, takeUntil } from 'rxjs';
   styleUrls: ['./tech-record-amend-vrm-reason.component.scss'],
 })
 export class AmendVrmReasonComponent implements OnDestroy, OnInit {
-  techRecord?: NotTrailer;
+  techRecord?: NotVehicle<'trl'>;
   makeAndModel?: string;
 
   form = new FormGroup({
@@ -43,7 +43,7 @@ export class AmendVrmReasonComponent implements OnDestroy, OnInit {
       if (record?.techRecord_statusCode === 'archived' || !record) {
         return this.navigateBack();
       }
-      this.techRecord = record as NotTrailer;
+      this.techRecord = record as NotVehicle<'trl'>;
       this.makeAndModel = this.technicalRecordService.getMakeAndModel(record);
     });
   }

--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.spec.ts
@@ -6,7 +6,9 @@ import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router'
 import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
+import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
+import { NotVehicle } from '@models/vehicle-tech-record.model';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -16,8 +18,6 @@ import { initialAppState, State } from '@store/index';
 import { selectRouteData } from '@store/router/selectors/router.selectors';
 import { amendVrm, amendVrmSuccess } from '@store/technical-records';
 import { of, ReplaySubject } from 'rxjs';
-import { DynamicFormService } from '@forms/services/dynamic-form.service';
-import { NotTrailer } from '@models/vehicle-tech-record.model';
 import { AmendVrmComponent } from './tech-record-amend-vrm.component';
 
 const mockTechRecordService = {
@@ -112,7 +112,7 @@ describe('TechRecordChangeVrmComponent', () => {
 
   describe('handleSubmit', () => {
     beforeEach(() => {
-      component.techRecord = mockVehicleTechnicalRecord('psv') as NotTrailer;
+      component.techRecord = mockVehicleTechnicalRecord('psv') as NotVehicle<'trl'>;
       jest.resetAllMocks();
       jest.resetModules();
     });

--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.spec.ts
@@ -8,7 +8,7 @@ import { GlobalErrorService } from '@core/components/global-error/global-error.s
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
-import { NotVehicle } from '@models/vehicle-tech-record.model';
+import { VehiclesOtherThan } from '@models/vehicle-tech-record.model';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
@@ -112,7 +112,7 @@ describe('TechRecordChangeVrmComponent', () => {
 
   describe('handleSubmit', () => {
     beforeEach(() => {
-      component.techRecord = mockVehicleTechnicalRecord('psv') as NotVehicle<'trl'>;
+      component.techRecord = mockVehicleTechnicalRecord('psv') as VehiclesOtherThan<'trl'>;
       jest.resetAllMocks();
       jest.resetModules();
     });

--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.ts
@@ -10,7 +10,7 @@ import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormControl, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { CustomValidators } from '@forms/validators/custom-validators';
-import { NotVehicle, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { VehicleTypes, VehiclesOtherThan } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -24,7 +24,7 @@ import { Subject, take, takeUntil } from 'rxjs';
   styleUrls: ['./tech-record-amend-vrm.component.scss'],
 })
 export class AmendVrmComponent implements OnDestroy, OnInit {
-  techRecord?: NotVehicle<'trl'>;
+  techRecord?: VehiclesOtherThan<'trl'>;
   makeAndModel?: string;
   isCherishedTransfer = false;
   systemNumber?: string;
@@ -98,7 +98,7 @@ export class AmendVrmComponent implements OnDestroy, OnInit {
       if (record?.techRecord_statusCode === 'archived' || !record) {
         return this.navigateBack();
       }
-      this.techRecord = record as NotVehicle<'trl'>;
+      this.techRecord = record as VehiclesOtherThan<'trl'>;
       this.makeAndModel = this.technicalRecordService.getMakeAndModel(record);
     });
 

--- a/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vrm/tech-record-amend-vrm.component.ts
@@ -10,7 +10,7 @@ import { DynamicFormGroupComponent } from '@forms/components/dynamic-form-group/
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormControl, FormNodeTypes, FormNodeWidth } from '@forms/services/dynamic-form.types';
 import { CustomValidators } from '@forms/validators/custom-validators';
-import { NotTrailer, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { NotVehicle, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -24,7 +24,7 @@ import { Subject, take, takeUntil } from 'rxjs';
   styleUrls: ['./tech-record-amend-vrm.component.scss'],
 })
 export class AmendVrmComponent implements OnDestroy, OnInit {
-  techRecord?: NotTrailer;
+  techRecord?: NotVehicle<'trl'>;
   makeAndModel?: string;
   isCherishedTransfer = false;
   systemNumber?: string;
@@ -98,7 +98,7 @@ export class AmendVrmComponent implements OnDestroy, OnInit {
       if (record?.techRecord_statusCode === 'archived' || !record) {
         return this.navigateBack();
       }
-      this.techRecord = record as NotTrailer;
+      this.techRecord = record as NotVehicle<'trl'>;
       this.makeAndModel = this.technicalRecordService.getMakeAndModel(record);
     });
 

--- a/src/app/features/tech-record/components/tech-record-search-tyres/tech-record-search-tyres.component.ts
+++ b/src/app/features/tech-record/components/tech-record-search-tyres/tech-record-search-tyres.component.ts
@@ -49,7 +49,7 @@ export class TechRecordSearchTyresComponent implements OnInit {
   public form!: CustomFormGroup;
   public searchResults: Array<ReferenceDataTyre> | null = null;
   public vehicleTechRecord?: V3TechRecordModel;
-  public viewableTechRecord?: TechRecordType<'hgv'> | TechRecordType<'psv'> | TechRecordType<'trl'>;
+  public viewableTechRecord?: TechRecordType<'hgv' | 'psv' | 'trl'>;
   private params: SearchParams = {};
   private pageStart?: number;
   private pageEnd?: number;
@@ -80,7 +80,7 @@ export class TechRecordSearchTyresComponent implements OnInit {
       this.params = p;
     });
     this.technicalRecordService.techRecord$.pipe(take(1)).subscribe((data) => {
-      this.viewableTechRecord = data as TechRecordType<'hgv'> | TechRecordType<'psv'> | TechRecordType<'trl'>;
+      this.viewableTechRecord = data as TechRecordType<'hgv' | 'psv' | 'trl'>;
     });
     this.referenceDataService
       .getTyreSearchReturn$()

--- a/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.ts
@@ -3,9 +3,6 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { HGVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
-import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
-import { TRLAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import {
   TechRecordGETCar,
@@ -17,11 +14,12 @@ import {
 import { FormNode, FormNodeViewTypes } from '@forms/services/dynamic-form.types';
 import { VehicleSummary } from '@forms/templates/tech-records/vehicle-summary.template';
 import { vehicleTemplateMap } from '@forms/utils/tech-record-constants';
-import { VehicleTypes } from '@models/vehicle-tech-record.model';
+import { Axles, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { RouterService } from '@services/router/router.service';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { UserService } from '@services/user-service/user-service';
 import { State } from '@store/index';
 import {
   clearADRDetailsBeforeUpdate,
@@ -37,7 +35,6 @@ import {
 import {
   Subject, combineLatest, map, take, takeUntil,
 } from 'rxjs';
-import { UserService } from '@services/user-service/user-service';
 
 @Component({
   selector: 'app-tech-record-summary-changes',
@@ -141,20 +138,20 @@ export class TechRecordSummaryChangesComponent implements OnInit, OnDestroy {
     return VehicleSummary;
   }
 
-  get deletedAxles(): HGVAxles[] | TRLAxles[] | PSVAxles[] {
+  get deletedAxles(): Axles {
     if (this.techRecordEdited?.techRecord_vehicleType === 'hgv' && this.techRecordDeletions) {
-      return Object.values((this.techRecordDeletions as Partial<TechRecordGETHGV>).techRecord_axles ?? {}) as [HGVAxles, ...HGVAxles[]];
+      return Object.values((this.techRecordDeletions as Partial<TechRecordGETHGV>).techRecord_axles ?? {});
     }
 
     if (this.techRecordEdited?.techRecord_vehicleType === 'trl' && this.techRecordDeletions) {
-      return Object.values((this.techRecordDeletions as Partial<TechRecordGETTRL>).techRecord_axles ?? {}) as [TRLAxles, ...TRLAxles[]];
+      return Object.values((this.techRecordDeletions as Partial<TechRecordGETTRL>).techRecord_axles ?? {});
     }
 
     if (this.techRecordEdited?.techRecord_vehicleType === 'psv' && this.techRecordDeletions) {
-      return Object.values((this.techRecordDeletions as Partial<TechRecordGETPSV>).techRecord_axles ?? {}) as [PSVAxles, ...PSVAxles[]];
+      return Object.values((this.techRecordDeletions as Partial<TechRecordGETPSV>).techRecord_axles ?? {});
     }
 
-    return [] as HGVAxles[] | TRLAxles[] | PSVAxles[];
+    return [];
   }
 
   get sectionTemplatesState$() {

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.spec.ts
@@ -8,7 +8,7 @@ import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 import { Roles } from '@models/roles.enum';
 import {
-  NotTrailer, V3TechRecordModel, VehicleTypes,
+  NotVehicle, V3TechRecordModel, VehicleTypes,
 } from '@models/vehicle-tech-record.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -82,7 +82,7 @@ describe('TechRecordTitleComponent', () => {
       expect(vrmField.textContent).not.toContain('TESTV RM4');
     });
     it('should not create previous-vrm-span if no secondary vrm exists', () => {
-      delete (mockRecord as NotTrailer).secondaryVrms;
+      delete (mockRecord as NotVehicle<'trl'>).secondaryVrms;
       fixture.detectChanges();
 
       const vrmField = fixture.debugElement.query(By.css('#previous-vrm-span'));

--- a/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-title/tech-record-title.component.spec.ts
@@ -8,7 +8,8 @@ import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
 import { Roles } from '@models/roles.enum';
 import {
-  NotVehicle, V3TechRecordModel, VehicleTypes,
+  V3TechRecordModel, VehicleTypes,
+  VehiclesOtherThan,
 } from '@models/vehicle-tech-record.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -82,7 +83,7 @@ describe('TechRecordTitleComponent', () => {
       expect(vrmField.textContent).not.toContain('TESTV RM4');
     });
     it('should not create previous-vrm-span if no secondary vrm exists', () => {
-      delete (mockRecord as NotVehicle<'trl'>).secondaryVrms;
+      delete (mockRecord as VehiclesOtherThan<'trl'>).secondaryVrms;
       fixture.detectChanges();
 
       const vrmField = fixture.debugElement.query(By.css('#previous-vrm-span'));

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -11,7 +11,8 @@ import { CustomFormControl, CustomFormGroup, FormNodeTypes } from '@forms/servic
 import { CustomValidators } from '@forms/validators/custom-validators';
 import { SEARCH_TYPES } from '@models/search-types-enum';
 import {
-  NotVehicle, StatusCodes, V3TechRecordModel, VehicleTypes,
+  StatusCodes, V3TechRecordModel, VehicleTypes,
+  VehiclesOtherThan,
 } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
@@ -179,9 +180,9 @@ export class CreateTechRecordComponent implements OnChanges {
   }
 
   async isVrmUnique() {
-    (this.techRecord as NotVehicle<'trl'>).primaryVrm = this.form.value.vrmTrm;
+    (this.techRecord as VehiclesOtherThan<'trl'>).primaryVrm = this.form.value.vrmTrm;
     const isVrmUnique = await firstValueFrom(
-      this.technicalRecordService.isUnique((this.techRecord as NotVehicle<'trl'>).primaryVrm?.replace(/\s+/g, '') ?? '', SEARCH_TYPES.VRM),
+      this.technicalRecordService.isUnique((this.techRecord as VehiclesOtherThan<'trl'>).primaryVrm?.replace(/\s+/g, '') ?? '', SEARCH_TYPES.VRM),
     );
     if (!isVrmUnique) {
       this.globalErrorService.addError({ error: 'Vrm not unique', anchorLink: 'input-vrm-or-trailer-id' });

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -11,7 +11,7 @@ import { CustomFormControl, CustomFormGroup, FormNodeTypes } from '@forms/servic
 import { CustomValidators } from '@forms/validators/custom-validators';
 import { SEARCH_TYPES } from '@models/search-types-enum';
 import {
-  NotTrailer, StatusCodes, V3TechRecordModel, VehicleTypes,
+  NotVehicle, StatusCodes, V3TechRecordModel, VehicleTypes
 } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';
@@ -179,9 +179,9 @@ export class CreateTechRecordComponent implements OnChanges {
   }
 
   async isVrmUnique() {
-    (this.techRecord as NotTrailer).primaryVrm = this.form.value.vrmTrm;
+    (this.techRecord as NotVehicle<'trl'>).primaryVrm = this.form.value.vrmTrm;
     const isVrmUnique = await firstValueFrom(
-      this.technicalRecordService.isUnique((this.techRecord as NotTrailer).primaryVrm?.replace(/\s+/g, '') ?? '', SEARCH_TYPES.VRM),
+      this.technicalRecordService.isUnique((this.techRecord as NotVehicle<'trl'>).primaryVrm?.replace(/\s+/g, '') ?? '', SEARCH_TYPES.VRM),
     );
     if (!isVrmUnique) {
       this.globalErrorService.addError({ error: 'Vrm not unique', anchorLink: 'input-vrm-or-trailer-id' });

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -11,7 +11,7 @@ import { CustomFormControl, CustomFormGroup, FormNodeTypes } from '@forms/servic
 import { CustomValidators } from '@forms/validators/custom-validators';
 import { SEARCH_TYPES } from '@models/search-types-enum';
 import {
-  NotVehicle, StatusCodes, V3TechRecordModel, VehicleTypes
+  NotVehicle, StatusCodes, V3TechRecordModel, VehicleTypes,
 } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { BatchTechnicalRecordService } from '@services/batch-technical-record/batch-technical-record.service';

--- a/src/app/forms/custom-sections/adr-examiner-notes-history/adr-examiner-notes-history.component.ts
+++ b/src/app/forms/custom-sections/adr-examiner-notes-history/adr-examiner-notes-history.component.ts
@@ -1,14 +1,14 @@
+import { KeyValue } from '@angular/common';
 import {
   AfterContentInit,
   Component, inject, OnDestroy, OnInit,
 } from '@angular/core';
-import { ReplaySubject, takeUntil } from 'rxjs';
 import { FormArray, NgControl } from '@angular/forms';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { BaseControlComponent } from '@forms/components/base-control/base-control.component';
 import { CustomControl, CustomFormControl } from '@forms/services/dynamic-form.types';
-import { KeyValue } from '@angular/common';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
+import { ReplaySubject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-adr-examiner-notes-history',
@@ -20,14 +20,14 @@ export class AdrExaminerNotesHistoryComponent extends BaseControlComponent imple
   destroy$ = new ReplaySubject<boolean>(1);
 
   formArray = new FormArray<CustomFormControl>([]);
-  currentTechRecord?: TechRecordType<'hgv'> | TechRecordType<'lgv'> | TechRecordType<'trl'> = undefined;
+  currentTechRecord?: TechRecordType<'hgv' | 'lgv' | 'trl'> = undefined;
   technicalRecordService = inject(TechnicalRecordService);
   ngOnInit() {
     this.formArray.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => {
       this.control?.patchValue(changes, { emitModelToViewChange: true });
     });
     this.technicalRecordService.techRecord$.pipe(takeUntil(this.destroy$)).subscribe((currentTechRecord) => {
-      this.currentTechRecord = currentTechRecord as TechRecordType<'hgv'> | TechRecordType<'lgv'> | TechRecordType<'trl'>;
+      this.currentTechRecord = currentTechRecord as TechRecordType<'hgv' | 'lgv' | 'trl'>;
     });
   }
 

--- a/src/app/forms/custom-sections/approval-type/approval-type.component.ts
+++ b/src/app/forms/custom-sections/approval-type/approval-type.component.ts
@@ -22,7 +22,7 @@ import { Subject, debounceTime, takeUntil } from 'rxjs';
   styleUrls: ['./approval-type.component.scss'],
 })
 export class ApprovalTypeComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() techRecord!: TechRecordType<'trl'> | TechRecordType<'psv'> | TechRecordType<'hgv'>;
+  @Input() techRecord!: TechRecordType<'hgv' | 'psv' | 'trl'>;
   @Input() isEditing = false;
   @Output() formChange = new EventEmitter();
   @Output() approvalTypeNumberChange = new EventEmitter<string>();

--- a/src/app/forms/custom-sections/plates/plates.component.spec.ts
+++ b/src/app/forms/custom-sections/plates/plates.component.spec.ts
@@ -7,7 +7,7 @@ import { GlobalErrorService } from '@core/components/global-error/global-error.s
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { Roles } from '@models/roles.enum';
-import { HgvOrTrl, VehicleConfigurations } from '@models/vehicle-tech-record.model';
+import { VehicleConfigurations } from '@models/vehicle-tech-record.model';
 import { StoreModule } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { UserService } from '@services/user-service/user-service';
@@ -58,7 +58,7 @@ describe('PlatesComponent', () => {
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
     errorService = TestBed.inject(GlobalErrorService);
-    component.techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as HgvOrTrl;
+    component.techRecord = { systemNumber: 'foo', createdTimestamp: 'bar', vin: 'testVin' } as TechRecordType<'hgv' | 'trl'>;
     store = TestBed.inject(MockStore);
     fixture.detectChanges();
   });
@@ -191,7 +191,7 @@ describe('PlatesComponent', () => {
         techRecord_vehicleConfiguration: VehicleConfigurations.RIGID,
         vin: 'HGVTEST01',
         techRecord_axles: [],
-      } as unknown as HgvOrTrl;
+      } as unknown as TechRecordType<'hgv' | 'trl'>;
 
       component.techRecord.techRecord_axles = [
         {

--- a/src/app/forms/custom-sections/plates/plates.component.ts
+++ b/src/app/forms/custom-sections/plates/plates.component.ts
@@ -4,14 +4,15 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { HGVAxles, HGVPlates } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
+import { HGVPlates } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
 import { TRLPlates } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
+import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { hgvRequiredFields, trlRequiredFields, tyreRequiredFields } from '@forms/models/plateRequiredFields.model';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
 import { CustomFormGroup, FormNodeEditTypes } from '@forms/services/dynamic-form.types';
 import { PlatesTemplate } from '@forms/templates/general/plates.template';
 import { Roles } from '@models/roles.enum';
-import { HgvOrTrl, StatusCodes } from '@models/vehicle-tech-record.model';
+import { Axle, StatusCodes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { canGeneratePlate, updateScrollPosition } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
@@ -24,7 +25,7 @@ import { Subscription, debounceTime } from 'rxjs';
   styleUrls: ['./plates.component.scss'],
 })
 export class PlatesComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() techRecord!: HgvOrTrl;
+  @Input() techRecord!: TechRecordType<'hgv' | 'trl'>;
   @Input() isEditing = false;
 
   @Output() formChange = new EventEmitter();
@@ -142,7 +143,7 @@ export class PlatesComponent implements OnInit, OnDestroy, OnChanges {
 
   private cannotGeneratePlate(plateRequiredFields: string[]): boolean {
     const isOneFieldEmpty = plateRequiredFields.some((field) => {
-      const value = this.techRecord[field as keyof HgvOrTrl];
+      const value = this.techRecord[field as keyof TechRecordType<'hgv' | 'trl'>];
       return value === undefined || value === null || value === '';
     });
 
@@ -153,11 +154,11 @@ export class PlatesComponent implements OnInit, OnDestroy, OnChanges {
     // check tyre fields
     const areTyresInvalid = this.techRecord.techRecord_axles?.some((axle) => {
       tyreRequiredFields.some((field) => {
-        const value = axle[field as keyof HGVAxles];
+        const value = axle[field as keyof Axle<'hgv'>];
         return value === undefined || value === null || value === '';
       });
       // either one of ply rating or load index is required
-      const plyOrLoad = axle['tyres_plyRating' as keyof HGVAxles] || axle['tyres_dataTrAxles' as keyof HGVAxles];
+      const plyOrLoad = axle['tyres_plyRating' as keyof Axle<'hgv'>] || axle['tyres_dataTrAxles' as keyof Axle<'hgv'>];
       return plyOrLoad === undefined || plyOrLoad === null || plyOrLoad === '';
     });
 

--- a/src/app/forms/custom-sections/tyres/tyres.component.spec.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.spec.ts
@@ -2,16 +2,15 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { SimpleChanges } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { DynamicFormsModule } from '@forms/dynamic-forms.module';
 import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record.mock';
-import { Tyres } from '@models/vehicle-tech-record.model';
+import { Axles, Tyres } from '@models/vehicle-tech-record.model';
 import { StoreModule } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { State, initialAppState } from '@store/index';
 import { of, throwError } from 'rxjs';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { TyresComponent } from './tyres.component';
 
 const mockReferenceDataService = {
@@ -259,9 +258,7 @@ describe('TyresComponent', () => {
 
       component.addTyreToTechRecord(tyre, 1);
 
-      const axles = component.vehicleTechRecord.techRecord_axles as NonNullable<
-      (TechRecordType<'psv'> | TechRecordType<'trl'> | TechRecordType<'hgv'>)['techRecord_axles']
-      >;
+      const axles = component.vehicleTechRecord.techRecord_axles as Axles;
 
       expect(axles[0]?.tyres_tyreSize).toBe(tyre.tyreSize);
       expect(axles[0]?.tyres_dataTrAxles).toBe(tyre.dataTrAxles);

--- a/src/app/forms/custom-sections/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.ts
@@ -5,9 +5,6 @@ import {
 import { ActivatedRoute, Router } from '@angular/router';
 import { TyreUseCode as HgvTyreUseCode } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/tyreUseCodeHgv.enum.js';
 import { TyreUseCode as TrlTyreUseCode } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/tyreUseCodeTrl.enum.js';
-import { HGVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
-import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
-import { TRLAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { MultiOptions } from '@forms/models/options.model';
 import { DynamicFormService } from '@forms/services/dynamic-form.service';
@@ -23,17 +20,18 @@ import {
   Axle, FitmentCode, ReasonForEditing, SpeedCategorySymbol, Tyre, Tyres, VehicleTypes,
 } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
+import { ReferenceDataService } from '@services/reference-data/reference-data.service';
+import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { selectAllReferenceDataByResourceType } from '@store/reference-data';
 import { addAxle, removeAxle, updateScrollPosition } from '@store/technical-records';
 import { TechnicalRecordServiceState } from '@store/technical-records/reducers/technical-record-service.reducer';
 import { cloneDeep } from 'lodash';
 import {
+  Observable,
   ReplaySubject,
   filter,
-  takeUntil, Observable,
+  takeUntil,
 } from 'rxjs';
-import { ReferenceDataService } from '@services/reference-data/reference-data.service';
-import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 
 @Component({
   selector: 'app-tyres',
@@ -41,7 +39,7 @@ import { TechnicalRecordService } from '@services/technical-record/technical-rec
   styleUrls: ['./tyres.component.scss'],
 })
 export class TyresComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() vehicleTechRecord!: TechRecordType<'psv'> | TechRecordType<'trl'> | TechRecordType<'hgv'>;
+  @Input() vehicleTechRecord!: TechRecordType<'hgv' | 'psv' | 'trl'>;
   @Input() isEditing = false;
 
   @Output() formChange = new EventEmitter();
@@ -166,7 +164,7 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
       && (vehicleTechRecord.currentValue.techRecord_axles === vehicleTechRecord.previousValue.techRecord_axles))) {
       return;
     }
-    vehicleTechRecord.currentValue.techRecord_axles.forEach((axle: HGVAxles | TRLAxles | PSVAxles) => {
+    vehicleTechRecord.currentValue.techRecord_axles.forEach((axle: Axle) => {
       if (axle.tyres_dataTrAxles && axle.weights_gbWeight && axle.axleNumber) {
         const weightValue = this.technicalRecordService.getAxleFittingWeightValueFromLoadIndex(
           axle.tyres_dataTrAxles.toString(),

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -1,5 +1,6 @@
 import { ApprovalType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/approvalType.enum';
 import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
+import { VehicleType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/search';
 import { ParagraphIds } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType as TechRecordTypeByVehicle } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
@@ -14,14 +15,13 @@ export interface VehicleTechRecordModel {
 }
 
 export type V3TechRecordModel = TechRecordType<'get'> | TechRecordType<'put'>;
-export type NotTrailer =
-  | TechRecordTypeByVehicle<'hgv'>
-  | TechRecordTypeByVehicle<'psv'>
-  | TechRecordTypeByVehicle<'motorcycle'>
-  | TechRecordTypeByVehicle<'lgv'>
-  | TechRecordTypeByVehicle<'car'>;
 
-export type HgvOrTrl = TechRecordTypeByVehicle<'hgv'> | TechRecordTypeByVehicle<'trl'>;
+export type Empty<T> = { [key in keyof T]: T[key] | null };
+
+export type NotVehicle<T extends VehicleType> = TechRecordTypeByVehicle<Exclude<VehicleType, T>>;
+
+export type Axles<T extends 'hgv' | 'psv' | 'trl' = 'hgv' | 'psv' | 'trl'> = NonNullable<TechRecordTypeByVehicle<T>['techRecord_axles']>;
+export type Axle<T extends 'hgv' | 'psv' | 'trl' = 'hgv' | 'psv' | 'trl'> = Axles<T>[0];
 
 export type BatchUpdateVehicleModel = TechRecordType<'put'> & {
   createdTimestamp: string;
@@ -167,14 +167,6 @@ export enum SpeedCategorySymbol {
   N = 'n',
   P = 'p',
   Q = 'q',
-}
-
-export interface Axle {
-  axleNumber?: number;
-  brakes?: AxleBrakeProperties;
-  parkingBrakeMrk?: boolean;
-  tyres?: Tyres;
-  weights?: AxleWeights;
 }
 
 export enum FitmentCode {

--- a/src/app/models/vehicle-tech-record.model.ts
+++ b/src/app/models/vehicle-tech-record.model.ts
@@ -18,7 +18,7 @@ export type V3TechRecordModel = TechRecordType<'get'> | TechRecordType<'put'>;
 
 export type Empty<T> = { [key in keyof T]: T[key] | null };
 
-export type NotVehicle<T extends VehicleType> = TechRecordTypeByVehicle<Exclude<VehicleType, T>>;
+export type VehiclesOtherThan<T extends VehicleType> = TechRecordTypeByVehicle<Exclude<VehicleType, T>>;
 
 export type Axles<T extends 'hgv' | 'psv' | 'trl' = 'hgv' | 'psv' | 'trl'> = NonNullable<TechRecordTypeByVehicle<T>['techRecord_axles']>;
 export type Axle<T extends 'hgv' | 'psv' | 'trl' = 'hgv' | 'psv' | 'trl'> = Axles<T>[0];

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HGVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
-import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
-import { TRLAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
-import { AxleSpacing } from '@models/vehicle-tech-record.model';
+import {
+  Axle, AxleSpacing, Axles, Empty,
+} from '@models/vehicle-tech-record.model';
 import cloneDeep from 'lodash.clonedeep';
 
 @Injectable({
@@ -10,9 +9,9 @@ import cloneDeep from 'lodash.clonedeep';
 })
 export class AxlesService {
   normaliseAxles(
-    axles?: HGVAxles[] | PSVAxles[] | TRLAxles[],
+    axles?: Axles,
     axleSpacings?: AxleSpacing[],
-  ): [HGVAxles[] | PSVAxles[] | TRLAxles[] | undefined, AxleSpacing[] | undefined] {
+  ): [Axles | undefined, AxleSpacing[] | undefined] {
     let newAxles = cloneDeep(axles ?? []);
     let newAxleSpacings = cloneDeep(axleSpacings ?? []);
 
@@ -44,8 +43,8 @@ export class AxlesService {
 
   generateAxlesFromAxleSpacings(
     vehicleAxleSpacingsLength: number,
-    previousAxles?: HGVAxles[] | PSVAxles[] | TRLAxles[],
-  ): HGVAxles[] | PSVAxles[] | TRLAxles[] {
+    previousAxles?: Empty<Axle>[],
+  ): Empty<Axle>[] {
     const axles = previousAxles ?? [];
 
     for (let i = axles.length; i < vehicleAxleSpacingsLength + 1; i++) {
@@ -55,13 +54,12 @@ export class AxlesService {
     return axles;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  generateEmptyAxle(axleNumber: number): any {
+  generateEmptyAxle(axleNumber: number): Empty<Axle> & { axleNumber?: number } {
     return {
       axleNumber,
       weights_gbWeight: null,
       weights_eecWeight: null,
-      weights_designedWeight: null,
+      weights_designWeight: null,
       tyres_tyreSize: null,
       tyres_fitmentCode: null,
       tyres_dataTrAxles: null,

--- a/src/mocks/psv-record.mock.ts
+++ b/src/mocks/psv-record.mock.ts
@@ -2,10 +2,10 @@ import { ApprovalType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/en
 import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryPsv.enum.js';
 import { VehicleClassDescription } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/vehicleClassDescriptionPSV.enum.js';
 import { VehicleConfiguration } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/vehicleConfigurationHgvPsv.enum.js';
-import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { BodyTypeDescription } from '@models/body-type-enum';
 import {
+  Axles,
   FuelTypes, Retarders, StatusCodes,
   VehicleSizes,
 } from '../app/models/vehicle-tech-record.model';
@@ -22,7 +22,7 @@ export const createMockPsv = (systemNumber: number): TechRecordType<'psv'> => ({
   techRecord_vehicleType: 'psv',
   techRecord_regnDate: '1234',
   techRecord_manufactureYear: 2022,
-  techRecord_axles: axles as unknown as PSVAxles[],
+  techRecord_axles: axles as unknown as Axles<'psv'>,
   techRecord_noOfAxles: 2,
   techRecord_brakes_dtpNumber: '1234',
   techRecord_brakes_brakeCode: '1234',


### PR DESCRIPTION
## Tech Debt

Generally the aim of this PR is to get the codebase to have a better source of truth for types, with better inference - all derived from the types package.

Changes:
1. Changes use of unions of TechRecordType to use more succinct syntax
2. Adds VehicleOtherThan utility type to exclude vehicle types from TechRecordType, this also replaces the NotTrailer type with this more general utility type, i.e. VehicleOtherThan<'trl'>
3. Adds Empty utility type to convert another type into the same type but with nullable fields
4. Adds Axles type which is derived from the techRecord_axles property of the V3 model and infers the specific properties of that axle based on the generic passed in, e.g. Axles<'psv'> returns an array of PSVAxles, where each item can have weights_kerbWeight. By default this uses the union of vehicle types which can have axles, i.e. 'hgv' | 'psv' | 'trl'
5. Adds Axle type which is derived from the type of items of the Axles type array, and also provides the same generics
6. Fixed no-explicit-any warning in axles service as the aforementioned types provide correct type inference


[CB2-8121](https://dvsa.atlassian.net/browse/CB2-8121)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
