### PR TITLE
fix(cb2-12009): default psv body model to null if its an empty string

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -12,13 +12,12 @@ version: v1.25.0
 ignore:
   SNYK-JS-BRACES:
     - '*':
-    reason: Remediation not yet available
-    expires: 2024-11-24T09:01:15.119Z
-    created: 2024-05-24T09:01:15.122Z
+      reason: Remediation not yet available
+      expires: 2024-11-24T09:01:15.119Z
+      created: 2024-05-24T09:01:15.122Z
   SNYK-JS-MICROMATCH:
     - '*':
-    reason: Remediation not yet available
-    expires: 2024-11-24T09:01:15.119Z
-    created: 2024-05-24T09:01:15.122Z
+      reason: Remediation not yet available
+      expires: 2024-11-24T09:01:15.119Z
+      created: 2024-05-24T09:01:15.122Z
 patch: {}
-

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,24 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+
+# TEMPLATE that can be used inside the `ignore section`
+#  SNYK-LANG-PKG-NUM:
+#    - '*':
+#        reason: Remediation not yet available
+#        expires: 2023-08-27T09:01:15.119Z
+#        created: 2022-08-08T09:01:15.122Z
+
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-BRACES:
+    - '*':
+    reason: Remediation not yet available
+    expires: 2024-11-24T09:01:15.119Z
+    created: 2024-05-24T09:01:15.122Z
+  SNYK-JS-MICROMATCH:
+    - '*':
+    reason: Remediation not yet available
+    expires: 2024-11-24T09:01:15.119Z
+    created: 2024-05-24T09:01:15.122Z
+patch: {}
+

--- a/.snyk
+++ b/.snyk
@@ -10,12 +10,12 @@ version: v1.25.0
 
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-BRACES:
+  SNYK-JS-BRACES-6838727:
     - '*':
       reason: Remediation not yet available
       expires: 2024-11-24T09:01:15.119Z
       created: 2024-05-24T09:01:15.122Z
-  SNYK-JS-MICROMATCH:
+  SNYK-JS-MICROMATCH-6838728:
     - '*':
       reason: Remediation not yet available
       expires: 2024-11-24T09:01:15.119Z

--- a/src/app/models/test-results/test-result.model.ts
+++ b/src/app/models/test-results/test-result.model.ts
@@ -46,7 +46,7 @@ export interface TestResultModel {
   testStatus?: TestResultStatus;
 
   make?: string;
-  model?: string;
+  model?: string | null;
   bodyType?: TechRecordBodyType;
 
   /**

--- a/src/app/resolvers/contingency-test/contingency-test.resolver.ts
+++ b/src/app/resolvers/contingency-test/contingency-test.resolver.ts
@@ -115,7 +115,7 @@ export function getBodyMake(techRecord: V3TechRecordModel | undefined) {
 
 export function getBodyModel(techRecord: V3TechRecordModel | undefined) {
   if (techRecord?.techRecord_vehicleType === 'psv') {
-    return techRecord.techRecord_bodyModel;
+    return techRecord.techRecord_bodyModel ? techRecord.techRecord_bodyModel : null;
   }
 
   if (techRecord?.techRecord_vehicleType === 'hgv' || techRecord?.techRecord_vehicleType === 'trl') {

--- a/src/app/services/test-records/test-records.service.ts
+++ b/src/app/services/test-records/test-records.service.ts
@@ -197,7 +197,7 @@ export class TestRecordsService {
   }
 
   private canHandleTestType(templateMap: Record<VehicleTypes, Record<string, Record<string, FormNode>>>) {
-    return function handleTestType <T>(source: Observable<T>): Observable<boolean> {
+    return function handleTestType<T>(source: Observable<T>): Observable<boolean> {
       const handle = (testResult: TestResultModel | undefined): boolean => {
         if (!testResult) {
           return false;


### PR DESCRIPTION
## VTM - PSV testable records Body Model required for all tests

Set body model of PSV to null if its an empty string so it passes backend validation.

[CB2-12009](https://dvsa.atlassian.net/browse/CB2-12009)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
