### PR TITLE
feat(cb2-13234): Add guidance notes links within VTM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cvs-app-vtm",
-  "version": "1.25",
+  "version": "1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cvs-app-vtm",
-      "version": "1.25",
+      "version": "1.26",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvs-app-vtm",
-  "version": "1.25",
+  "version": "1.26",
   "description": "DVSA CVS Vehicle Testing Management Application",
   "main": "index.js",
   "engines": {

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -5,7 +5,7 @@
         <div class="vehicle_heading">
           <h1 class="govuk-heading-l">
             <span>
-              {{ test?.testTypeId ?? '' | testTypeName: (selectAllTestTypes$ | async) | defaultNullOrEmpty }}
+              {{ test?.testTypeId ?? '' | testTypeName : (selectAllTestTypes$ | async) | defaultNullOrEmpty }}
               {{ testCode | uppercase }}
             </span>
             <app-icon [icon]="(techRecord$ | async)?.techRecord_vehicleType || ''"></app-icon>
@@ -41,12 +41,14 @@
               {{ testResult?.vin }}
             </dd>
           </div>
-          <div class="govuk-summary-list__row">
-            <span>
-              <a class="govuk-link--no-visited-state" target="_blank" href="https://dvsauk.sharepoint.com/sites/HVTPDVSA/SitePages/ADR-Assessor-Guidance-Notes.aspx">
-                View guidance notes (opens in new tab)
-              </a>
-            </span>
+          <div class="govuk-summary-list__row guidance_notes_link">
+            <a
+              class="govuk-link--no-visited-state"
+              target="_blank"
+              href="https://dvsauk.sharepoint.com/sites/HVTPDVSA/SitePages/ADR-Assessor-Guidance-Notes.aspx"
+            >
+              View guidance notes (opens in new tab)
+            </a>
           </div>
         </dl>
       </div>
@@ -57,10 +59,10 @@
     <div class="test_result_header">
       <div class="test_name_and_date">
         <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
-          <span>{{ test?.testTypeId || '' | testTypeName: (selectAllTestTypes$ | async) }} {{ testCode | uppercase }}</span>
+          <span>{{ test?.testTypeId || '' | testTypeName : (selectAllTestTypes$ | async) }} {{ testCode | uppercase }}</span>
         </h1>
         <div class="date_and_result">
-          <span class="govuk-caption-l">{{ testResult?.createdAt | date: 'dd MMM yyyy' }}</span>
+          <span class="govuk-caption-l">{{ testResult?.createdAt | date : 'dd MMM yyyy' }}</span>
           <app-tag [type]="tagType">{{ resultOfTest | defaultNullOrEmpty }}</app-tag>
         </div>
       </div>
@@ -122,7 +124,7 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Country of registration</dt>
         <dd id="test-cor" class="govuk-summary-list__value">
-          {{ testResult?.countryOfRegistration | refDataDecode$: referenceDataType.CountryOfRegistration | async | defaultNullOrEmpty | uppercase }}
+          {{ testResult?.countryOfRegistration | refDataDecode$ : referenceDataType.CountryOfRegistration | async | defaultNullOrEmpty | uppercase }}
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -41,6 +41,13 @@
               {{ testResult?.vin }}
             </dd>
           </div>
+          <div class="govuk-summary-list__row">
+            <span>
+              <a class="govuk-link--no-visited-state" target="_blank" href="https://dvsauk.sharepoint.com/sites/HVTPDVSA/SitePages/ADR-Assessor-Guidance-Notes.aspx">
+                View guidance notes (opens in new tab)
+              </a>
+            </span>
+          </div>
         </dl>
       </div>
     </div>

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -41,7 +41,7 @@
               {{ testResult?.vin }}
             </dd>
           </div>
-          <div class="govuk-summary-list__row guidance_notes_link">
+          <div *ngIf="isADRTest" class="govuk-summary-list__row guidance_notes_link">
             <a
               class="govuk-link--no-visited-state"
               target="_blank"

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.scss
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.scss
@@ -56,3 +56,14 @@
   gap: 10px;
   align-items: center;
 }
