### PR TITLE
fix(cb2-13164): remove issues docs centrally for notifable templates

### DIFF
--- a/src/app/forms/models/testTypeId.enum.ts
+++ b/src/app/forms/models/testTypeId.enum.ts
@@ -32,11 +32,8 @@ export const TEST_TYPES_GROUP3_4_8: string[] = [
 	'85',
 ];
 
-// 47 - free notifiable alteration (HGV/TRL), 48 - paid notifiable alteration (HGV/TRL)
-export const TEST_TYPES_GROUP8_NOTIFABLE = ['47', '48'];
-
-// 87 through 85 - tests for HGV and TRL - voluntary shaker plate check, Free/Paid notifiable alteration, voluntary break test
-export const TEST_TYPES_GROUP8_VOLUNTARY = ['85', '87'];
+// HGV and TRL - free/paid notifiable alteration (47/48), voluntary shaker plate check (85), voluntary brake test (87)
+export const TEST_TYPES_GROUP8 = ['47', '48', '85', '87'];
 
 // 56 and 49 - tests for HGV and TRL - Paid TIR retest, TIR test
 // 57 - test for TRL - Free TIR retest
@@ -241,7 +238,7 @@ export const TEST_TYPES = {
 	testTypesGroup2: TEST_TYPES_GROUP2,
 	testTypesGroup3And4And8: TEST_TYPES_GROUP3_4_8,
 	testTypesGroup7: TEST_TYPES_GROUP7,
-	testTypesGroup8Notifiable: TEST_TYPES_GROUP8_NOTIFABLE,
+	testTypesGroup8: TEST_TYPES_GROUP8,
 	testTypesGroup9And10: TEST_TYPES_GROUP9_10,
 	testTypesGroup9And10CentralDocs: TEST_TYPES_GROUP9_10_CENTRAL_DOCS,
 	testTypesGroup6And11: TEST_TYPES_GROUP6_11,

--- a/src/app/forms/templates/test-records/create-master.template.ts
+++ b/src/app/forms/templates/test-records/create-master.template.ts
@@ -29,7 +29,7 @@ import { ContingencyTestSectionGroup3And4And8 } from './section-templates/test/c
 import { ContingencyTestSectionGroup5And13 } from './section-templates/test/contingency/contingency-test-section-group5And13.template';
 import { ContingencyTestSectionGroup6And11 } from './section-templates/test/contingency/contingency-test-section-group6And11.template';
 import { ContingencyTestSectionGroup7 } from './section-templates/test/contingency/contingency-test-section-group7.template';
-import { ContingencyTestSectionGroup8Notifiable } from './section-templates/test/contingency/contingency-test-section-group8Notifiable.template';
+import { ContingencyTestSectionGroup8 } from './section-templates/test/contingency/contingency-test-section-group8.template';
 import { ContingencyTestSectionGroup9And10 } from './section-templates/test/contingency/contingency-test-section-group9And10.template';
 import { ContingencyTestSectionGroup9And10CentralDocs } from './section-templates/test/contingency/contingency-test-section-group9And10CentralDocs.template';
 import { ContingencyTestSectionGroup12and14 } from './section-templates/test/contingency/contingency-test-section-group12and14.template';
@@ -102,9 +102,9 @@ export const contingencyTestTemplates: Record<
 			reasonForCreation: reasonForCreationSection,
 			required: CreateRequiredSection,
 		},
