### PR TITLE
fix(cb2-10525): keep vrm on a single line

### DIFF
--- a/src/app/shared/components/number-plate/number-plate.component.scss
+++ b/src/app/shared/components/number-plate/number-plate.component.scss
@@ -18,6 +18,7 @@
   line-height: 1;
   padding: 0.5rem 0.1rem;
   width: 100px;
+  white-space: nowrap;
 }
 
 .secondary {


### PR DESCRIPTION
## VRM with length 9 is getting move to next line

whitespace: nowrap; - works everytime.

[CB2-10525](https://dvsa.atlassian.net/browse/CB2-10525)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