+
+.guidance_notes_link {
+  display: flex;
+  padding: 10px 0;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__row {
+    display: flex;
+  }
+}

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.spec.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TestTypesService } from '@api/test-types';
+import { TestType } from '@models/test-types/test-type.model';
 import { V3TechRecordModel, VehicleConfigurations, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { provideMockStore } from '@ngrx/store/testing';
 import { ResultOfTestService } from '@services/result-of-test/result-of-test.service';
@@ -95,5 +96,17 @@ describe('VehicleHeaderComponent', () => {
 			techRecord_chassisModel: 'testChassisModel',
 		} as unknown as V3TechRecordModel;
 		expect(component.getVehicleDescription(mockRecord, undefined)).toBe('Unknown Vehicle Type');
+	});
+
+	describe('isADRTest', () => {
+		it('should return true if the selected test type is an ADR test', () => {
+			jest.spyOn(component, 'test', 'get').mockReturnValue({ testTypeId: '50' } as TestType);
+			expect(component.isADRTest).toBe(true);
+		});
+
+		it('should return false if the selected test type is not an ADR test', () => {
+			jest.spyOn(component, 'test', 'get').mockReturnValue({ testTypeId: '94' } as TestType);
+			expect(component.isADRTest).toBe(false);
+		});
 	});
 });

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { TestTypesTaxonomy } from '@api/test-types';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
+import { TEST_TYPES_GROUP7 } from '@forms/models/testTypeId.enum';
 import { ReferenceDataResourceType } from '@models/reference-data.model';
 import { TestResultStatus } from '@models/test-results/test-result-status.enum';
 import { TestResultModel } from '@models/test-results/test-result.model';
@@ -107,5 +108,9 @@ export class VehicleHeaderComponent {
 			default:
 				return 'Unknown Vehicle Type';
 		}
+	}
+
+	get isADRTest(): boolean {
+		return TEST_TYPES_GROUP7.includes(this.test?.testTypeId as string) || false;
 	}
 }

--- a/src/app/forms/components/base-control/base-control.component.ts
+++ b/src/app/forms/components/base-control/base-control.component.ts
@@ -28,6 +28,7 @@ export class BaseControlComponent implements ControlValueAccessor, AfterContentI
 	@Input() name = '';
 	@Input() customId?: string;
 	@Input() hint?: string;
+	@Input() link?: string;
 	@Input() label?: string;
 	@Input() width?: FormNodeWidth;
 	@Input() viewType: FormNodeViewTypes = FormNodeViewTypes.STRING;

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
@@ -69,16 +69,19 @@
   <ng-container [formGroup]="formGroup">
     <ng-container *ngIf="control.value.meta && !control.value.meta.hide" [ngSwitch]="edit">
       <ng-container *ngIf="control.value.meta.viewType !== 'hidden'">
-        <tr
-          *ngSwitchCase="false"
-          app-view-list-item
-          class="govuk-table__row"
-          [label]="control.value.meta.label"
-          [name]="control.value.meta.name"
-          [customId]="control.value.meta.customId ?? ''"
-          [viewType]="control.value.meta.viewType"
-          [formControlName]="control.key"
-        ></tr>
+        <a *ngIf="control.value.meta.link" [href]="control.value.meta.link" target="_blank">
+        </a>
+          <tr
+            *ngSwitchCase="false"
+            app-view-list-item
+            class="govuk-table__row"
+            [label]="'bjt'+control.value.meta.label"
+            [name]="control.value.meta.name"
+            [customId]="control.value.meta.customId ?? ''"
+            [viewType]="control.value.meta.viewType"
+            [formControlName]="control.key"
+            [link]="control.value.meta.link"
+          ></tr>
       </ng-container>
       <app-dynamic-form-field
         *ngSwitchCase="true"

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
@@ -69,13 +69,11 @@
   <ng-container [formGroup]="formGroup">
     <ng-container *ngIf="control.value.meta && !control.value.meta.hide" [ngSwitch]="edit">
       <ng-container *ngIf="control.value.meta.viewType !== 'hidden'">
