### PR TITLE
feat(cb2-9649): allow new failed iva/msva tests to fetch certs

### DIFF
--- a/src/app/models/test-types/test-type.model.ts
+++ b/src/app/models/test-types/test-type.model.ts
@@ -42,7 +42,7 @@ export interface TestType {
 }
 
 export interface CustomDefects {
-  referenceNumber: string;
+  referenceNumber?: string;
   defectName: string;
   defectNotes: string;
 }

--- a/src/app/shared/components/test-certificate/test-certificate.component.html
+++ b/src/app/shared/components/test-certificate/test-certificate.component.html
@@ -1,3 +1,10 @@
-<button id="test-certificate-link" [ngClass]="isClickable ? 'link' : 'text'" appRetrieveDocument [params]="documentParams" [fileName]="fileName">
+<button
+  id="test-certificate-link"
+  [ngClass]="certNotNeeded || !isClickable ? 'text' : 'link'"
+  appRetrieveDocument
+  [params]="documentParams"
+  [fileName]="fileName"
+  [certNotNeeded]="certNotNeeded"
+>
   <ng-content></ng-content>
 </button>

--- a/src/app/shared/components/test-certificate/test-certificate.component.scss
+++ b/src/app/shared/components/test-certificate/test-certificate.component.scss
@@ -16,6 +16,7 @@
   text-decoration: underline;
   text-decoration-thickness: max(1px, 0.0625rem);
   text-underline-offset: 0.1em;
+  cursor: pointer;
 
   &:hover {
     background-color: transparent;

--- a/src/app/shared/components/test-certificate/test-certificate.component.spec.ts
+++ b/src/app/shared/components/test-certificate/test-certificate.component.spec.ts
@@ -1,30 +1,102 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DocumentRetrievalService } from '@api/document-retrieval';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { RetrieveDocumentDirective } from '@shared/directives/retrieve-document/retrieve-document.directive';
-import { initialAppState } from '@store/index';
+import { initialAppState, State } from '@store/index';
+import { isTestTypeOldIvaOrMsva, toEditOrNotToEdit } from '@store/test-records';
+import { resultOfTestEnum } from '@models/test-types/test-type.model';
+import { TestResultModel } from '@models/test-results/test-result.model';
+import { FeatureToggleService } from '@services/feature-toggle-service/feature-toggle-service';
 import { TestCertificateComponent } from './test-certificate.component';
 
 describe('TestCertificateComponent', () => {
   let component: TestCertificateComponent;
   let fixture: ComponentFixture<TestCertificateComponent>;
+  let store: MockStore<State>;
+  let featureToggleService: FeatureToggleService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [RetrieveDocumentDirective, TestCertificateComponent],
       imports: [HttpClientTestingModule],
-      providers: [DocumentRetrievalService, provideMockStore({ initialState: initialAppState })],
+      providers: [DocumentRetrievalService, provideMockStore({ initialState: initialAppState }), FeatureToggleService],
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestCertificateComponent);
     component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    featureToggleService = TestBed.inject(FeatureToggleService);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    beforeEach(() => {
+      jest.spyOn(featureToggleService, 'isFeatureEnabled').mockReturnValue(true);
+    });
+    it('should set certNotNeeded to false if test type is not an iva or msva test', () => {
+      store.overrideSelector(toEditOrNotToEdit, { testTypes: [{ testResult: resultOfTestEnum.pass, testTypeId: '94' }] } as TestResultModel);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, false);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(false);
+    });
+
+    it('should set certNotNeeded to true if test type is an old iva or msva test', () => {
+      store.overrideSelector(toEditOrNotToEdit, { testTypes: [{ testResult: resultOfTestEnum.pass, testTypeId: '125' }] } as TestResultModel);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, true);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(true);
+    });
+
+    it('should set certNotNeeded to true if test type is an new iva or msva test and the test is a pass', () => {
+      store.overrideSelector(toEditOrNotToEdit, { testTypes: [{ testResult: resultOfTestEnum.pass, testTypeId: '125' }] } as TestResultModel);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, false);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(true);
+    });
+
+    it('should set certNotNeeded to true if test type is an new iva or msva test and the test is a prs', () => {
+      store.overrideSelector(toEditOrNotToEdit, { testTypes: [{ testResult: resultOfTestEnum.prs, testTypeId: '125' }] } as TestResultModel);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, false);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(true);
+    });
+
+    it('should set certNotNeeded to false if test type is an new iva or msva test and the test is a fail', () => {
+      store.overrideSelector(toEditOrNotToEdit, { testTypes: [{ testResult: resultOfTestEnum.fail, testTypeId: '125' }] } as TestResultModel);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, false);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(false);
+    });
+
+    it('should not change certNotNeeded value if no test result is found', () => {
+      component.certNotNeeded = false;
+      store.overrideSelector(toEditOrNotToEdit, undefined);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, true);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(false);
+    });
+
+    it('should not certNotNeeded value if requiredStandards feature is false', () => {
+      component.certNotNeeded = false;
+      jest.spyOn(featureToggleService, 'isFeatureEnabled').mockReturnValue(false);
+      store.overrideSelector(toEditOrNotToEdit, { testTypes: [{ testResult: resultOfTestEnum.pass, testTypeId: '125' }] } as TestResultModel);
+      store.overrideSelector(isTestTypeOldIvaOrMsva, true);
+      component.ngOnInit();
+
+      expect(component.certNotNeeded).toBe(false);
+    });
   });
 });

