### PR TITLE
feat(cb2-10286): add hint text to 3 month extension

### DIFF
--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -587,6 +587,7 @@ export const AdrTemplate: FormNode = {
     {
       name: 'techRecord_adrDetails_memosApply',
       label: 'Memo 7/9 (3 month extension) applied',
+      hint: 'Only applicable for vehicles used on national journeys',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CHECKBOXGROUP,
       groups: ['tank_details', 'dangerous_goods'],


### PR DESCRIPTION
##  VTM: Add hint to 3 month ext to inform it can only be applied for national journeys

Adds hint text for 3 month extension ADR field.

[CB2-10286](https://dvsa.atlassian.net/browse/CB2-10286)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
