### PR TITLE
fix(cb2-13941): handle when current axles is falsy

### DIFF
--- a/src/app/forms/custom-sections/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections/tyres/tyres.component.ts
@@ -194,6 +194,7 @@ export class TyresComponent implements OnInit, OnDestroy, OnChanges {
 			const currentAxles = vehicleTechRecord.currentValue.techRecord_axles;
 			const previousAxles = vehicleTechRecord.previousValue.techRecord_axles;
 
+			if (!currentAxles) return false;
 			if (!previousAxles) return false;
 
 			// eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
## VTM Sentry -  Cannot read properties of undefined (reading 'entries')

[CB2-13941](https://dvsa.atlassian.net/browse/CB2-13941)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
