### PR TITLE
feat(cb2-10930): refactor un subsequent inspections component

### DIFF
--- a/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.html
+++ b/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.html
@@ -32,7 +32,7 @@
               ></app-text-input>
             </td>
             <td class="govuk-table__cell align-middle">
-              <a class="govuk-link" role="button" href="javascript:void(0)" (click)="removeControl(i)">Remove</a>
+              <a class="govuk-link link" (click)="removeControl(i)">Remove</a>
             </td>
           </tr>
         </ng-container>
@@ -41,6 +41,6 @@
   </ng-template>
 
   <p class="govuk-body">
-    <a role="button" class="govuk-link" href="javascript:void(0)" (click)="addControl()"> Add UN Number </a>
+    <a class="govuk-link link" (click)="addControl()">Add UN Number</a>
   </p>
 </ng-container>

--- a/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.html
+++ b/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.html
@@ -1,40 +1,44 @@
-<ng-container *ngIf="control && formArray.controls[0]">
-  <app-field-error-message
-    [error]="!formArray.controls[0].value && control.invalid && (control.touched || submitted) ? control.meta.customErrorMessage : ''"
-  ></app-field-error-message>
+<ng-container *ngIf="control && formArray.controls.length">
+  <app-field-error-message [error]="control.touched ? control.getError('custom')?.message : ''"></app-field-error-message>
 
-  <ng-container *ngIf="formArray.controls.length === 1">
+  <ng-container *ngIf="formArray.controls.length === 1; else multiple">
     <app-text-input
-      [id]="control.meta.name"
-      [name]="formArray.controls[0].meta.name"
-      [label]="formArray.controls[0].meta.label + ' 1'"
-      [customId]="formArray.controls[0].meta.customId"
+      [id]="'UN_number_1'"
+      [name]="'UN number 1'"
+      [label]="'UN number 1'"
+      [customId]="'UN number 1'"
       [formControl]="formArray.controls[0]"
+      [minlength]="1"
+      [maxlength]="1500"
       (blur)="formArray.controls[0].markAsTouched(); control.markAsTouched()"
     ></app-text-input>
   </ng-container>
 
-  <!-- Additional UN numbers -->
-  <table class="govuk-table" *ngIf="formArray.controls.length > 1">
-    <tbody class="govuk-table__body">
-      <ng-container *ngFor="let child of formArray.controls; let i = index">
-        <tr>
-          <td class="govuk-table__cell">
-            <app-text-input
-              [name]="child.meta.name"
-              [label]="(child.meta.label ?? '') + ' ' + (i + 1)"
-              [customId]="child.meta.customId"
-              [formControl]="child"
-              (blur)="child.markAsTouched(); control.markAsTouched()"
-            ></app-text-input>
-          </td>
-          <td class="govuk-table__cell align-middle">
-            <a class="govuk-link" role="button" href="javascript:void(0)" (click)="removeControl(i)">Remove</a>
-          </td>
-        </tr>
-      </ng-container>
-    </tbody>
-  </table>
+  <ng-template #multiple>
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <ng-container *ngFor="let child of formArray.controls; let i = index">
+          <tr>
+            <td class="govuk-table__cell">
+              <app-text-input
+                [id]="'UN_number_' + (i + 1)"
+                [name]="'UN number ' + (i + 1)"
+                [label]="'UN number ' + (i + 1)"
+                [customId]="'UN number ' + (i + 1)"
+                [formControl]="child"
+                [minlength]="1"
+                [maxlength]="1500"
+                (blur)="child.markAsTouched(); control.markAsTouched()"
+              ></app-text-input>
+            </td>
+            <td class="govuk-table__cell align-middle">
+              <a class="govuk-link" role="button" href="javascript:void(0)" (click)="removeControl(i)">Remove</a>
+            </td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </table>
+  </ng-template>
 
   <p class="govuk-body">
     <a role="button" class="govuk-link" href="javascript:void(0)" (click)="addControl()"> Add UN Number </a>

--- a/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.scss
+++ b/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.scss
@@ -1,3 +1,14 @@
+@import 'govuk-frontend/govuk/all';
+
 .align-middle {
     vertical-align: middle;
+}
+
+.link {
+    cursor: pointer;
+    color: $govuk-brand-colour;
+
+    &:hover {
+        color: govuk-colour('dark-blue', $legacy: 'light-blue');
+    }
 }