-		testTypesGroup8Notifiable: {
+		testTypesGroup8: {
 			vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
-			test: ContingencyTestSectionGroup8Notifiable,
+			test: ContingencyTestSectionGroup8,
 			visit: ContingencyVisitSection,
 			seatbelts: SeatbeltHiddenSection,
 			notes: NotesSection,
@@ -269,9 +269,9 @@ export const contingencyTestTemplates: Record<
 			reasonForCreation: reasonForCreationSection,
 			required: CreateRequiredSectionHgvTrl,
 		},
-		testTypesGroup8Notifiable: {
+		testTypesGroup8: {
 			vehicle: ContingencyVehicleSectionDefaultPsvHgvLight,
-			test: ContingencyTestSectionGroup8Notifiable,
+			test: ContingencyTestSectionGroup8,
 			visit: ContingencyVisitSection,
 			notes: NotesSection,
 			customDefects: CustomDefectsSection,
@@ -463,9 +463,9 @@ export const contingencyTestTemplates: Record<
 			reasonForCreation: reasonForCreationSection,
 			required: CreateRequiredSectionHgvTrl,
 		},
-		testTypesGroup8Notifiable: {
+		testTypesGroup8: {
 			vehicle: ContingencyVehicleSectionDefaultTrl,
-			test: ContingencyTestSectionGroup8Notifiable,
+			test: ContingencyTestSectionGroup8,
 			visit: ContingencyVisitSection,
 			notes: NotesSection,
 			customDefects: CustomDefectsSection,

--- a/src/app/forms/templates/test-records/master.template.ts
+++ b/src/app/forms/templates/test-records/master.template.ts
@@ -42,7 +42,7 @@ import { TestSectionGroup3And4And8 } from './section-templates/test/test-section
 import { TestSectionGroup5And13 } from './section-templates/test/test-section-group5And13.template';
 import { TestSectionGroup6And11 } from './section-templates/test/test-section-group6And11.template';
 import { TestSectionGroup7 } from './section-templates/test/test-section-group7.template';
-import { TestSectionGroup8Notifiable } from './section-templates/test/test-section-group8Notifiable.template';
+import { TestSectionGroup8 } from './section-templates/test/test-section-group8.template';
 import { TestSectionGroup9And10 } from './section-templates/test/test-section-group9And10.template';
 import { TestSectionGroup9And10CentralDocs } from './section-templates/test/test-section-group9And10CentralDocs.template';
 import { TestSectionGroup12And14 } from './section-templates/test/test-section-group12And14.template';
@@ -111,9 +111,9 @@ export const masterTpl: Record<
 			reasonForCreation: reasonForCreationSection,
 			required: RequiredSection,
 		},
-		testTypesGroup8Notifiable: {
+		testTypesGroup8: {
 			vehicle: VehicleSectionDefaultPsvHgvLight,
-			test: TestSectionGroup8Notifiable,
+			test: TestSectionGroup8,
 			visit: VisitSection,
 			notes: NotesSection,
 			customDefects: CustomDefectsSection,
@@ -259,9 +259,9 @@ export const masterTpl: Record<
 			reasonForCreation: reasonForCreationSection,
 			required: RequiredSectionHGVTRL,
 		},
-		testTypesGroup8Notifiable: {
+		testTypesGroup8: {
 			vehicle: VehicleSectionDefaultPsvHgvLight,
-			test: TestSectionGroup8Notifiable,
+			test: TestSectionGroup8,
 			visit: VisitSection,
 			notes: NotesSection,
 			customDefects: CustomDefectsSection,
@@ -444,9 +444,9 @@ export const masterTpl: Record<
 			reasonForCreation: reasonForCreationSection,
 			required: RequiredSectionHGVTRL,
 		},
-		testTypesGroup8Notifiable: {
+		testTypesGroup8: {
 			vehicle: VehicleSectionDefaultTrl,
-			test: TestSectionGroup8Notifiable,
+			test: TestSectionGroup8,
 			visit: VisitSection,
 			notes: NotesSection,
 			customDefects: CustomDefectsSection,

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group8.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group8.template.ts
@@ -8,7 +8,7 @@ import {
 	FormNodeWidth,
 } from '@forms/services/dynamic-form.types';
 
-export const ContingencyTestSectionGroup8Notifiable: FormNode = {
+export const ContingencyTestSectionGroup8: FormNode = {
 	name: 'testSection',
 	label: 'Test',
 	type: FormNodeTypes.GROUP,
@@ -59,33 +59,8 @@ export const ContingencyTestSectionGroup8Notifiable: FormNode = {
 								{ value: 'pass', label: 'Pass' },
 								{ value: 'fail', label: 'Fail' },
 							],
-							validators: [{ name: ValidatorNames.HideIfNotEqual, args: { sibling: 'centralDocs', value: ['pass'] } }],
 							asyncValidators: [{ name: AsyncValidatorNames.ResultDependantOnCustomDefects }],
 							type: FormNodeTypes.CONTROL,
-						},
-						{
-							name: 'centralDocs',
-							type: FormNodeTypes.GROUP,
-							children: [
-								{
-									name: 'issueRequired',
-									type: FormNodeTypes.CONTROL,
-									label: 'Issue documents centrally',
-									editType: FormNodeEditTypes.RADIO,
-									value: false,
-									options: [
-										{ value: true, label: 'Yes' },
-										{ value: false, label: 'No' },
-									],
-								},
-								{
-									name: 'reasonsForIssue',
-									type: FormNodeTypes.CONTROL,
-									viewType: FormNodeViewTypes.HIDDEN,
-									editType: FormNodeEditTypes.HIDDEN,
-									value: [],
-								},
-							],
 						},
 						{
 							name: 'testTypeName',

--- a/src/app/forms/templates/test-records/section-templates/test/test-section-group8.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/test-section-group8.template.ts
@@ -9,7 +9,7 @@ import {
 } from '@forms/services/dynamic-form.types';
 import { SpecialRefData } from '@forms/services/multi-options.service';
 
-export const TestSectionGroup8Notifiable: FormNode = {
+export const TestSectionGroup8: FormNode = {
 	name: 'testSection',
 	label: 'Test',
 	type: FormNodeTypes.GROUP,
@@ -65,34 +65,9 @@ export const TestSectionGroup8Notifiable: FormNode = {
 									name: ValidatorNames.HideIfNotEqual,
 									args: { sibling: 'additionalCommentsForAbandon', value: 'abandoned' },
 								},
-								{ name: ValidatorNames.HideIfNotEqual, args: { sibling: 'centralDocs', value: ['pass'] } },
 							],
 							asyncValidators: [{ name: AsyncValidatorNames.ResultDependantOnCustomDefects }],
 							type: FormNodeTypes.CONTROL,
-						},
-						{
-							name: 'centralDocs',
-							type: FormNodeTypes.GROUP,
-							children: [
-								{
-									name: 'issueRequired',
-									type: FormNodeTypes.CONTROL,
-									label: 'Issue documents centrally',
-									editType: FormNodeEditTypes.RADIO,
-									value: false,
-									options: [
-										{ value: true, label: 'Yes' },
-										{ value: false, label: 'No' },
-									],
-								},
-								{
-									name: 'reasonsForIssue',
-									type: FormNodeTypes.CONTROL,
-									viewType: FormNodeViewTypes.HIDDEN,
-									editType: FormNodeEditTypes.HIDDEN,
-									value: [],
-								},
-							],
 						},
 						{
 							name: 'testTypeName',


### PR DESCRIPTION
## Remove issues docs centrally for notifiable templates

Revert back to using a single group 8 template without central docs.

[CB2-13164](https://dvsa.atlassian.net/browse/CB2-13164)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
