### PR TITLE
fix(cb2-11013): prevent fitment code being cut-off on larger viewports

### DIFF
--- a/src/app/forms/custom-sections/tyres/tyres.component.html
+++ b/src/app/forms/custom-sections/tyres/tyres.component.html
@@ -82,7 +82,7 @@
 
           <ng-template
             [ngTemplateOutlet]="axleTdInput"
-            [ngTemplateOutletContext]="{ name: 'tyres_fitmentCode', type: types.DROPDOWN, width: widths.XXS, options: fitmentCode }"
+            [ngTemplateOutletContext]="{ name: 'tyres_fitmentCode', type: types.DROPDOWN, width: widths.XS, options: fitmentCode }"
           ></ng-template>
 
           <td *ngIf="isEditing" class="govuk-table__cell">


### PR DESCRIPTION
## Not able to view Single and Double in tyre details

Increases max width of fitment code select dropdown in the tyres component so it no longer is cut-off on larger screens.
[CB2-11013](https://dvsa.atlassian.net/browse/CB2-11013)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