--- a/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.spec.ts
+++ b/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import {
+  FormBuilder,
   FormControl, FormGroup, NG_VALUE_ACCESSOR, NgControl,
 } from '@angular/forms';
 import { GlobalWarningService } from '@core/components/global-warning/global-warning.service';
@@ -13,6 +14,7 @@ import { initialAppState } from '@store/index';
 import { AdrTankStatementUnNumberEditComponent } from './adr-tank-statement-un-number-edit.component';
 
 describe('AdrTankStatementUnNumberEditComponent', () => {
+  let fb: FormBuilder;
   let component: AdrTankStatementUnNumberEditComponent;
   let fixture: ComponentFixture<AdrTankStatementUnNumberEditComponent>;
 
@@ -27,6 +29,7 @@ describe('AdrTankStatementUnNumberEditComponent', () => {
       imports: [DynamicFormsModule, SharedModule],
       declarations: [AdrTankStatementUnNumberEditComponent],
       providers: [
+        FormBuilder,
         provideMockStore({ initialState: initialAppState }),
         { provide: GlobalWarningService, useValue: { error$: jest.fn() } },
         { provide: NG_VALUE_ACCESSOR, useExisting: AdrTankStatementUnNumberEditComponent, multi: true },
@@ -46,6 +49,7 @@ describe('AdrTankStatementUnNumberEditComponent', () => {
     })
       .compileComponents();
 
+    fb = TestBed.inject(FormBuilder);
     fixture = TestBed.createComponent(AdrTankStatementUnNumberEditComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -53,21 +57,6 @@ describe('AdrTankStatementUnNumberEditComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  describe('ngOnInit', () => {
-    it('should call ngOnInit', () => {
-      const spy = jest.spyOn(component, 'ngOnInit');
-      component.ngOnInit();
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('should subscribe to the form array value changes', () => {
-      const spy = jest.spyOn(component, 'onFormChange');
-      component.formArray.patchValue([null]);
-      expect(spy).toHaveBeenCalled();
-    });
-
   });
 
   describe('ngAfterContentInit', () => {
@@ -79,30 +68,11 @@ describe('AdrTankStatementUnNumberEditComponent', () => {
     });
   });
 
-  describe('canAddControl', () => {
-
-    it('should return true if a control can be added, e.g. when the previous control is empty, and there is at least 1 control', () => {
-      const spy = jest.spyOn(component, 'canAddControl');
-      component.formArray.patchValue(['valid']);
-      const canAdd = component.canAddControl();
-      expect(spy).toHaveBeenCalled();
-      expect(canAdd).toBe(true);
-    });
-
-    it('should return false if a control cannot be added, e.g. when the previous control is empty', () => {
-      const spy = jest.spyOn(component, 'canAddControl');
-      component.formArray.patchValue(['valid']);
-      component.addControl();
-      const canAdd = component.canAddControl();
-      expect(spy).toHaveBeenCalled();
-      expect(canAdd).toBe(false);
-    });
-  });
-
   describe('addControl', () => {
     it('should add a copy of the control to the end of the form array', () => {
       const spy = jest.spyOn(component, 'addControl');
-      component.formArray.patchValue(['valid']); // fill in controls, to allow adding of additional ones
+      component.formArray = fb.array<CustomFormControl>([]);
+      component.addControl('valid');
       component.addControl('valid');
       component.addControl('valid');
       component.addControl('valid');
@@ -112,8 +82,11 @@ describe('AdrTankStatementUnNumberEditComponent', () => {
     });
 
     it('should prevent the adding of additional controls, when the previous one is empty', () => {
+      component.formArray = fb.array<CustomFormControl>([]);
+      component.addControl('valid');
       component.addControl();
-      expect(component.formArray.value).toHaveLength(1);
+      component.addControl();
+      expect(component.formArray.value).toHaveLength(2);
     });
   });
 
@@ -135,19 +108,6 @@ describe('AdrTankStatementUnNumberEditComponent', () => {
       expect(component.formArray.controls.at(3)).toBeUndefined();
       expect(component.formArray.controls.at(2)).toBeDefined();
       expect(component.formArray.controls).toHaveLength(3);
-    });
-  });
-
-  describe('updateControls', () => {
-    it('should update the meta properties of each control after insertion or deletion', () => {
-      const methodSpy = jest.spyOn(component, 'updateControls');
-      component.formArray.patchValue(['valid']);
-      component.addControl('valid');
-      expect(methodSpy).toHaveBeenCalled();
-      component.removeControl(0);
-      expect(methodSpy).toHaveBeenCalled();
-      expect(component.formArray.controls).toHaveLength(1);
-      expect(component.formArray.controls.at(0)?.meta.customId).toBe('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo_1');
     });
   });
 });

--- a/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.ts
+++ b/src/app/forms/custom-sections/adr-tank-statement-un-number-edit/adr-tank-statement-un-number-edit.component.ts
@@ -1,17 +1,9 @@
 import {
-  Component, OnDestroy, OnInit,
-  inject,
+  Component, OnDestroy, inject,
 } from '@angular/core';
-import { FormArray, Validators } from '@angular/forms';
-import { GlobalError } from '@core/components/global-error/global-error.interface';
-import { GlobalErrorService } from '@core/components/global-error/global-error.service';
-import { CustomFormControl } from '@forms/services/dynamic-form.types';
-import _ from 'lodash';
-import {
-  ReplaySubject,
-  skip,
-  takeUntil,
-} from 'rxjs';
+import { FormBuilder, Validators } from '@angular/forms';
+import { CustomFormControl, FormNodeTypes } from '@forms/services/dynamic-form.types';
+import { Subject, takeUntil } from 'rxjs';
 import { CustomFormControlComponent } from '../custom-form-control/custom-form-control.component';
 
 @Component({
@@ -19,110 +11,56 @@ import { CustomFormControlComponent } from '../custom-form-control/custom-form-c
   templateUrl: './adr-tank-statement-un-number-edit.component.html',
   styleUrls: ['./adr-tank-statement-un-number-edit.component.scss'],
 })
-export class AdrTankStatementUnNumberEditComponent extends CustomFormControlComponent implements OnInit, OnDestroy {
-  checked = false;
-  submitted = false;
-  destroy$ = new ReplaySubject<boolean>(1);
-  formArray = new FormArray<CustomFormControl>([]);
-  globalErrorService = inject(GlobalErrorService);
+export class AdrTankStatementUnNumberEditComponent extends CustomFormControlComponent implements OnDestroy {
+  fb = inject(FormBuilder);
 
-  ngOnInit() {
-    this.formArray.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => this.onFormChange(changes));
-    this.globalErrorService.errors$.pipe(skip(1), takeUntil(this.destroy$)).subscribe((errors) => this.onFormSubmitted(errors));
-  }
+  destroy$ = new Subject();
+  formArray = this.fb.array<CustomFormControl>([]);
+
+  onFormArrayChange = this.formArray.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => {
+    this.control?.patchValue(changes, { emitModelToViewChange: true });
+  });
 
   ngOnDestroy(): void {
     this.destroy$.next(true);
-    this.destroy$.unsubscribe();
+    this.destroy$.complete();
   }
 
   override ngAfterContentInit(): void {
     super.ngAfterContentInit();
     this.buildFormArray();
-
   }
 
   buildFormArray() {
-    const value = this.form?.get(this.name)?.value;
-    const values = Array.isArray(value) && value.length ? value : [''];
-    values.forEach((unNumber: string) => this.addControl(unNumber));
+    const values: string[] = this.control?.value ?? [''];
+    values.forEach((value) => this.addControl(value));
   }
 
-  canAddControl() {
-    return !(this.formArray.length && !this.formArray.at(-1).value);
-  }
+  addControl(value = '') {
+    const lastUnNumber = this.formArray.at(-1);
 
-  addControl(value: string | null = null) {
-    if (!this.control) return;
+    if (this.formArray.length > 0 && (lastUnNumber.invalid || !lastUnNumber.value)) {
+      // If the parent control or lastUnNumber control isn't already invalid set additional errors
+      if (!this.control?.invalid && !lastUnNumber.invalid) {
+        lastUnNumber.setErrors({ required: true });
+      }
 
-    // Prevent adding new controls, whilst previous ones are empty
-    if (!this.canAddControl()) {
-      this.control.markAsTouched();
+      // Mark as touched to show errors
       this.formArray.markAllAsTouched();
+
       return;
     }
 
-    const control = new CustomFormControl({ ...this.control.meta }, value);
-    control.addValidators(Validators.maxLength(1500));
-
-    // If this is a subsequent UN Number, then it is required, and must be filled in, or removed.
-    if (this.formArray.length > 0) {
-      const firstUnNumber = this.formArray.at(0);
-      if (!firstUnNumber.hasValidator(Validators.required)) firstUnNumber.addValidators(Validators.required);
-      control.addValidators(Validators.required);
-      control.meta.validators = undefined;
-    }
-
-    this.formArray.push(control);
-    this.updateControls();
+    this.formArray.push(
+      new CustomFormControl(
+        { type: FormNodeTypes.CONTROL, name: 'UN number' },
+        value,
+        [Validators.minLength(1), Validators.maxLength(1500)],
+      ),
+    );
   }
 
   removeControl(index: number) {
-    if (this.formArray.length < 2) return;
     this.formArray.removeAt(index);
-    this.updateControls();
-
-    if (this.formArray.length === 1) {
-      this.formArray.at(0).meta.customErrorMessage = undefined;
-      this.formArray.at(0).removeValidators(Validators.required);
-    }
-  }
-
-  updateControls() {
-    this.formArray.controls.forEach((control, index) => {
-      // Make all UN NUmbers labels reflect their position in form array
-      control.meta.customId = `${this.control?.meta.name}_${index + 1}`;
-      control.meta.customErrorMessage = control.invalid && control.hasError('maxlength')
-        ? `UN number ${index + 1} must be less than or equal to 1500 characters`
-        : `UN number ${index + 1} is required or remove UN number ${index + 1}`;
-    });
-  }
-
-  onFormChange(changes: (string | null)[] | null) {
-    this.control?.patchValue(changes, { emitModelToViewChange: true });
-    this.updateControls();
-  }
-
-  onFormSubmitted(globalErrors: GlobalError[]) {
-    this.submitted = true;
-
-    // If ANY UN Numbers are invalid, loop through them and add to global errors, but avoid adding duplicates
-    if (this.formArray.invalid) {
-      const firstCtrl = this.formArray.at(0);
-      const customErrorMessage = this.control?.meta.customErrorMessage;
-
-      const formErrors = this.formArray.controls
-        .filter((control) => control.invalid)
-        .map((control) => ({ error: control.meta.customErrorMessage as string, anchorLink: control.meta.customId }));
-
-      const allErrors = _.chain(globalErrors)
-        .filter((error) => !(error.error === customErrorMessage && (firstCtrl.valid || !firstCtrl.hasError(customErrorMessage))))
-        .concat(formErrors)
-        .uniqBy((error) => error.error);
-
-      if (!allErrors.isEqualWith(globalErrors).value()) {
-        this.globalErrorService.setErrors(allErrors.value());
-      }
-    }
   }
 }

--- a/src/app/forms/models/validators.enum.ts
+++ b/src/app/forms/models/validators.enum.ts
@@ -45,5 +45,4 @@ export enum ValidatorNames {
   Custom = 'custom',
   Tc3TestValidator = 'tc3TestValidator',
   DateIsInvalid = 'dateIsInvalid',
-  TankDetailsUnNumberValidator = 'tankDetailsUnNumberValidator',
 }

--- a/src/app/forms/services/dynamic-form.service.ts
+++ b/src/app/forms/services/dynamic-form.service.ts
@@ -87,7 +87,6 @@ export class DynamicFormService {
     [ValidatorNames.Tc3TestValidator]: (args: { inspectionNumber: number }) => CustomValidators.tc3TestValidator(args),
     [ValidatorNames.RequiredIfNotHidden]: () => CustomValidators.requiredIfNotHidden(),
     [ValidatorNames.DateIsInvalid]: () => CustomValidators.dateIsInvalid,
-    [ValidatorNames.TankDetailsUnNumberValidator]: () => CustomValidators.tankDetailsUnNumberValidator(),
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -191,13 +190,22 @@ export class DynamicFormService {
 
     if (errors) {
       if (meta?.hide) return;
-      const errorList = Object.keys(errors);
-      errorList.forEach((error) => {
-        validationErrorList.push({
-          error: meta?.customErrorMessage ?? ErrorMessageMap[`${error}`](errors[`${error}`], meta?.customValidatorErrorName ?? meta?.label),
-          anchorLink: meta?.customId ?? meta?.name,
-        } as GlobalError);
+      Object.entries(errors).forEach(([error, data]) => {
+        // If an anchor link is provided, use that, otherwise determine target element from customId or name
+        const defaultAnchorLink = meta?.customId ?? meta?.name;
+        const anchorLink = typeof data === 'object' && data !== null
+          ? data.anchorLink ?? defaultAnchorLink
+          : defaultAnchorLink;
+
+        // If typeof data is an array, assume we're passing the service multiple global errors
+        const globalErrors = Array.isArray(data) ? data : [{
+          error: meta?.customErrorMessage ?? ErrorMessageMap[`${error}`](data, meta?.customValidatorErrorName ?? meta?.label),
+          anchorLink,
+        }];
+
+        validationErrorList.push(...globalErrors);
       });
     }
+
   }
 }

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -19,10 +19,10 @@ import {
   AdrExaminerNotesHistoryViewComponent,
 } from '@forms/custom-sections/adr-examiner-notes-history-view/adr-examiner-notes-history-view.component';
 import { AdrGuidanceNotesComponent } from '@forms/custom-sections/adr-guidance-notes/adr-guidance-notes.component';
-import { AdrTankDetailsM145ViewComponent } from '@forms/custom-sections/adr-tank-details-m145-view/adr-tank-details-m145-view.component';
 import {
   AdrTankDetailsInitialInspectionViewComponent,
 } from '@forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component';
+import { AdrTankDetailsM145ViewComponent } from '@forms/custom-sections/adr-tank-details-m145-view/adr-tank-details-m145-view.component';
 import {
   AdrTankDetailsSubsequentInspectionsEditComponent,
 } from '@forms/custom-sections/adr-tank-details-subsequent-inspections-edit/adr-tank-details-subsequent-inspections-edit.component';
@@ -39,6 +39,7 @@ import { ValidatorNames } from '@forms/models/validators.enum';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { TC2Types } from '@models/adr.enum';
 import {
+  CustomFormControl,
   FormNode,
   FormNodeEditTypes,
   FormNodeTypes,
@@ -469,17 +470,25 @@ export const AdrTemplate: FormNode = {
       type: FormNodeTypes.CONTROL,
       groups: ['productList', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
-      customErrorMessage: 'Reference number or UN number 1 is required when selecting Product List',
       validators: [
         { name: ValidatorNames.MaxLength, args: 1500 },
         {
-          name: ValidatorNames.requiredIfAllEquals,
-          args: {
-            sibling: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo',
-            value: [[], [null], [''], null, undefined],
+          name: ValidatorNames.Custom,
+          args: (control: CustomFormControl) => {
+            if (control.meta?.hide) {
+              return null;
+            }
+
+            const unNumber1 = control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo');
+
+            // If either productListRefNo is empty, or the first unNumber, mark as invalid
+            if ((!control.value && !unNumber1?.value) || (!control.value && !unNumber1?.value?.at(0))) {
+              return { custom: { message: 'Reference number or UN number 1 is required when selecting Product List' } };
+            }
+
+            return null;
           },
-        },
-      ],
+        }],
     },
     {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo',
@@ -491,13 +500,56 @@ export const AdrTemplate: FormNode = {
       viewComponent: AdrTankStatementUnNumberViewComponent,
       groups: ['productList', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
-      customErrorMessage: 'Reference number or UN number 1 is required when selecting Product List',
       validators: [
         {
-          name: ValidatorNames.RequiredIfEquals,
-          args: { sibling: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo', value: [null, undefined, ''] },
+          name: ValidatorNames.Custom,
+          args: (control: CustomFormControl) => {
+            if (control.meta?.hide) {
+              return null;
+            }
+
+            const productListRefNo = control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo');
+            const firstUnNumber = control.value?.at(0);
+            const lastUnNumberIndex = (control.value?.length ?? 0) - 1;
+            const lastUnNumber = control.value?.at(lastUnNumberIndex);
+
+            // If either productListRefNo is empty, or the first unNumber, mark as invalid
+            if ((!productListRefNo?.value && !control?.value) || (!productListRefNo?.value && !firstUnNumber)) {
+              return {
+                custom: {
+                  message: 'Reference number or UN number 1 is required when selecting Product List',
+                  anchorLink: 'UN_number_1',
+                },
+              };
+            }
+
+            // If there are more than 1 UN numbers, and the last UN number is empty, mark as invalid
+            if (control.value?.length > 1 && !lastUnNumber) {
+              return {
+                custom: {
+                  message: `UN number ${lastUnNumberIndex + 1} is required or remove UN number ${lastUnNumberIndex + 1}`,
+                  anchorLink: `UN_number_${lastUnNumberIndex + 1}`,
+                },
+              };
+            }
+
+            // If any of the control indices have length greater than 1500 characters, show an error message for each
+            if (control.value && control.value.some((unNumber: string) => unNumber.length > 1500)) {
+              return {
+                multiple: control.value.map((unNumber: string, index: number) =>
+                  unNumber.length > 1500
+                    ? {
+                      error: `UN number ${index + 1} must be less than or equal to 1500 characters`,
+                      anchorLink: `UN_number_${index + 1}`,
+                    }
+                    : null)
+                  .filter(Boolean),
+              };
+            }
+
+            return null;
+          },
         },
-        { name: ValidatorNames.TankDetailsUnNumberValidator },
       ],
     },
     {

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -37,9 +37,9 @@ import {
 } from '@forms/custom-sections/adr-tank-statement-un-number-view/adr-tank-statement-un-number-view.component';
 import { ValidatorNames } from '@forms/models/validators.enum';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
+import { AdrValidators } from '@forms/validators/adr/adr.validators';
 import { TC2Types } from '@models/adr.enum';
 import {
-  CustomFormControl,
   FormNode,
   FormNodeEditTypes,
   FormNodeTypes,
@@ -472,23 +472,7 @@ export const AdrTemplate: FormNode = {
       hide: true,
       validators: [
         { name: ValidatorNames.MaxLength, args: 1500 },
-        {
-          name: ValidatorNames.Custom,
-          args: (control: CustomFormControl) => {
-            if (control.meta?.hide) {
-              return null;
-            }
-
-            const unNumber1 = control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo');
-
-            // If either productListRefNo is empty, or the first unNumber, mark as invalid
-            if ((!control.value && !unNumber1?.value) || (!control.value && !unNumber1?.value?.at(0))) {
-              return { custom: { message: 'Reference number or UN number 1 is required when selecting Product List' } };
-            }
-
-            return null;
-          },
-        }],
+        { name: ValidatorNames.Custom, args: AdrValidators.validateProductListRefNo }],
     },
     {
       name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo',
@@ -501,55 +485,7 @@ export const AdrTemplate: FormNode = {
       groups: ['productList', 'statement_select_hide', 'tank_details_hide', 'dangerous_goods'],
       hide: true,
       validators: [
-        {
-          name: ValidatorNames.Custom,
-          args: (control: CustomFormControl) => {
-            if (control.meta?.hide) {
-              return null;
-            }
-
-            const productListRefNo = control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo');
-            const firstUnNumber = control.value?.at(0);
-            const lastUnNumberIndex = (control.value?.length ?? 0) - 1;
-            const lastUnNumber = control.value?.at(lastUnNumberIndex);
-
-            // If either productListRefNo is empty, or the first unNumber, mark as invalid
-            if ((!productListRefNo?.value && !control?.value) || (!productListRefNo?.value && !firstUnNumber)) {
-              return {
-                custom: {
-                  message: 'Reference number or UN number 1 is required when selecting Product List',
-                  anchorLink: 'UN_number_1',
-                },
-              };
-            }
-
-            // If there are more than 1 UN numbers, and the last UN number is empty, mark as invalid
-            if (control.value?.length > 1 && !lastUnNumber) {
-              return {
-                custom: {
-                  message: `UN number ${lastUnNumberIndex + 1} is required or remove UN number ${lastUnNumberIndex + 1}`,
-                  anchorLink: `UN_number_${lastUnNumberIndex + 1}`,
-                },
-              };
-            }
-
-            // If any of the control indices have length greater than 1500 characters, show an error message for each
-            if (control.value && control.value.some((unNumber: string) => unNumber.length > 1500)) {
-              return {
-                multiple: control.value.map((unNumber: string, index: number) =>
-                  unNumber.length > 1500
-                    ? {
-                      error: `UN number ${index + 1} must be less than or equal to 1500 characters`,
-                      anchorLink: `UN_number_${index + 1}`,
-                    }
-                    : null)
-                  .filter(Boolean),
-              };
-            }
-
-            return null;
-          },
-        },
+        { name: ValidatorNames.Custom, args: AdrValidators.validateProductListUNNumbers },
       ],
     },
     {

--- a/src/app/forms/utils/error-message-map.ts
+++ b/src/app/forms/utils/error-message-map.ts
@@ -43,6 +43,7 @@ export const ErrorMessageMap: Record<string, Function> = {
   [ValidatorNames.IsArray]: (err: { message: string }, label?: string) => `${label || DEFAULT_LABEL}`,
   [ValidatorNames.Tc3TestValidator]: (err: { message: string }) => `${err.message}`,
   [ValidatorNames.DateIsInvalid]: (err: { message?: string }, label?: string) => err.message ?? `${label || DEFAULT_LABEL} is invalid`,
+  [ValidatorNames.Custom]: (err: { message: string }) => err.message,
 
   [AsyncValidatorNames.RequiredIfNotAbandoned]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is required`,
   [AsyncValidatorNames.RequiredIfNotFail]: (err: boolean, label?: string) => `${label || DEFAULT_LABEL} is required`,

--- a/src/app/forms/validators/adr/adr.validators.spec.ts
+++ b/src/app/forms/validators/adr/adr.validators.spec.ts
@@ -1,0 +1,155 @@
+import {
+  CustomFormControl, CustomFormGroup,
+  FormNodeTypes,
+} from '@forms/services/dynamic-form.types';
+import { AdrValidators } from './adr.validators';
+
+describe('ADR Validators', () => {
+  let form: CustomFormGroup;
+
+  beforeEach(() => {
+    form = new CustomFormGroup({ type: FormNodeTypes.GROUP, name: 'adrForm' }, {
+      techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo: new CustomFormControl({
+        name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo',
+        type: FormNodeTypes.CONTROL,
+      }),
+      techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo: new CustomFormControl({
+        name: 'techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo',
+        type: FormNodeTypes.CONTROL,
+      }),
+    });
+  });
+
+  describe('validateProductListRefNo', () => {
+    it('should return NULL if the control is hidden', () => {
+      const control = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      control.meta.hide = true;
+
+      expect(AdrValidators.validateProductListRefNo(control)).toBeNull();
+    });
+
+    it('should return an error message if the product list reference number and first UN number is empty', () => {
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue(''); // make so product list reference number is empty
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['']); // make so first UN number is empty
+
+      expect(AdrValidators.validateProductListRefNo(a)).toStrictEqual({
+        custom: {
+          message: 'Reference number or UN number 1 is required when selecting Product List',
+        },
+      });
+    });
+
+    it('should return NULL if the product list reference number is populated', () => {
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue('reference no.'); // make so product list reference number is populated
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['']); // make so first UN number is empty
+
+      expect(AdrValidators.validateProductListRefNo(a)).toBeNull();
+    });
+
+    it('should return NULL if the first UN number is populated', () => {
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue(''); // make so product list reference number is empty
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['something']); // make so first UN number is empty
+
+      expect(AdrValidators.validateProductListRefNo(a)).toBeNull();
+    });
+  });
+
+  describe('validProductListUNNumbers', () => {
+    it('should return NULL if the control is hidden', () => {
+      const control = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      control.meta.hide = true;
+
+      expect(AdrValidators.validateProductListUNNumbers(control)).toBeNull();
+    });
+
+    it('should return an error message if the product list reference number and first UN number is empty', () => {
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue(''); // make so product list reference number is empty
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['']); // make so first UN number is empty
+
+      expect(AdrValidators.validateProductListUNNumbers(b)).toStrictEqual({
+        custom: {
+          anchorLink: 'UN_number_1',
+          message: 'Reference number or UN number 1 is required when selecting Product List',
+        },
+      });
+    });
+
+    it('should return an error message if the last UN number is empty', () => {
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue(''); // make so product list reference number is empty
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['first un', '']); // make so last UN number is empty
+
+      expect(AdrValidators.validateProductListUNNumbers(b)).toStrictEqual({
+        custom: {
+          anchorLink: 'UN_number_2',
+          message: 'UN number 2 is required or remove UN number 2',
+        },
+      });
+    });
+
+    it('should return an error message for any UN number which exceeds 1500 characters', () => {
+      const longString = new Array(1501).fill('a').join();
+
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue(''); // make so product list reference number is empty
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['first un', longString, longString, longString]); // make so last UN number is empty
+
+      expect(AdrValidators.validateProductListUNNumbers(b)).toStrictEqual({
+        multiple: [
+          {
+            anchorLink: 'UN_number_2',
+            error: 'UN number 2 must be less than or equal to 1500 characters',
+          },
+          {
+            anchorLink: 'UN_number_3',
+            error: 'UN number 3 must be less than or equal to 1500 characters',
+          },
+          {
+            anchorLink: 'UN_number_4',
+            error: 'UN number 4 must be less than or equal to 1500 characters',
+          },
+        ],
+      });
+    });
+
+    it('should return NULL if ALL UN numbers are populated, but less than 1500 characters in length', () => {
+      const a = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo') as CustomFormControl;
+      a.meta.hide = false;
+      a.patchValue(''); // make so product list reference number is empty
+
+      const b = form.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo') as CustomFormControl;
+      b.meta.hide = false;
+      b.patchValue(['small string', 'small string', 'small string']); // make so last UN number is empty
+
+      expect(AdrValidators.validateProductListUNNumbers(b)).toBeNull();
+    });
+  });
+});

--- a/src/app/forms/validators/adr/adr.validators.ts
+++ b/src/app/forms/validators/adr/adr.validators.ts
@@ -1,0 +1,66 @@
+import { ValidationErrors } from '@angular/forms';
+import { CustomFormControl } from '@forms/services/dynamic-form.types';
+
+export class AdrValidators {
+  static validateProductListRefNo = (control: CustomFormControl): ValidationErrors | null => {
+    if (control.meta?.hide) {
+      return null;
+    }
+
+    const unNumber1 = control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo');
+
+    // If either productListRefNo is empty, or the first unNumber, mark as invalid
+    if ((!control.value && !unNumber1?.value) || (!control.value && !unNumber1?.value?.at(0))) {
+      return { custom: { message: 'Reference number or UN number 1 is required when selecting Product List' } };
+    }
+
+    return null;
+  };
+
+  static validateProductListUNNumbers = (control: CustomFormControl): ValidationErrors | null => {
+    if (control.meta?.hide) {
+      return null;
+    }
+
+    const productListRefNo = control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo');
+    const firstUnNumber = control.value?.at(0);
+    const lastUnNumberIndex = (control.value?.length ?? 0) - 1;
+    const lastUnNumber = control.value?.at(lastUnNumberIndex);
+
+    // If either productListRefNo is empty, or the first unNumber, mark as invalid
+    if ((!productListRefNo?.value && !control?.value) || (!productListRefNo?.value && !firstUnNumber)) {
+      return {
+        custom: {
+          message: 'Reference number or UN number 1 is required when selecting Product List',
+          anchorLink: 'UN_number_1',
+        },
+      };
+    }
+
+    // If there are more than 1 UN numbers, and the last UN number is empty, mark as invalid
+    if (control.value?.length > 1 && !lastUnNumber) {
+      return {
+        custom: {
+          message: `UN number ${lastUnNumberIndex + 1} is required or remove UN number ${lastUnNumberIndex + 1}`,
+          anchorLink: `UN_number_${lastUnNumberIndex + 1}`,
+        },
+      };
+    }
+
+    // If any of the control indices have length greater than 1500 characters, show an error message for each
+    if (control.value && control.value.some((unNumber: string) => unNumber.length > 1500)) {
+      return {
+        multiple: control.value.map((unNumber: string, index: number) =>
+          unNumber.length > 1500
+            ? {
+              error: `UN number ${index + 1} must be less than or equal to 1500 characters`,
+              anchorLink: `UN_number_${index + 1}`,
+            }
+            : null)
+          .filter(Boolean),
+      };
+    }
+
+    return null;
+  };
+}

--- a/src/app/forms/validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators.ts
@@ -571,34 +571,6 @@ export class CustomValidators {
         : null;
     };
   };
-
-  /**
-   * Custom validator specifically for the UN numbers section of the ADR section of a tech record, applicable to:
-   *  - HGVs, TRLs, or LGVs,
-   *  - which carry dangerous goods, and
-   *  - have an ADR body type which contains the words 'tank' or 'battery', and
-   *  - have substances permitted selected with the 'class UN' option, and
-   *  - have the subsequent 'product list' option selected from the subsequent select control
-   *
-   * The UN numbers form array is invalid if:
-   *  - The above conditions are met, and
-   *  - The reference number is empty and any UN number is the form array is empty
-   *  - The reference number is empty and any UN number is the form array has length greater than 1500 characters
-   *
-   * @returns
-   */
-  static tankDetailsUnNumberValidator = () => {
-    return (control: AbstractControl): ValidationErrors | null => {
-      if (control instanceof CustomFormControl) {
-        if (control.meta.hide) return null;
-        if (control.parent?.get('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo')?.value) return null;
-        if (Array.isArray(control.value) && control.value.some((value) => value?.length > 1500)) return { maxlength: true };
-        return CustomValidators.isArray({ ofType: 'string' })(control);
-      }
-
-      return null;
-    };
-  };
 }
 
 export type EnumValidatorOptions = {


### PR DESCRIPTION
## ADR Product List: UN Number 1 validation broken, allowing submission of UN Numbers over max length

- Refactors the tank statement un numbers edit component - moving validation logic back to the template.
- Removes the old validator in favour of an inline custom one for both UN numbers and the reference number
- Adds functionality to the global error service to display multiple separate errors from a single validator - this was needs to show multiple warnings of controls of form array exceeding the 1500 character limit.


[CB2-10930](https://dvsa.atlassian.net/browse/CB2-10930)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
