### PR TITLE
feat(cb2-10129): Odometer reading marked as optional on IVA

### DIFF
--- a/src/app/forms/models/validators.enum.ts
+++ b/src/app/forms/models/validators.enum.ts
@@ -46,5 +46,4 @@ export enum ValidatorNames {
   Tc3TestValidator = 'tc3TestValidator',
   DateIsInvalid = 'dateIsInvalid',
   TankDetailsUnNumberValidator = 'tankDetailsUnNumberValidator',
-  SetSiblingAsTouchedIfNotEqual = 'setSiblingTouchedIfNotEqual',
 }

--- a/src/app/forms/models/validators.enum.ts
+++ b/src/app/forms/models/validators.enum.ts
@@ -46,5 +46,5 @@ export enum ValidatorNames {
   Tc3TestValidator = 'tc3TestValidator',
   DateIsInvalid = 'dateIsInvalid',
   TankDetailsUnNumberValidator = 'tankDetailsUnNumberValidator',
-  SetSiblingErrorsIfNotEqual = 'setSiblingErrorsIfNotEqual',
+  SetSiblingAsTouchedIfNotEqual = 'setSiblingTouchedIfNotEqual',
 }

--- a/src/app/forms/models/validators.enum.ts
+++ b/src/app/forms/models/validators.enum.ts
@@ -46,4 +46,5 @@ export enum ValidatorNames {
   Tc3TestValidator = 'tc3TestValidator',
   DateIsInvalid = 'dateIsInvalid',
   TankDetailsUnNumberValidator = 'tankDetailsUnNumberValidator',
+  SetSiblingErrorsIfNotEqual = 'setSiblingErrorsIfNotEqual',
 }

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -58,8 +58,10 @@ export class DynamicFormService {
     [ValidatorNames.RequiredIfEquals]: (args: { sibling: string; value: unknown[] }) => CustomValidators.requiredIfEquals(args.sibling, args.value),
     [ValidatorNames.requiredIfAllEquals]: (args: { sibling: string; value: unknown[] }) =>
       CustomValidators.requiredIfAllEquals(args.sibling, args.value),
-    [ValidatorNames.RequiredIfNotEquals]: (args: { sibling: string; value: unknown }) =>
-      CustomValidators.requiredIfNotEqual(args.sibling, args.value),
+    [ValidatorNames.RequiredIfNotEquals]: (args: { sibling: string; value: unknown[] }) =>
+      CustomValidators.requiredIfNotEquals(args.sibling, args.value),
+    [ValidatorNames.SetSiblingErrorsIfNotEqual]: (args: { sibling: string; value: unknown[] }) =>
+      CustomValidators.setSiblingErrorsIfNotEqual(args.sibling, args.value),
     [ValidatorNames.ValidateVRMTrailerIdLength]: (args: { sibling: string }) => CustomValidators.validateVRMTrailerIdLength(args.sibling),
     [ValidatorNames.ValidateDefectNotes]: () => DefectValidators.validateDefectNotes,
     [ValidatorNames.ValidateProhibitionIssued]: () => DefectValidators.validateProhibitionIssued,

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -60,8 +60,6 @@ export class DynamicFormService {
       CustomValidators.requiredIfAllEquals(args.sibling, args.value),
     [ValidatorNames.RequiredIfNotEquals]: (args: { sibling: string; value: unknown[] }) =>
       CustomValidators.requiredIfNotEquals(args.sibling, args.value),
-    [ValidatorNames.SetSiblingAsTouchedIfNotEqual]: (args: { sibling: string; value: unknown[] }) =>
-      CustomValidators.setSiblingAsTouchedIfNotEqual(args.sibling, args.value),
     [ValidatorNames.ValidateVRMTrailerIdLength]: (args: { sibling: string }) => CustomValidators.validateVRMTrailerIdLength(args.sibling),
     [ValidatorNames.ValidateDefectNotes]: () => DefectValidators.validateDefectNotes,
     [ValidatorNames.ValidateProhibitionIssued]: () => DefectValidators.validateProhibitionIssued,

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -60,8 +60,8 @@ export class DynamicFormService {
       CustomValidators.requiredIfAllEquals(args.sibling, args.value),
     [ValidatorNames.RequiredIfNotEquals]: (args: { sibling: string; value: unknown[] }) =>
       CustomValidators.requiredIfNotEquals(args.sibling, args.value),
-    [ValidatorNames.SetSiblingErrorsIfNotEqual]: (args: { sibling: string; value: unknown[] }) =>
-      CustomValidators.setSiblingErrorsIfNotEqual(args.sibling, args.value),
+    [ValidatorNames.SetSiblingAsTouchedIfNotEqual]: (args: { sibling: string; value: unknown[] }) =>
+      CustomValidators.setSiblingAsTouchedIfNotEqual(args.sibling, args.value),
     [ValidatorNames.ValidateVRMTrailerIdLength]: (args: { sibling: string }) => CustomValidators.validateVRMTrailerIdLength(args.sibling),
     [ValidatorNames.ValidateDefectNotes]: () => DefectValidators.validateDefectNotes,
     [ValidatorNames.ValidateProhibitionIssued]: () => DefectValidators.validateProhibitionIssued,

--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -107,7 +107,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
       reasonForCreation: reasonForCreationSection,
     },
     testTypesSpecialistGroup1: {
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup1,
       seatbelts: SeatbeltHiddenSection,
       visit: ContingencyVisitSection,
@@ -151,7 +151,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
       required: CreateRequiredSection,
     },
     testTypesSpecialistGroup5: {
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup5,
       seatbelts: SeatbeltHiddenSection,
       visit: ContingencyVisitSection,
@@ -278,7 +278,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
       reasonForCreation: reasonForCreationSection,
     },
     testTypesSpecialistGroup1: {
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup1,
       visit: ContingencyVisitSection,
       notes: NotesSection,
@@ -288,7 +288,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
       required: CreateRequiredSectionHgvTrl,
     },
     testTypesSpecialistGroup5: {
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup5,
       visit: ContingencyVisitSection,
       notes: NotesSection,
@@ -503,7 +503,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     },
     testTypesSpecialistGroup1: {
       required: CreateRequiredSectionLgvCar,
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup1,
       customDefects: CustomDefectsSection,
       visit: ContingencyVisitSection,
@@ -521,7 +521,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     },
     testTypesSpecialistGroup5: {
       required: CreateRequiredSectionLgvCar,
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup5,
       customDefects: CustomDefectsSection,
       visit: ContingencyVisitSection,
@@ -569,7 +569,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     },
     testTypesSpecialistGroup5: {
       required: CreateRequiredSectionLgvCar,
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup5,
       customDefects: CustomDefectsSection,
       visit: ContingencyVisitSection,

--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -55,6 +55,7 @@ import { DeskBasedVehicleSectionGroup5Lgv } from './section-templates/vehicle/de
 import { VehicleSectionGroup3 } from './section-templates/vehicle/group-3-light-vehicle-section.template';
 import { ContingencyVisitSection } from './section-templates/visit/contingency-visit-section.template';
 import { VisitSection } from './section-templates/visit/visit-section.template';
+import { ContingencyM1IvaVehicleSection } from './section-templates/vehicle/contingency-m1-iva-vehicle-section.template';
 
 const groups1and2Template: Record<string, FormNode> = {
   required: CreateRequiredSection,
@@ -550,7 +551,7 @@ export const contingencyTestTemplates: Record<VehicleTypes, Partial<Record<keyof
     },
     testTypesSpecialistGroup1: {
       required: CreateRequiredSectionLgvCar,
-      vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
+      vehicle: ContingencyM1IvaVehicleSection,
       test: ContingencyTestSectionSpecialistGroup1,
       customDefects: CustomDefectsSection,
       visit: ContingencyVisitSection,

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-m1-iva-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-m1-iva-vehicle-section.template.ts
@@ -56,8 +56,8 @@ export const ContingencyM1IvaVehicleSection: FormNode = {
       label: 'Odometer Reading',
       value: null,
       validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Max, args: 9999999 },
-        { name: ValidatorNames.RequiredIfEquals, args: { sibling: 'odometerReadingUnits', value: 'miles' } },
-        { name: ValidatorNames.SetSiblingErrorsIfNotEqual, args: { sibling: 'odometerReadingUnits', value: [null] } },
+        { name: ValidatorNames.RequiredIfEquals, args: { sibling: 'odometerReadingUnits', value: ['miles', 'kilometres'] } },
+        { name: ValidatorNames.SetSiblingAsTouchedIfNotEqual, args: { sibling: 'odometerReadingUnits', value: [null] } },
       ],
       editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
@@ -67,7 +67,9 @@ export const ContingencyM1IvaVehicleSection: FormNode = {
     {
       name: 'odometerReadingUnits',
       label: 'Odometer Reading Units',
-      validators: [{ name: ValidatorNames.RequiredIfNotEquals, args: { sibling: 'odometerReading', value: [null] } }],
+      validators: [{ name: ValidatorNames.RequiredIfNotEquals, args: { sibling: 'odometerReading', value: [null] } },
+        { name: ValidatorNames.SetSiblingAsTouchedIfNotEqual, args: { sibling: 'odometerReading', value: [null] } }],
+
       value: null,
       options: [
         { value: 'kilometres', label: 'Kilometres' },

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-m1-iva-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-m1-iva-vehicle-section.template.ts
@@ -1,0 +1,99 @@
+import { AsyncValidatorNames } from '@forms/models/async-validators.enum';
+import { ValidatorNames } from '@forms/models/validators.enum';
+import {
+  FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth,
+} from '@forms/services/dynamic-form.types';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
+import { ReferenceDataResourceType } from '@models/reference-data.model';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
+
+export const ContingencyM1IvaVehicleSection: FormNode = {
+  name: 'vehicleSection',
+  label: 'Vehicle Details',
+  type: FormNodeTypes.GROUP,
+  children: [
+    {
+      name: 'vin',
+      label: 'VIN/chassis number',
+      value: '',
+      disabled: true,
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN,
+    },
+    {
+      name: 'vrm',
+      label: 'VRM',
+      value: '',
+      disabled: true,
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN,
+    },
+    {
+      name: 'countryOfRegistration',
+      label: 'Country Of Registration',
+      value: '',
+      options: [],
+      editType: FormNodeEditTypes.AUTOCOMPLETE,
+      referenceData: ReferenceDataResourceType.CountryOfRegistration,
+      type: FormNodeTypes.CONTROL,
+      asyncValidators: [{ name: AsyncValidatorNames.RequiredIfNotAbandoned }],
+      width: FormNodeWidth.XL,
+    },
+    {
+      name: 'euVehicleCategory',
+      label: 'EU Vehicle Category',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.SELECT,
+      width: FormNodeWidth.S,
+      options: getOptionsFromEnum(EUVehicleCategory),
+      validators: [{ name: ValidatorNames.Required }],
+    },
+    {
+      name: 'odometerReading',
+      label: 'Odometer Reading',
+      value: null,
+      validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Max, args: 9999999 },
+        { name: ValidatorNames.RequiredIfEquals, args: { sibling: 'odometerReadingUnits', value: 'miles' } },
+        { name: ValidatorNames.SetSiblingErrorsIfNotEqual, args: { sibling: 'odometerReadingUnits', value: [null] } },
+      ],
+      editType: FormNodeEditTypes.NUMBER,
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      width: FormNodeWidth.L,
+    },
+    {
+      name: 'odometerReadingUnits',
+      label: 'Odometer Reading Units',
+      validators: [{ name: ValidatorNames.RequiredIfNotEquals, args: { sibling: 'odometerReading', value: [null] } }],
+      value: null,
+      options: [
+        { value: 'kilometres', label: 'Kilometres' },
+        { value: 'miles', label: 'Miles' },
+      ],
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.SELECT,
+    },
+    {
+      name: 'preparerName',
+      label: 'Preparer Name',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN,
+      disabled: true,
+    },
+    {
+      name: 'preparerId',
+      label: 'Preparer ID',
+      value: '',
+      type: FormNodeTypes.CONTROL,
+      viewType: FormNodeViewTypes.HIDDEN,
+      editType: FormNodeEditTypes.HIDDEN,
+      disabled: true,
+    },
+  ],
+};

--- a/src/app/forms/templates/test-records/section-templates/vehicle/contingency-m1-iva-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/contingency-m1-iva-vehicle-section.template.ts
@@ -57,7 +57,6 @@ export const ContingencyM1IvaVehicleSection: FormNode = {
       value: null,
       validators: [{ name: ValidatorNames.Numeric }, { name: ValidatorNames.Max, args: 9999999 },
         { name: ValidatorNames.RequiredIfEquals, args: { sibling: 'odometerReadingUnits', value: ['miles', 'kilometres'] } },
-        { name: ValidatorNames.SetSiblingAsTouchedIfNotEqual, args: { sibling: 'odometerReadingUnits', value: [null] } },
       ],
       editType: FormNodeEditTypes.NUMBER,
       type: FormNodeTypes.CONTROL,
@@ -67,8 +66,7 @@ export const ContingencyM1IvaVehicleSection: FormNode = {
     {
       name: 'odometerReadingUnits',
       label: 'Odometer Reading Units',
-      validators: [{ name: ValidatorNames.RequiredIfNotEquals, args: { sibling: 'odometerReading', value: [null] } },
-        { name: ValidatorNames.SetSiblingAsTouchedIfNotEqual, args: { sibling: 'odometerReading', value: [null] } }],
+      validators: [{ name: ValidatorNames.RequiredIfNotEquals, args: { sibling: 'odometerReading', value: [null] } }],
 
       value: null,
       options: [

--- a/src/app/forms/utils/error-message-map.ts
+++ b/src/app/forms/utils/error-message-map.ts
@@ -32,6 +32,7 @@ export const ErrorMessageMap: Record<string, Function> = {
   [ValidatorNames.Pattern]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} must match a pattern`,
   [ValidatorNames.Required]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is required`,
   [ValidatorNames.RequiredIfEquals]: (err: { sibling: string }, label?: string) => `${label || DEFAULT_LABEL} is required with ${err.sibling}`,
+  [ValidatorNames.RequiredIfNotEquals]: (err: { sibling: string }, label?: string) => `${label || DEFAULT_LABEL} is required with ${err.sibling}`,
   [ValidatorNames.requiredIfAllEquals]: (err: { sibling: string }, label?: string) => `${label || DEFAULT_LABEL} is required with ${err.sibling}`,
   [ValidatorNames.RequiredIfNotHidden]: (label?: string) => `${label || DEFAULT_LABEL}  is required`,
   [ValidatorNames.ValidateDefectNotes]: () => 'Notes is required',

--- a/src/app/forms/validators/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators.spec.ts
@@ -282,29 +282,7 @@ describe('Required validators', () => {
     });
   });
 
-  describe('Set sibling error if not equal', () => {
-    it('should set the sibling as touched if the value does not match', () => {
-      form.controls['foo'].patchValue('some value');
-      form.controls['sibling'].patchValue(null);
-      const result = CustomValidators.setSiblingAsTouchedIfNotEqual('sibling', '')(form.controls['foo']);
-      expect(form.controls['sibling'].touched).toBe(true);
-      expect(result).toBeNull();
-    });
 
-    it('should not set the sibling as touched if the value does not match', () => {
-      form.controls['foo'].patchValue('some value');
-      form.controls['sibling'].patchValue(null);
-      const result = CustomValidators.setSiblingAsTouchedIfNotEqual('sibling', 'some value')(form.controls['foo']);
-      expect(form.controls['sibling'].touched).toBe(false);
-      expect(result).toBeNull();
-    });
-
-    it('should not be required (return null) if content of sibling does matches a value and we have a value', () => {
-      form.controls['foo'].patchValue('some foo value');
-      const result = CustomValidators.requiredIfEquals('sibling', ['some othervalue'])(form.controls['foo']);
-      expect(result).toBeNull();
-    });
-  });
 
   describe('Must Equal Sibling', () => {
     it('should return null if content of sibling matches a value', () => {

--- a/src/app/forms/validators/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators.spec.ts
@@ -266,13 +266,37 @@ describe('Required validators', () => {
 
   describe('Required if not equal', () => {
     it('should not be required (return null) if content of sibling does not match a value', () => {
-      const result = CustomValidators.requiredIfNotEqual('sibling', 'some value')(form.controls['foo']);
+      const result = CustomValidators.requiredIfNotEquals('sibling', 'some value')(form.controls['foo']);
       expect(result).toBeNull();
     });
 
     it('should be required (return ValidationErrors) if content of sibling does not match a value', () => {
-      const result = CustomValidators.requiredIfNotEqual('sibling', 'some other value')(form.controls['foo']);
-      expect(result).toEqual({ requiredIfNotEqual: { sibling: 'Sibling' } });
+      const result = CustomValidators.requiredIfNotEquals('sibling', 'some other value')(form.controls['foo']);
+      expect(result).toEqual({ requiredIfNotEquals: { sibling: 'Sibling' } });
+    });
+
+    it('should not be required (return null) if content of sibling does matches a value and we have a value', () => {
+      form.controls['foo'].patchValue('some foo value');
+      const result = CustomValidators.requiredIfEquals('sibling', ['some othervalue'])(form.controls['foo']);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Set sibling error if not equal', () => {
+    it('should not set siblings error if form control matches', () => {
+      form.controls['foo'].patchValue('some value');
+      form.controls['sibling'].patchValue(null);
+      const result = CustomValidators.setSiblingErrorsIfNotEqual('sibling', 'some value')(form.controls['foo']);
+      expect(form.controls['sibling'].errors).toBeNull();
+      expect(result).toBeNull();
+    });
+
+    it('should set the error if the form control does not match the value', () => {
+      form.controls['foo'].patchValue('some other value');
+      form.controls['sibling'].patchValue(null);
+      const result = CustomValidators.setSiblingErrorsIfNotEqual('sibling', 'some value')(form.controls['foo']);
+      expect(form.controls['sibling'].errors).not.toBeNull();
+      expect(result).toBeNull();
     });
 
     it('should not be required (return null) if content of sibling does matches a value and we have a value', () => {

--- a/src/app/forms/validators/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators.spec.ts
@@ -282,8 +282,6 @@ describe('Required validators', () => {
     });
   });
 
-
-
   describe('Must Equal Sibling', () => {
     it('should return null if content of sibling matches a value', () => {
       const value = 'some value';

--- a/src/app/forms/validators/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators.spec.ts
@@ -283,19 +283,19 @@ describe('Required validators', () => {
   });
 
   describe('Set sibling error if not equal', () => {
-    it('should not set siblings error if form control matches', () => {
+    it('should set the sibling as touched if the value does not match', () => {
       form.controls['foo'].patchValue('some value');
       form.controls['sibling'].patchValue(null);
-      const result = CustomValidators.setSiblingErrorsIfNotEqual('sibling', 'some value')(form.controls['foo']);
-      expect(form.controls['sibling'].errors).toBeNull();
+      const result = CustomValidators.setSiblingAsTouchedIfNotEqual('sibling', '')(form.controls['foo']);
+      expect(form.controls['sibling'].touched).toBe(true);
       expect(result).toBeNull();
     });
 
-    it('should set the error if the form control does not match the value', () => {
-      form.controls['foo'].patchValue('some other value');
+    it('should not set the sibling as touched if the value does not match', () => {
+      form.controls['foo'].patchValue('some value');
       form.controls['sibling'].patchValue(null);
-      const result = CustomValidators.setSiblingErrorsIfNotEqual('sibling', 'some value')(form.controls['foo']);
-      expect(form.controls['sibling'].errors).not.toBeNull();
+      const result = CustomValidators.setSiblingAsTouchedIfNotEqual('sibling', 'some value')(form.controls['foo']);
+      expect(form.controls['sibling'].touched).toBe(false);
       expect(result).toBeNull();
     });
 

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -153,22 +153,6 @@ export class CustomValidators {
         : null;
     };
 
-  static setSiblingAsTouchedIfNotEqual = (sibling: string, value: unknown): ValidatorFn => {
-    return (control: AbstractControl): null => {
-      if (control?.parent) {
-        const siblingControl = control.parent.get(sibling) as CustomFormControl;
-        const siblingValue = siblingControl.value;
-        const newValue = Array.isArray(value) ? value.includes(control.value) : control.value === value;
-
-        if (!newValue && (siblingValue === null || siblingValue === undefined || siblingValue === '') && !siblingControl.errors) {
-          siblingControl.markAsTouched();
-          siblingControl.updateValueAndValidity();
-        }
-      }
-      return null;
-    };
-  };
-
   static requiredIfNotEquals = (sibling: string, value: unknown): ValidatorFn => {
     return (control: AbstractControl): ValidationErrors | null => {
       if (control?.parent) {

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -153,7 +153,7 @@ export class CustomValidators {
         : null;
     };
 
-  static setSiblingErrorsIfNotEqual = (sibling: string, value: unknown): ValidatorFn => {
+  static setSiblingAsTouchedIfNotEqual = (sibling: string, value: unknown): ValidatorFn => {
     return (control: AbstractControl): null => {
       if (control?.parent) {
         const siblingControl = control.parent.get(sibling) as CustomFormControl;
@@ -162,7 +162,6 @@ export class CustomValidators {
 
         if (!newValue && (siblingValue === null || siblingValue === undefined || siblingValue === '') && !siblingControl.errors) {
           siblingControl.markAsTouched();
-          siblingControl.setErrors({ requiredIfNotEquals: { sibling: siblingControl.meta.label } });
           siblingControl.updateValueAndValidity();
         }
       }

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -153,7 +153,24 @@ export class CustomValidators {
         : null;
     };
 
-  static requiredIfNotEqual = (sibling: string, value: unknown): ValidatorFn => {
+  static setSiblingErrorsIfNotEqual = (sibling: string, value: unknown): ValidatorFn => {
+    return (control: AbstractControl): null => {
+      if (control?.parent) {
+        const siblingControl = control.parent.get(sibling) as CustomFormControl;
+        const siblingValue = siblingControl.value;
+        const newValue = Array.isArray(value) ? value.includes(control.value) : control.value === value;
+
+        if (!newValue && (siblingValue === null || siblingValue === undefined || siblingValue === '') && !siblingControl.errors) {
+          siblingControl.markAsTouched();
+          siblingControl.setErrors({ requiredIfNotEquals: { sibling: siblingControl.meta.label } });
+          siblingControl.updateValueAndValidity();
+        }
+      }
+      return null;
+    };
+  };
+
+  static requiredIfNotEquals = (sibling: string, value: unknown): ValidatorFn => {
     return (control: AbstractControl): ValidationErrors | null => {
       if (control?.parent) {
         const siblingControl = control.parent.get(sibling) as CustomFormControl;
@@ -161,7 +178,7 @@ export class CustomValidators {
         const newValue = Array.isArray(value) ? value.includes(siblingValue) : siblingValue === value;
 
         if (!newValue && (control.value === null || control.value === undefined || control.value === '')) {
-          return { requiredIfNotEqual: { sibling: siblingControl.meta.label } };
+          return { requiredIfNotEquals: { sibling: siblingControl.meta.label } };
         }
       }
 


### PR DESCRIPTION
Makes Odometer Reading/Units optional on IVA tests for all vehicle types except Motorcycles by creating a new template specifically for those test types. Also fixes a typo with a validator.

## Odometer Reading marked as optional on IVA tests

[CB2-10531](https://dvsa.atlassian.net/browse/CB2-10531)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
