### PR TITLE
fix(cb2-11302): correct spelling of accessor to assessor

### DIFF
--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -5,7 +5,7 @@
         <div class="vehicle_heading">
           <h1 class="govuk-heading-l">
             <span>
-              {{ test?.testTypeId ?? '' | testTypeName : (selectAllTestTypes$ | async) | defaultNullOrEmpty }}
+              {{ test?.testTypeId ?? '' | testTypeName: (selectAllTestTypes$ | async) | defaultNullOrEmpty }}
               {{ testCode | uppercase }}
             </span>
             <app-icon [icon]="(techRecord$ | async)?.techRecord_vehicleType || ''"></app-icon>
@@ -50,10 +50,10 @@
     <div class="test_result_header">
       <div class="test_name_and_date">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-          <span>{{ test?.testTypeId || '' | testTypeName : (selectAllTestTypes$ | async) }} {{ testCode | uppercase }}</span>
+          <span>{{ test?.testTypeId || '' | testTypeName: (selectAllTestTypes$ | async) }} {{ testCode | uppercase }}</span>
         </h1>
         <div class="date_and_result">
-          <span class="govuk-caption-l">{{ testResult?.createdAt | date : 'dd MMM yyyy' }}</span>
+          <span class="govuk-caption-l">{{ testResult?.createdAt | date: 'dd MMM yyyy' }}</span>
           <app-tag [type]="tagType">{{ resultOfTest | defaultNullOrEmpty }}</app-tag>
         </div>
       </div>
@@ -61,7 +61,7 @@
       <div class="tester_and_location">
         <dl class="govuk-summary-list govuk-summary-list--no-border">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Accessor</dt>
+            <dt class="govuk-summary-list__key">Assessor</dt>
             <dd class="govuk-summary-list__value">{{ testResult?.testerName | defaultNullOrEmpty }}</dd>
           </div>
           <div class="govuk-summary-list__row">
@@ -115,7 +115,7 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Country of registration</dt>
         <dd id="test-cor" class="govuk-summary-list__value">
-          {{ testResult?.countryOfRegistration | refDataDecode$ : referenceDataType.CountryOfRegistration | async | defaultNullOrEmpty | uppercase }}
+          {{ testResult?.countryOfRegistration | refDataDecode$: referenceDataType.CountryOfRegistration | async | defaultNullOrEmpty | uppercase }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">


### PR DESCRIPTION
## Correct Spelling Error in VTM - Change "Accessor" to "Assessor"

[CB2-11302](https://dvsa.atlassian.net/browse/CB2-11302)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
