### PR TITLE
fix(cb2-9198): correctly name application id key so its saved in the db

### DIFF
--- a/src/app/store/technical-records/effects/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/effects/technical-record-service.effects.ts
@@ -108,7 +108,7 @@ export class TechnicalRecordServiceEffects {
       ofType(createVehicleRecord),
       withLatestFrom(this.batchTechRecordService.applicationId$, this.userService.name$, this.userService.id$),
       concatMap(([{ vehicle }, applicationId]) => {
-        const vehicleRecord = { ...vehicle, applicationId };
+        const vehicleRecord = { ...vehicle, techRecord_applicationId: applicationId };
 
         return this.techRecordHttpService.createVehicleRecord$(vehicleRecord).pipe(
           map((response) => createVehicleRecordSuccess({ vehicleTechRecord: response })),


### PR DESCRIPTION
## Application ID not being added to payload sent from VTM on batch create

Renames applicationId to techRecord_applicationId so its saved correctly in db

[CB2-9198](https://dvsa.atlassian.net/browse/CB2-9198)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
