### PR TITLE
fix(cb2-10441): fix reference number incorrectly display

### DIFF
--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -649,7 +649,7 @@ export const AdrTemplate: FormNode = {
       value: null,
       type: FormNodeTypes.CONTROL,
       width: FormNodeWidth.L,
-      groups: ['battery_list_applicable', 'battery_list_hide', 'dangerous_goods'],
+      groups: ['battery_list_applicable', 'battery_list_hide'],
       validators: [
         { name: ValidatorNames.MaxLength, args: 8 },
         {

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -631,7 +631,7 @@ export const AdrTemplate: FormNode = {
       ],
       validators: [
         { name: ValidatorNames.ShowGroupsWhenEqualTo, args: { values: [true], groups: ['battery_list_applicable'] } },
-        { name: ValidatorNames.HideGroupsWhenEqualTo, args: { values: [false], groups: ['battery_list_applicable'] } },
+        { name: ValidatorNames.HideGroupsWhenEqualTo, args: { values: [false, undefined, null], groups: ['battery_list_applicable'] } },
         {
           name: ValidatorNames.RequiredIfEquals,
           args: {
@@ -649,7 +649,7 @@ export const AdrTemplate: FormNode = {
       value: null,
       type: FormNodeTypes.CONTROL,
       width: FormNodeWidth.L,
-      groups: ['battery_list_applicable', 'battery_list_hide'],
+      groups: ['battery_list_applicable', 'battery_list_hide', 'dangerous_goods'],
       validators: [
         { name: ValidatorNames.MaxLength, args: 8 },
         {

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -490,7 +490,11 @@ function handleClearADRDetails(state: TechnicalRecordServiceState) {
       if (!listStatementApplicable) {
         sanitisedEditingTechRecord = { ...sanitisedEditingTechRecord, ...nulledBatteryListNumber };
       }
-
+      // If the ADR body type not includes 'battery', null the battery list number even if the listStatementApplicable is true
+      const { techRecord_adrDetails_vehicleDetails_type: vehicleDetailsType } = sanitisedEditingTechRecord;
+      if (!vehicleDetailsType?.includes('battery')) {
+        sanitisedEditingTechRecord = { ...sanitisedEditingTechRecord, ...nulledBatteryListNumber };
+      }
       // If manufacturer brake declaration is no, null dependent sections
       const { techRecord_adrDetails_brakeDeclarationsSeen: brakeDeclarationSeen } = sanitisedEditingTechRecord;
       if (!brakeDeclarationSeen) {


### PR DESCRIPTION
## ADR-Reference number display incorrectly
The reference number should be displayed when the user selects option 'yes' in the battery applicable field.

[CB2-10441](https://dvsa.atlassian.net/browse/CB2-10441)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
