### PR TITLE
fix(cb2-11068): fix tyre use code not showing all letters

### DIFF
--- a/src/app/forms/components/select/select.component.scss
+++ b/src/app/forms/components/select/select.component.scss
@@ -30,6 +30,10 @@
   min-width: unset;
 }
 
+.govuk-input--width-unset {
+  min-width: unset;
+}
+
 #techRecord_vehicleClass_description-hint {
   max-width: 32rem;
 }

--- a/src/app/forms/custom-sections/tyres/tyres.component.html
+++ b/src/app/forms/custom-sections/tyres/tyres.component.html
@@ -130,7 +130,7 @@
       [type]="types.DROPDOWN"
       name="techRecord_tyreUseCode"
       label="Tyre Use Code"
-      [width]="widths.XS"
+      [width]="widths.UNSET"
       [isEditing]="isEditing"
       [options]="tyreUseCode"
     ></app-switchable-input>

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -83,6 +83,7 @@ export enum FormNodeWidth {
   S = 4,
   XS = 3,
   XXS = 2,
+  UNSET = 'unset',
 }
 
 export interface FormNodeOption<T> {

--- a/src/app/forms/templates/hgv/hgv-tyres.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tyres.template.ts
@@ -21,7 +21,7 @@ export const tyresTemplateHgv: FormNode = {
       value: null,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
-      width: FormNodeWidth.XS,
+      width: FormNodeWidth.UNSET,
       options: getOptionsFromEnum(TyreUseCode),
       customTags: [{ colour: TagType.PURPLE, label: TagTypeLabels.PLATES }],
     },

--- a/src/app/forms/templates/trl/trl-tyres.template.ts
+++ b/src/app/forms/templates/trl/trl-tyres.template.ts
@@ -1,10 +1,10 @@
+import { TyreUseCode } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/tyreUseCodeTrl.enum.js';
 import { ValidatorNames } from '@forms/models/validators.enum';
 import {
   FormNode, FormNodeEditTypes, FormNodeTypes, FormNodeWidth, TagTypeLabels,
 } from '@forms/services/dynamic-form.types';
-import { TagType } from '@shared/components/tag/tag.component';
 import { getOptionsFromEnum } from '@forms/utils/enum-map';
-import { TyreUseCode } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/tyreUseCodeTrl.enum.js';
+import { TagType } from '@shared/components/tag/tag.component';
 
 export const tyresTemplateTrl: FormNode = {
   name: 'tyreSection',
@@ -17,7 +17,7 @@ export const tyresTemplateTrl: FormNode = {
       value: null,
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.SELECT,
-      width: FormNodeWidth.XS,
+      width: FormNodeWidth.UNSET,
       options: getOptionsFromEnum(TyreUseCode),
       customTags: [{ colour: TagType.PURPLE, label: TagTypeLabels.PLATES }],
     },


### PR DESCRIPTION
## Tyre use code is not getting displayed in correctly

Set min-width to unset so select is not too large, but don't provide a max-width to allow the select to expand with text on different screen sizes, preventing cut-off.

[CB2-XXXX](https://dvsa.atlassian.net/browse/CB2-11068)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
