### PR TITLE
fix(cb2-10591): uncomment custom views for TC2 and TC3 inspections

### DIFF
--- a/src/app/forms/components/view-list-item/view-list-item.component.html
+++ b/src/app/forms/components/view-list-item/view-list-item.component.html
@@ -49,32 +49,6 @@
       </td>
     </ng-container>
 
-    <!-- TODO: remove entirely, and use custom view component -->
-    <ng-container *ngSwitchCase="formNodeViewTypes.ADRINSPECTIONS">
-      <ng-container *ngIf="value && value.length > 0">
-        <table>
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header"></th>
-              <th scope="col" class="govuk-table__header">TC3: Inspection Type</th>
-              <th scope="col" class="govuk-table__header">TC3: Certificate Number</th>
-              <th scope="col" class="govuk-table__header">TC3: Expiry Date</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <tr class="govuk-table__row" *ngFor="let result of value; let i = index; let isLast = last">
-              <td class="govuk-table__cell break-words" [class.border-b-0]="isLast">{{ i + 1 }}</td>
-              <td class="govuk-table__cell break-words" [class.border-b-0]="isLast">{{ result.tc3Type }}</td>
-              <td class="govuk-table__cell break-words" [class.border-b-0]="isLast">{{ result.tc3PeriodicNumber }}</td>
-              <td class="govuk-table__cell break-words" [class.border-b-0]="isLast">
-                {{ result.tc3PeriodicExpiryDate | date : 'dd/MM/yyyy' | defaultNullOrEmpty }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </ng-container>
-    </ng-container>
-
     <ng-container *ngSwitchCase="formNodeViewTypes.CUSTOM">
       <ng-container *ngIf="control && control.meta && control.meta.viewComponent">
         <td colspan="2" id="test-{{ name }}" class="govuk-table__cell">

--- a/src/app/forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component.html
+++ b/src/app/forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component.html
@@ -4,13 +4,13 @@
     <table class="govuk-table">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <th class="govuk-table__header break-words">Certificate number:</th>
+          <th class="govuk-table__header break-words" [style.width.%]="30">Certificate number:</th>
           <td class="govuk-table__cell break-words">
             {{ control.parent.value.techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateApprovalNo | defaultNullOrEmpty }}
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <th class="govuk-table__header break-words">Expiry date:</th>
+          <th class="govuk-table__header break-words" [style.width.%]="30">Expiry date:</th>
           <td class="govuk-table__cell break-words">
             {{
               control.parent.value.techRecord_adrDetails_tank_tankDetails_tc2Details_tc2IntermediateExpiryDate

--- a/src/app/forms/custom-sections/adr-tank-details-subsequent-inspections-view/adr-tank-details-subsequent-inspections-view.component.html
+++ b/src/app/forms/custom-sections/adr-tank-details-subsequent-inspections-view/adr-tank-details-subsequent-inspections-view.component.html
@@ -5,15 +5,15 @@
       <table class="govuk-table">
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header break-words">Inspection type:</th>
+            <th class="govuk-table__header break-words" [style.width.%]="30">Inspection type:</th>
             <td class="govuk-table__cell break-words">{{ inspection.tc3Type | defaultNullOrEmpty }}</td>
           </tr>
           <tr class="govuk-table__row">
-            <th class="govuk-table__header break-words">Certificate number:</th>
+            <th class="govuk-table__header break-words" [style.width.%]="30">Certificate number:</th>
             <td class="govuk-table__cell break-words">{{ inspection.tc3PeriodicNumber | defaultNullOrEmpty }}</td>
           </tr>
           <tr class="govuk-table__row">
-            <th class="govuk-table__header break-words">Inspection type:</th>
+            <th class="govuk-table__header break-words" [style.width.%]="30">Expiry Date:</th>
             <td class="govuk-table__cell break-words">{{ inspection.tc3PeriodicExpiryDate | date : 'dd/MM/yyyy' | defaultNullOrEmpty }}</td>
           </tr>
         </tbody>

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -37,7 +37,6 @@ export enum FormNodeViewTypes {
   VRM = 'vrm',
   CUSTOM = 'custom',
   ADR_EXAMINER_NOTES = 'adrExaminerNotes', // TODO: remove in favour of custom
-  ADRINSPECTIONS = 'adrInspections', // TODO: remove in favour of custom
 }
 
 export enum TagTypeLabels {

--- a/src/app/forms/templates/general/adr-summary.template.ts
+++ b/src/app/forms/templates/general/adr-summary.template.ts
@@ -16,6 +16,9 @@ import {
 } from '@forms/custom-sections/adr-examiner-notes-history-view/adr-examiner-notes-history-view.component';
 import { AdrGuidanceNotesComponent } from '@forms/custom-sections/adr-guidance-notes/adr-guidance-notes.component';
 import {
+  AdrTankDetailsInitialInspectionViewComponent,
+} from '@forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component';
+import {
   AdrTankDetailsSubsequentInspectionsEditComponent,
 } from '@forms/custom-sections/adr-tank-details-subsequent-inspections-edit/adr-tank-details-subsequent-inspections-edit.component';
 import {
@@ -536,9 +539,6 @@ export const AdrSummaryTemplate: FormNode = {
         },
       ],
     },
-    // Note: this used only for the view mode for the ADR Tank Details initial inpsection controls
-    // TODO: uncomment this when needed
-    /*
     {
       name: 'tankInspectionsInitialView',
       type: FormNodeTypes.CONTROL,
@@ -548,11 +548,10 @@ export const AdrSummaryTemplate: FormNode = {
       groups: ['tank_details', 'dangerous_goods'],
       hide: true,
     },
-    */
     {
       name: 'techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type',
       type: FormNodeTypes.CONTROL,
-      // viewType: FormNodeViewTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
       editType: FormNodeEditTypes.HIDDEN,
       label: 'TC2: Inspection type',
       value: TC2Types.INITIAL,
@@ -585,7 +584,7 @@ export const AdrSummaryTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tc3Details',
       label: 'Subsequent Inspections',
       type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.ADRINSPECTIONS, // TODO: replace with custom view type
+      viewType: FormNodeViewTypes.CUSTOM,
       viewComponent: AdrTankDetailsSubsequentInspectionsViewComponent,
       editType: FormNodeEditTypes.CUSTOM,
       editComponent: AdrTankDetailsSubsequentInspectionsEditComponent,

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -20,6 +20,9 @@ import {
 } from '@forms/custom-sections/adr-examiner-notes-history-view/adr-examiner-notes-history-view.component';
 import { AdrGuidanceNotesComponent } from '@forms/custom-sections/adr-guidance-notes/adr-guidance-notes.component';
 import {
+  AdrTankDetailsInitialInspectionViewComponent,
+} from '@forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component';
+import {
   AdrTankDetailsSubsequentInspectionsEditComponent,
 } from '@forms/custom-sections/adr-tank-details-subsequent-inspections-edit/adr-tank-details-subsequent-inspections-edit.component';
 import {
@@ -534,9 +537,6 @@ export const AdrTemplate: FormNode = {
         },
       ],
     },
-    // Note: this used only for the view mode for the ADR Tank Details initial inpsection controls
-    // TODO: uncomment when needed
-    /*
     {
       name: 'tankInspectionsInitialView',
       type: FormNodeTypes.CONTROL,
@@ -546,12 +546,11 @@ export const AdrTemplate: FormNode = {
       groups: ['tank_details', 'dangerous_goods'],
       hide: true,
     },
-    */
     {
       name: 'techRecord_adrDetails_tank_tankDetails_tc2Details_tc2Type',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.HIDDEN,
-      // viewType: FormNodeViewTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
       label: 'TC2: Inspection type',
       value: TC2Types.INITIAL,
       hide: true,
@@ -583,7 +582,7 @@ export const AdrTemplate: FormNode = {
       name: 'techRecord_adrDetails_tank_tankDetails_tc3Details',
       label: 'Subsequent Inspections',
       type: FormNodeTypes.CONTROL,
-      viewType: FormNodeViewTypes.ADRINSPECTIONS, // TODO: replace with custom view type
+      viewType: FormNodeViewTypes.CUSTOM,
       viewComponent: AdrTankDetailsSubsequentInspectionsViewComponent,
       editType: FormNodeEditTypes.CUSTOM,
       editComponent: AdrTankDetailsSubsequentInspectionsEditComponent,


### PR DESCRIPTION
## TC2 Tank certificate details not available to view unless in amend mode

Uncomments code we had previously for the custom view modes of TC2 and TC3 inspections of ADR vehicles with an ADR vehicle type containing the words 'tank' or 'battery'.

[CB2-10591](https://dvsa.atlassian.net/browse/CB2-10591)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
