### PR TITLE
fix(cb2-11908): remove duplicate label from additional examiner notes history

### DIFF
--- a/src/app/forms/templates/general/adr-summary.template.ts
+++ b/src/app/forms/templates/general/adr-summary.template.ts
@@ -803,7 +803,6 @@ export const AdrSummaryTemplate: FormNode = {
     },
     {
       name: 'techRecord_adrDetails_additionalExaminerNotes',
-      label: 'Additional examiner notes history',
       value: null,
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.CUSTOM,

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -810,7 +810,6 @@ export const AdrTemplate: FormNode = {
     },
     {
       name: 'techRecord_adrDetails_additionalExaminerNotes',
-      label: 'Additional examiner notes history',
       value: null,
       type: FormNodeTypes.CONTROL,
       viewType: FormNodeViewTypes.CUSTOM,


### PR DESCRIPTION
## VTM - Duplicated 'Additional Examiner Notes History' Label in VTMDEV-1 Branch 

[CB2-11908](https://dvsa.atlassian.net/browse/CB2-11908)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
