### PR TITLE
fix(cb2-10685): add make model and body type to payload on *all* vehicles

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group4-lgv.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group4-lgv.template.ts
@@ -1,10 +1,10 @@
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { ValidatorNames } from '@forms/models/validators.enum';
 import {
   FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth,
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionGroup4LGV: FormNode = {
   name: 'vehicleSection',
@@ -83,6 +83,24 @@ export const DeskBasedVehicleSectionGroup4LGV: FormNode = {
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.HIDDEN,
       editType: FormNodeEditTypes.HIDDEN,
+    },
+    {
+      name: 'make',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
+    },
+    {
+      name: 'model',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
+    },
+    {
+      name: 'bodyType',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
     },
   ],
 };

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group5-lgv.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-vehicle-section-group5-lgv.template.ts
@@ -1,9 +1,9 @@
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import {
   FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeViewTypes, FormNodeWidth,
 } from '@forms/services/dynamic-form.types';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
-import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 
 export const DeskBasedVehicleSectionGroup5Lgv: FormNode = {
   name: 'vehicleSection',
@@ -73,6 +73,24 @@ export const DeskBasedVehicleSectionGroup5Lgv: FormNode = {
       name: 'preparerId',
       label: 'Preparer ID',
       value: '',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
+    },
+    {
+      name: 'make',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
+    },
+    {
+      name: 'model',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.HIDDEN,
+      viewType: FormNodeViewTypes.HIDDEN,
+    },
+    {
+      name: 'bodyType',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.HIDDEN,
       viewType: FormNodeViewTypes.HIDDEN,

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.spec.ts
@@ -119,7 +119,7 @@ describe('ContingencyTestResolver', () => {
       } as V3TechRecordModel;
 
       const make = getBodyMake(techRecord);
-      expect(make).toBeUndefined();
+      expect(make).toBeNull();
     });
   });
 
@@ -160,7 +160,7 @@ describe('ContingencyTestResolver', () => {
       } as V3TechRecordModel;
 
       const model = getBodyModel(techRecord);
-      expect(model).toBeUndefined();
+      expect(model).toBeNull();
     });
   });
 
@@ -207,7 +207,7 @@ describe('ContingencyTestResolver', () => {
       } as V3TechRecordModel;
 
       const bodyType = getBodyType(techRecord);
-      expect(bodyType).toBeUndefined();
+      expect(bodyType).toBeNull();
     });
   });
 

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.ts
@@ -110,7 +110,7 @@ export function getBodyMake(techRecord: V3TechRecordModel | undefined) {
     return techRecord.techRecord_make;
   }
 
-  return undefined;
+  return null;
 }
 
 export function getBodyModel(techRecord: V3TechRecordModel | undefined) {
@@ -122,13 +122,13 @@ export function getBodyModel(techRecord: V3TechRecordModel | undefined) {
     return techRecord.techRecord_model;
   }
 
-  return undefined;
+  return null;
 }
 
 export function getBodyType(techRecord: V3TechRecordModel | undefined) {
   const vehicleType = techRecord?.techRecord_vehicleType;
 
-  if (!vehicleType || (vehicleType !== 'hgv' && vehicleType !== 'psv' && vehicleType !== 'trl')) return undefined;
+  if (!vehicleType || (vehicleType !== 'hgv' && vehicleType !== 'psv' && vehicleType !== 'trl')) return null;
 
   return {
     code: techRecord.techRecord_bodyType_code,


### PR DESCRIPTION
## Ticket title

Updates previous pr.
Adds make, model and body type to the payload for all vehicles even if they don't collect that data. Changes return on those from undefined to null.
[CB2-10685](https://dvsa.atlassian.net/browse/CB2-10685)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
