### PR TITLE
feat/CB2-10740 - Mark if a vehicle is used for international journeys on VTM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/router": "^17.2.1",
         "@azure/msal-angular": "^3.0.13",
         "@azure/msal-browser": "^3.10.0",
-        "@dvsa/cvs-type-definitions": "^6.2.0",
+        "@dvsa/cvs-type-definitions": "^6.3.0",
         "@ngrx/effects": "^17.1.0",
         "@ngrx/entity": "^17.1.0",
         "@ngrx/router-store": "^17.1.0",
@@ -3723,9 +3723,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.2.0.tgz",
-      "integrity": "sha512-r1oPXfn0WeP9zitBJVU+w0r4Eco4t02Wl54UdxeEdJ6B0u0BNC7mIQ1Wr1RqQmMw4kCFSIYop6RinEVpbp/WtA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-6.3.0.tgz",
+      "integrity": "sha512-wWeGVDdfacUnO+aM1a/42k72XJjPwWIT/9Fc94hJATdUeF8b4rd7DefDXHEzlP+7uZr7CwtVn0/bLStJ7n35Tw==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@angular/router": "^17.2.1",
     "@azure/msal-angular": "^3.0.13",
     "@azure/msal-browser": "^3.10.0",
-    "@dvsa/cvs-type-definitions": "^6.2.0",
+    "@dvsa/cvs-type-definitions": "^6.3.0",
     "@ngrx/effects": "^17.1.0",
     "@ngrx/entity": "^17.1.0",
     "@ngrx/router-store": "^17.1.0",

--- a/src/app/forms/custom-sections/adr-examiner-notes-history-view/adr-examiner-notes-history-view.component.spec.ts
+++ b/src/app/forms/custom-sections/adr-examiner-notes-history-view/adr-examiner-notes-history-view.component.spec.ts
@@ -8,9 +8,8 @@ import { mockVehicleTechnicalRecord } from '@mocks/mock-vehicle-technical-record
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { of } from 'rxjs';
-import { AdrExaminerNotesHistoryViewComponent } from './adr-examiner-notes-history-view.component';
 import { RouterService } from '@services/router/router.service';
-
+import { AdrExaminerNotesHistoryViewComponent } from './adr-examiner-notes-history-view.component';
 
 describe('AdrExaminerNotesHistoryViewComponent', () => {
   let component: AdrExaminerNotesHistoryViewComponent;

--- a/src/app/forms/templates/general/adr-summary.template.ts
+++ b/src/app/forms/templates/general/adr-summary.template.ts
@@ -172,6 +172,18 @@ export const AdrSummaryTemplate: FormNode = {
       ],
     },
     {
+      name: 'techRecord_adrDetails_vehicleDetails_usedOnInternationalJourneys',
+      label: 'Vehicle used on international journeys',
+      type: FormNodeTypes.CONTROL,
+      options: [
+        { value: 'yes', label: 'Yes' },
+        { value: 'no', label: 'No' },
+        { value: 'n/a', label: 'Not applicable' },
+      ],
+      hide: true,
+      groups: ['adr_details', 'dangerous_goods'],
+    },
+    {
       name: 'techRecord_adrDetails_vehicleDetails_approvalDate',
       label: 'Date processed',
       type: FormNodeTypes.CONTROL,

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -23,7 +23,7 @@ import {
   AdrTankDetailsInitialInspectionViewComponent,
 } from '@forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component';
 import {
-  AdrTankDetailsM145ViewComponent
+  AdrTankDetailsM145ViewComponent,
 } from '@forms/custom-sections/adr-tank-details-m145-view/adr-tank-details-m145-view.component';
 import {
   AdrTankDetailsSubsequentInspectionsEditComponent,

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -22,7 +22,9 @@ import { AdrGuidanceNotesComponent } from '@forms/custom-sections/adr-guidance-n
 import {
   AdrTankDetailsInitialInspectionViewComponent,
 } from '@forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component';
-import { AdrTankDetailsM145ViewComponent } from '@forms/custom-sections/adr-tank-details-m145-view/adr-tank-details-m145-view.component';
+import {
+  AdrTankDetailsM145ViewComponent
+} from '@forms/custom-sections/adr-tank-details-m145-view/adr-tank-details-m145-view.component';
 import {
   AdrTankDetailsSubsequentInspectionsEditComponent,
 } from '@forms/custom-sections/adr-tank-details-subsequent-inspections-edit/adr-tank-details-subsequent-inspections-edit.component';
@@ -175,6 +177,19 @@ export const AdrTemplate: FormNode = {
           },
         },
       ],
+    },
+    {
+      name: 'techRecord_adrDetails_vehicleDetails_usedOnInternationalJourneys',
+      label: 'Vehicle used on international journeys',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.RADIO,
+      options: [
+        { value: 'yes', label: 'Yes' },
+        { value: 'no', label: 'No' },
+        { value: 'n/a', label: 'Not applicable' },
+      ],
+      hide: true,
+      groups: ['adr_details', 'dangerous_goods'],
     },
     {
       name: 'techRecord_adrDetails_vehicleDetails_approvalDate',

--- a/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
+++ b/src/app/store/technical-records/reducers/technical-record-service.reducer.ts
@@ -427,6 +427,7 @@ function handleClearADRDetails(state: TechnicalRecordServiceState) {
           editingTechRecord: {
             ...editingTechRecord,
             techRecord_adrDetails_vehicleDetails_type: null,
+            techRecord_adrDetails_vehicleDetails_usedOnInternationalJourneys: null,
             techRecord_adrDetails_vehicleDetails_approvalDate: null,
             techRecord_adrDetails_permittedDangerousGoods: null,
             ...nulledCompatibilityGroupJ,


### PR DESCRIPTION
## Ticket title
Introduces a mark to determine whether a vehicle is used for international journeys or not.
_One line description_
[CB2-10740](https://dvsa.atlassian.net/browse/CB2-10740)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
