### PR TITLE
fix(cb2-10560): shows the you must provide a new vrm error if you add a third mark

### DIFF
--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -184,6 +184,8 @@ export class TechnicalRecordService {
           const thirdMark = vrmControl.root.get('thirdMark')?.value;
           const previousVrm = vrmControl.root.get('previousVrm')?.value;
           if (thirdMark) {
+            const vrmNotNew = previousVrm === vrmControl.value;
+            if (vrmNotNew) return of({ validateVrm: { message: 'You must provide a new VRM' } });
             return this.techRecordHttpService.search$(SEARCH_TYPES.VRM, vrmControl.value).pipe(
               map((results) => {
                 if (results.some((result) => result.techRecord_statusCode === StatusCodes.CURRENT)) {
@@ -258,6 +260,7 @@ export class TechnicalRecordService {
         const provisionalRecord = results.filter((result) => result.techRecord_statusCode === StatusCodes.PROVISIONAL);
 
         if (control.value === previousVrm) {
+          console.log('new vrm message should be showing');
           return { validateVrm: { message: 'You must provide a new VRM' } };
         }
         if (currentRecord.length > 0) {
@@ -273,6 +276,7 @@ export class TechnicalRecordService {
         if (provisionalRecord.length > 0) {
           return { validateVrm: { message: `This VRM already exists on a provisional record with the VIN: ${provisionalRecord[0].vin}` } };
         }
+        console.log('you made it to null');
         return null;
       }),
       catchError((err: HttpErrorResponse) => {

--- a/src/app/services/technical-record/technical-record.service.ts
+++ b/src/app/services/technical-record/technical-record.service.ts
@@ -260,7 +260,6 @@ export class TechnicalRecordService {
         const provisionalRecord = results.filter((result) => result.techRecord_statusCode === StatusCodes.PROVISIONAL);
 
         if (control.value === previousVrm) {
-          console.log('new vrm message should be showing');
           return { validateVrm: { message: 'You must provide a new VRM' } };
         }
         if (currentRecord.length > 0) {
@@ -276,7 +275,6 @@ export class TechnicalRecordService {
         if (provisionalRecord.length > 0) {
           return { validateVrm: { message: `This VRM already exists on a provisional record with the VIN: ${provisionalRecord[0].vin}` } };
         }
-        console.log('you made it to null');
         return null;
       }),
       catchError((err: HttpErrorResponse) => {


### PR DESCRIPTION
## CB2-10560

when performing a cherished transfer and you add the same VRM that is already on the vehicle in the current VRM field you get an error, if you type anything in the third mark it was disappearing, this change makes the error persist. 

_One line description_
[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-XXXX)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