-        <a *ngIf="control.value.meta.link" [href]="control.value.meta.link" target="_blank">
-        </a>
           <tr
             *ngSwitchCase="false"
             app-view-list-item
             class="govuk-table__row"
-            [label]="'bjt'+control.value.meta.label"
+            [label]="control.value.meta.label"
             [name]="control.value.meta.name"
             [customId]="control.value.meta.customId ?? ''"
             [viewType]="control.value.meta.viewType"

--- a/src/app/forms/components/view-list-item/view-list-item.component.html
+++ b/src/app/forms/components/view-list-item/view-list-item.component.html
@@ -1,5 +1,15 @@
 <ng-container *ngIf="viewType !== formNodeViewTypes.HIDDEN">
-  <td *ngIf="displayAsRow" class="govuk-table__cell" [style.width.%]="30">{{ label }}:</td>
+  <ng-container *ngIf="link; else plainText">
+      <td *ngIf="displayAsRow" class="govuk-table__cell" [style.width.%]="30">
+        <a class="govuk-link--no-visited-state" target="_blank" [href]="link">
+          {{ label }}:
+        </a>
+      </td>
+  </ng-container>
+
+  <ng-template #plainText>
+    <td *ngIf="displayAsRow" class="govuk-table__cell" [style.width.%]="30">{{ label }}:</td>
+  </ng-template>
 
   <ng-container [ngSwitch]="viewType">
     <ng-container *ngSwitchCase="formNodeViewTypes.DATE">

--- a/src/app/forms/components/view-list-item/view-list-item.component.html
+++ b/src/app/forms/components/view-list-item/view-list-item.component.html
@@ -2,8 +2,7 @@
   <ng-container *ngIf="link; else plainText">
       <td *ngIf="displayAsRow" class="govuk-table__cell" [style.width.%]="30">
         <a class="govuk-link--no-visited-state" target="_blank" [href]="link">
-          {{ label }}:
-        </a>
+          {{ label }}</a>:
       </td>
   </ng-container>
 

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -103,7 +103,7 @@ export interface FormNode {
 	width?: FormNodeWidth;
 	label?: string;
 	hint?: string;
-  link?: string;
+	link?: string;
 	delimited?: { regex?: string; separator: string };
 	value?: unknown;
 	path?: string;

--- a/src/app/forms/services/dynamic-form.types.ts
+++ b/src/app/forms/services/dynamic-form.types.ts
@@ -103,6 +103,7 @@ export interface FormNode {
 	width?: FormNodeWidth;
 	label?: string;
 	hint?: string;
+  link?: string;
 	delimited?: { regex?: string; separator: string };
 	value?: unknown;
 	path?: string;

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -254,7 +254,7 @@ export const AdrTemplate: FormNode = {
 			groups: ['adr_details', 'dangerous_goods'],
 			hide: true,
 			width: FormNodeWidth.XS,
-      link: 'https://dvsauk.sharepoint.com/sites/HVTPDVSA/SitePages/ADR-Assessor-Guidance-Notes.aspx',
+			link: 'https://dvsauk.sharepoint.com/sites/HVTPDVSA/SitePages/ADR-Assessor-Guidance-Notes.aspx',
 			value: [],
 			options: getOptionsFromEnum(ADRAdditionalNotesNumber),
 			validators: [

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -254,6 +254,7 @@ export const AdrTemplate: FormNode = {
 			groups: ['adr_details', 'dangerous_goods'],
 			hide: true,
 			width: FormNodeWidth.XS,
+      link: 'https://dvsauk.sharepoint.com/sites/HVTPDVSA/SitePages/ADR-Assessor-Guidance-Notes.aspx',
 			value: [],
 			options: getOptionsFromEnum(ADRAdditionalNotesNumber),
 			validators: [


### PR DESCRIPTION
## Ticket title
Added a link for users to be navigated to the ADR guidance notes on Sharepoint, links are located on the vehicle details header for ADR tests only, and the guidance notes property on the ADR section on a vehicles technical record.   

_One line description_
[CB2-13234](https://dvsa.atlassian.net/browse/CB2-13234)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