--- a/src/app/shared/components/test-certificate/test-certificate.component.ts
+++ b/src/app/shared/components/test-certificate/test-certificate.component.ts
@@ -1,4 +1,15 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy, Component, inject, Input, OnDestroy, OnInit,
+} from '@angular/core';
+import { select, Store } from '@ngrx/store';
+import { isTestTypeOldIvaOrMsva, toEditOrNotToEdit } from '@store/test-records';
+import {
+  Subject, takeUntil, combineLatest, filter,
+} from 'rxjs';
+import { State } from '@store/index';
+import { resultOfTestEnum } from '@models/test-types/test-type.model';
+import { TEST_TYPES_GROUP1_SPEC_TEST, TEST_TYPES_GROUP5_SPEC_TEST } from '@forms/models/testTypeId.enum';
+import { FeatureToggleService } from '@services/feature-toggle-service/feature-toggle-service';
 
 @Component({
   selector: 'app-test-certificate[testNumber][vin]',
@@ -6,10 +17,31 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
   styleUrls: ['./test-certificate.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TestCertificateComponent {
+export class TestCertificateComponent implements OnInit, OnDestroy {
+  store: Store<State> = inject(Store<State>);
+  featureToggleService = inject(FeatureToggleService);
   @Input() testNumber!: string;
   @Input() vin!: string;
   @Input() isClickable = true;
+  certNotNeeded: boolean = false;
+  private destroyed$ = new Subject<void>();
+
+  ngOnInit(): void {
+    const isRequiredStandardsEnabled = this.featureToggleService.isFeatureEnabled('requiredStandards');
+    combineLatest([
+      this.store.pipe(select(toEditOrNotToEdit)),
+      this.store.pipe(select(isTestTypeOldIvaOrMsva)),
+    ]).pipe(
+      filter(([testResult]) => !!testResult),
+      takeUntil(this.destroyed$),
+    ).subscribe(([testResult, isOldIvaOrMsva]) => {
+      if (testResult && isRequiredStandardsEnabled) {
+        const { testResult: result, testTypeId: id } = testResult.testTypes[0];
+        const isIvaOrMsvaTest = TEST_TYPES_GROUP1_SPEC_TEST.includes(id) || TEST_TYPES_GROUP5_SPEC_TEST.includes(id);
+        this.certNotNeeded = isOldIvaOrMsva || (isIvaOrMsvaTest && result !== resultOfTestEnum.fail);
+      }
+    });
+  }
 
   get documentParams(): Map<string, string> {
     return new Map([
@@ -20,5 +52,10 @@ export class TestCertificateComponent {
 
   get fileName(): string {
     return `${this.testNumber}_${this.vin}`;
+  }
+
+  ngOnDestroy(): void {
+    this.destroyed$.next();
+    this.destroyed$.complete();
   }
 }

--- a/src/app/shared/components/test-certificate/test-certificate.component.ts
+++ b/src/app/shared/components/test-certificate/test-certificate.component.ts
@@ -4,7 +4,7 @@ import {
 import { select, Store } from '@ngrx/store';
 import { isTestTypeOldIvaOrMsva, toEditOrNotToEdit } from '@store/test-records';
 import {
-  Subject, takeUntil, combineLatest, filter,
+  Subject, takeUntil, combineLatest,
 } from 'rxjs';
 import { State } from '@store/index';
 import { resultOfTestEnum } from '@models/test-types/test-type.model';
@@ -32,7 +32,6 @@ export class TestCertificateComponent implements OnInit, OnDestroy {
       this.store.pipe(select(toEditOrNotToEdit)),
       this.store.pipe(select(isTestTypeOldIvaOrMsva)),
     ]).pipe(
-      filter(([testResult]) => !!testResult),
       takeUntil(this.destroyed$),
     ).subscribe(([testResult, isOldIvaOrMsva]) => {
       if (testResult && isRequiredStandardsEnabled) {

--- a/src/app/shared/directives/retrieve-document/retrieve-document.directive.ts
+++ b/src/app/shared/directives/retrieve-document/retrieve-document.directive.ts
@@ -12,10 +12,12 @@ export class RetrieveDocumentDirective {
   @Input() params: Map<string, string> = new Map();
   @Input() fileName = '';
   @Input() loading?: Boolean;
+  @Input() certNotNeeded: boolean = false;
 
   constructor(private documentRetrievalService: DocumentRetrievalService, private documentsService: DocumentsService, private store: Store<State>) { }
 
   @HostListener('click', ['$event']) clickEvent(event: PointerEvent) {
+    if (this.certNotNeeded) return;
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/app/store/test-records/selectors/test-records.selectors.spec.ts
+++ b/src/app/store/test-records/selectors/test-records.selectors.spec.ts
@@ -3,6 +3,7 @@ import { mockDefect } from '@mocks/mock-defects';
 import { createMockTestResult } from '@mocks/test-result.mock';
 import { createMockTestType } from '@mocks/test-type.mock';
 import { TestResultModel } from '@models/test-results/test-result.model';
+import { createMockAdditionalDefect, createMockCustomDefect } from '@mocks/custom-defect.mock';
 import { mockTestResult } from '../../../../mocks/mock-test-result';
 import { TestResultsState, initialTestResultsState } from '../reducers/test-records.reducer';
 import {
@@ -17,6 +18,7 @@ import {
   selectedTestResultState,
   selectedTestSortedAmendmentHistory,
   testResultLoadingState,
+  isTestTypeOldIvaOrMsva,
 } from './test-records.selectors';
 
 describe('Test Results Selectors', () => {
@@ -53,6 +55,29 @@ describe('Test Results Selectors', () => {
       const state: TestResultsState = { ...initialTestResultsState, loading: true };
       const selectedState = testResultLoadingState.projector(state);
       expect(selectedState).toBeTruthy();
+    });
+  });
+
+  describe('isTestTypeOldIvaOrMsva', () => {
+    it('should return true if all custom defects have a reference number', () => {
+      const state: TestResultModel = mockTestResult();
+      state.testTypes[0].customDefects = [createMockCustomDefect()];
+      const isOldIvaOrMsva = isTestTypeOldIvaOrMsva.projector(state);
+      expect(isOldIvaOrMsva).toBe(true);
+    });
+
+    it('should return false if all custom defects do not have a reference number', () => {
+      const state: TestResultModel = mockTestResult();
+      state.testTypes[0].customDefects = [createMockAdditionalDefect()];
+      const isOldIvaOrMsva = isTestTypeOldIvaOrMsva.projector(state);
+      expect(isOldIvaOrMsva).toBe(false);
+    });
+
+    it('should return false if no custom defects are present', () => {
+      const state: TestResultModel = mockTestResult();
+      state.testTypes[0].customDefects = [];
+      const isOldIvaOrMsva = isTestTypeOldIvaOrMsva.projector(state);
+      expect(isOldIvaOrMsva).toBe(false);
     });
   });
 

--- a/src/app/store/test-records/selectors/test-records.selectors.ts
+++ b/src/app/store/test-records/selectors/test-records.selectors.ts
@@ -52,6 +52,11 @@ export const testResultLoadingState = createSelector(testResultsFeatureState, (s
 
 export const selectDefectData = createSelector(selectedTestResultState, (testResult) => getDefectFromTestResult(testResult));
 
+export const isTestTypeOldIvaOrMsva = createSelector(toEditOrNotToEdit, (testResult) => {
+  return !!testResult?.testTypes[0]?.customDefects?.length
+    && !!testResult?.testTypes[0]?.customDefects?.every((defect) => !!defect.referenceNumber);
+});
+
 export const selectedTestSortedAmendmentHistory = createSelector(selectedTestResultState, (testResult) => {
   if (!testResult || !testResult.testHistory) {
     return [];

--- a/src/mocks/custom-defect.mock.ts
+++ b/src/mocks/custom-defect.mock.ts
@@ -6,3 +6,9 @@ export const createMockCustomDefect = (params: Partial<CustomDefects> = {}): Cus
   defectNotes: 'defectNotes',
   ...params,
 });
+
+export const createMockAdditionalDefect = (params: Partial<CustomDefects> = {}): CustomDefects => ({
+  defectName: 'defectName',
+  defectNotes: 'defectNotes',
+  ...params,
+});


### PR DESCRIPTION
## Ticket title
The new IVA/MSVA tests that use the required standards taxonomy will be able to retrieve an IVA30/MSVA30 certificate on the Test Record History page.

[CB2-9649](https://dvsa.atlassian.net/browse/CB2-9649)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
