### PR TITLE
feat(cb2-10521): change adr brake endurance weight unit of measurement to tonnes on a technical record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/router": "^15.2.8",
         "@azure/msal-angular": "^2.5.12",
         "@azure/msal-browser": "^2.38.3",
-        "@dvsa/cvs-type-definitions": "^5.0.0",
+        "@dvsa/cvs-type-definitions": "^5.1.0",
         "@ngrx/effects": "^15.4.0",
         "@ngrx/entity": "^15.4.0",
         "@ngrx/router-store": "^15.4.0",
@@ -5022,9 +5022,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-5.0.0.tgz",
-      "integrity": "sha512-rOMZRwQyiWrlEBlLC1MP9aQp2LuxAujicNJ698HKAlnnkylx6DUgAiXAemKQ4v8rSOnM5B5Tq2ED/DOyegQuZQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-5.1.0.tgz",
+      "integrity": "sha512-GjnTqJtS1Tqh3GWL/He2Q/l4YKPBSbP24WtDWMZ0H/pSZmmDF2/FbiYmedRn14r7ruaSN4MNnTNMGCYJrT/hsg==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@angular/router": "^15.2.8",
     "@azure/msal-angular": "^2.5.12",
     "@azure/msal-browser": "^2.38.3",
-    "@dvsa/cvs-type-definitions": "^5.0.0",
+    "@dvsa/cvs-type-definitions": "^5.1.0",
     "@ngrx/effects": "^15.4.0",
     "@ngrx/entity": "^15.4.0",
     "@ngrx/router-store": "^15.4.0",

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -731,9 +731,13 @@ export const AdrTemplate: FormNode = {
       groups: ['weight_section', 'issuer_section_hide', 'dangerous_goods_hide'],
       hide: true,
       validators: [
-        { name: ValidatorNames.MaxLength, args: 8 },
+        { name: ValidatorNames.Max, args: 99999999 },
         {
           name: ValidatorNames.RequiredIfNotHidden,
+        },
+        {
+          name: ValidatorNames.CustomPattern,
+          args: ['^\\d*(\\.\\d{0,3})?$', 'Max 3 decimal places'],
         },
       ],
     },

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -737,7 +737,7 @@ export const AdrTemplate: FormNode = {
         },
         {
           name: ValidatorNames.CustomPattern,
-          args: ['^\\d*(\\.\\d{0,3})?$', 'Max 3 decimal places'],
+          args: ['^\\d*(\\.\\d{0,2})?$', 'Max 2 decimal places'],
         },
       ],
     },

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -723,14 +723,15 @@ export const AdrTemplate: FormNode = {
     },
     {
       name: 'techRecord_adrDetails_weight',
-      label: 'Weight (kg)',
+      label: 'Weight (tonnes)',
       type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.NUMBER,
+      enableDecimals: true,
       width: FormNodeWidth.L,
       groups: ['weight_section', 'issuer_section_hide', 'dangerous_goods_hide'],
       hide: true,
       validators: [
         { name: ValidatorNames.MaxLength, args: 8 },
-        { name: ValidatorNames.Numeric },
         {
           name: ValidatorNames.RequiredIfNotHidden,
         },


### PR DESCRIPTION
## Ticket title
changes units on the label to tonnes and will allow up to 2 decimal places. Preserves max number as 99999999 based on the previous max length of string. 

Types package PR requires merging and v3 bumping before this will submit as change of data type

_One line description_
[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
