### PR TITLE
fix(cb2-11453): do not download link via external tab

### DIFF
--- a/src/app/forms/custom-sections/adr/adr.component.scss
+++ b/src/app/forms/custom-sections/adr/adr.component.scss
@@ -12,6 +12,7 @@
     background-color: transparent;
     box-shadow: none;
     cursor: pointer;
+    font-family: 'GDS Transport', arial, sans-serif;
   
     &:hover {
       text-decoration: underline;

--- a/src/app/services/documents/documents.service.spec.ts
+++ b/src/app/services/documents/documents.service.spec.ts
@@ -43,7 +43,7 @@ describe('DocumentsService', () => {
       const simulateClickSpy = jest.spyOn(service, 'simulateClick');
 
       const fakeAnchorZip = domParser
-        .parseFromString('<a download="fileName.zip" href="Response body" target="_blank" />', 'text/html')
+        .parseFromString('<a download="fileName.zip" href="Response body" />', 'text/html')
         .querySelector('a');
 
       service.openDocumentFromResponse(fileName, responseBody, 'zip');

--- a/src/app/services/documents/documents.service.ts
+++ b/src/app/services/documents/documents.service.ts
@@ -7,7 +7,6 @@ export class DocumentsService {
       const link: HTMLAnchorElement = document.createElement('a');
 
       link.href = (responseBody as string).toString();
-      link.target = '_blank';
       link.download = `${fileName}.${fileType}`;
 
       this.simulateClick(link);


### PR DESCRIPTION
## VTM - 'Download ADR Documentation' link opens download prompt in a new tab

Remove the option to open link in blank tab. 

[CB2-11453](https://dvsa.atlassian.net/browse/CB2-11453)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
