### PR TITLE
feat(cb2-11687): Hide Explosive Type 2 and 3 from Permitted Dangerous Goods when ADR Body Type includes 'Tank' or 'Battery'

### DIFF
--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.html
@@ -118,7 +118,7 @@
 
   <ng-container *ngSwitchCase="formNodeEditTypes.CUSTOM">
     <ng-container *ngIf="control.value.meta.editComponent">
-      <ng-container [ngComponentOutlet]="control.value.meta.editComponent" [ngComponentOutletInjector]="customFormControlInjector"></ng-container>
+      <ng-container [ngComponentOutlet]="control.value.meta.editComponent" [ngComponentOutletInputs]="customFormControlInputs" [ngComponentOutletInjector]="customFormControlInjector"></ng-container>
     </ng-container>
   </ng-container>
 

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -3,10 +3,10 @@ import { AfterContentInit, Component, InjectionToken, Injector, Input, OnInit } 
 import { FormGroup, NgControl } from '@angular/forms';
 // eslint-disable-next-line import/no-cycle
 import {
-  CustomFormControl,
-  CustomFormGroup,
-  FormNodeEditTypes,
-  FormNodeOption,
+	CustomFormControl,
+	CustomFormGroup,
+	FormNodeEditTypes,
+	FormNodeOption,
 } from '@services/dynamic-forms/dynamic-form.types';
 import { MultiOptionsService } from '@services/multi-options/multi-options.service';
 import { Observable, map, of } from 'rxjs';
@@ -19,11 +19,11 @@ import { Observable, map, of } from 'rxjs';
 export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 	@Input() control?: KeyValue<string, CustomFormControl>;
 	@Input() form?: FormGroup;
-  @Input() parentForm?: CustomFormGroup;
+	@Input() parentForm?: CustomFormGroup;
 	@Input() customId?: string;
 
 	customFormControlInjector?: Injector;
-  customFormControlInputs?: Record<string, unknown>;
+	customFormControlInputs?: Record<string, unknown>;
 
 	constructor(
 		private optionsService: MultiOptionsService,
@@ -44,7 +44,7 @@ export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 
 	ngOnInit(): void {
 		this.createCustomFormControlInjector();
-    this.customFormControlInputs = { parentForm: this.parentForm };
+		this.customFormControlInputs = { parentForm: this.parentForm };
 	}
 
 	ngAfterContentInit(): void {

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -2,7 +2,12 @@ import { KeyValue } from '@angular/common';
 import { AfterContentInit, Component, InjectionToken, Injector, Input, OnInit } from '@angular/core';
 import { FormGroup, NgControl } from '@angular/forms';
 // eslint-disable-next-line import/no-cycle
-import { CustomFormControl, FormNodeEditTypes, FormNodeOption } from '@services/dynamic-forms/dynamic-form.types';
+import {
+  CustomFormControl,
+  CustomFormGroup,
+  FormNodeEditTypes,
+  FormNodeOption,
+} from '@services/dynamic-forms/dynamic-form.types';
 import { MultiOptionsService } from '@services/multi-options/multi-options.service';
 import { Observable, map, of } from 'rxjs';
 
@@ -14,9 +19,11 @@ import { Observable, map, of } from 'rxjs';
 export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 	@Input() control?: KeyValue<string, CustomFormControl>;
 	@Input() form?: FormGroup;
+  @Input() parentForm?: CustomFormGroup;
 	@Input() customId?: string;
 
 	customFormControlInjector?: Injector;
+  customFormControlInputs?: Record<string, unknown>;
 
 	constructor(
 		private optionsService: MultiOptionsService,
@@ -37,6 +44,7 @@ export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 
 	ngOnInit(): void {
 		this.createCustomFormControlInjector();
+    this.createCustomFormControlInputs();
 	}
 
 	ngAfterContentInit(): void {
@@ -56,5 +64,8 @@ export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 			parent: this.injector,
 		});
 	}
+  createCustomFormControlInputs() {
+    this.customFormControlInputs = { parentForm: this.parentForm };
+  }
 }
 export const FORM_INJECTION_TOKEN = new InjectionToken('form');

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -65,6 +65,7 @@ export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 		});
 	}
   createCustomFormControlInputs() {
+    console.log(this.parentForm);
     this.customFormControlInputs = { parentForm: this.parentForm };
   }
 }

--- a/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
+++ b/src/app/forms/components/dynamic-form-field/dynamic-form-field.component.ts
@@ -44,7 +44,7 @@ export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 
 	ngOnInit(): void {
 		this.createCustomFormControlInjector();
-    this.createCustomFormControlInputs();
+    this.customFormControlInputs = { parentForm: this.parentForm };
 	}
 
 	ngAfterContentInit(): void {
@@ -64,9 +64,5 @@ export class DynamicFormFieldComponent implements OnInit, AfterContentInit {
 			parent: this.injector,
 		});
 	}
-  createCustomFormControlInputs() {
-    console.log(this.parentForm);
-    this.customFormControlInputs = { parentForm: this.parentForm };
-  }
 }
 export const FORM_INJECTION_TOKEN = new InjectionToken('form');

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.html
@@ -85,6 +85,7 @@
         *ngSwitchCase="true"
         [control]="control"
         [form]="formGroup"
+        [parentForm]="parentForm"
         [customId]="control.value.meta.customId"
         [ngClass]="control.value.meta.class"
       ></app-dynamic-form-field>

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
@@ -31,6 +31,7 @@ export class DynamicFormGroupComponent implements OnChanges, OnInit, OnDestroy {
 	@Input() data: any = {};
 	@Input() template?: FormNode;
 	@Input() edit = false;
+  @Input() parentForm?: CustomFormGroup;
 	@Output() formChange = new EventEmitter();
 
 	form: CustomFormGroup | CustomFormArray = new CustomFormGroup(

--- a/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
+++ b/src/app/forms/components/dynamic-form-group/dynamic-form-group.component.ts
@@ -31,7 +31,7 @@ export class DynamicFormGroupComponent implements OnChanges, OnInit, OnDestroy {
 	@Input() data: any = {};
 	@Input() template?: FormNode;
 	@Input() edit = false;
-  @Input() parentForm?: CustomFormGroup;
+	@Input() parentForm?: CustomFormGroup;
 	@Output() formChange = new EventEmitter();
 
 	form: CustomFormGroup | CustomFormArray = new CustomFormGroup(

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/__tests__/adr-permitted-dangerous-goods.component.spec.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/__tests__/adr-permitted-dangerous-goods.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SharedModule } from '@shared/shared.module';
+import { provideMockStore } from '@ngrx/store/testing';
+import { initialAppState, State } from '@store/index';
+import { NgControl } from '@angular/forms';
+import {
+  AdrPermittedDangerousGoodsComponent,
+} from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
+import { CustomFormControl, FormNodeTypes } from '@services/dynamic-forms/dynamic-form.types';
+import { ADRBodyType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrBodyType.enum.js';
+import { ADRDangerousGood } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrDangerousGood.enum.js';
+
+describe('AdrPermittedDangerousGoodsComponent', () => {
+    let component: AdrPermittedDangerousGoodsComponent;
+    let fixture: ComponentFixture<AdrPermittedDangerousGoodsComponent>;
+
+    const control = new CustomFormControl({
+      name: 'techRecord_adrDetails_permittedDangerousGoods',
+      type: FormNodeTypes.CONTROL,
+      value: [],
+    });
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        declarations: [AdrPermittedDangerousGoodsComponent],
+        imports: [SharedModule],
+        providers: [
+          provideMockStore<State>({ initialState: initialAppState }),
+          { provide: NgControl, useValue: { control } },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(AdrPermittedDangerousGoodsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+    describe('getOptions', () => {
+      it('should include explosives type 2 & 3 if adr body type is not tank or battery', () => {
+        component.adrBodyType = ADRBodyType.ARTIC_TRACTOR;
+        const multiOptions = [
+          { value: ADRDangerousGood.EXPLOSIVES_TYPE_2, label: ADRDangerousGood.EXPLOSIVES_TYPE_2 },
+          { value: ADRDangerousGood.EXPLOSIVES_TYPE_3, label: ADRDangerousGood.EXPLOSIVES_TYPE_3 }
+        ]
+        expect(component.getOptions()).toContainEqual(multiOptions[0]);
+        expect(component.getOptions()).toContainEqual(multiOptions[1]);
+      });
+      it('should not include explosives type 2 & 3 if adr body type is tank or battery', () => {
+        component.adrBodyType = ADRBodyType.FULL_DRAWBAR_TANK;
+        const multiOptions = [
+          { value: ADRDangerousGood.EXPLOSIVES_TYPE_2, label: ADRDangerousGood.EXPLOSIVES_TYPE_2 },
+          { value: ADRDangerousGood.EXPLOSIVES_TYPE_3, label: ADRDangerousGood.EXPLOSIVES_TYPE_3 }
+        ]
+        expect(component.getOptions()).not.toContainEqual(multiOptions[0]);
+        expect(component.getOptions()).not.toContainEqual(multiOptions[1]);
+      });
+    });
+  }
+)

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/__tests__/adr-permitted-dangerous-goods.component.spec.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/__tests__/adr-permitted-dangerous-goods.component.spec.ts
@@ -1,57 +1,54 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SharedModule } from '@shared/shared.module';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialAppState, State } from '@store/index';
 import { NgControl } from '@angular/forms';
-import {
-  AdrPermittedDangerousGoodsComponent,
-} from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
-import { CustomFormControl, FormNodeTypes } from '@services/dynamic-forms/dynamic-form.types';
 import { ADRBodyType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrBodyType.enum.js';
 import { ADRDangerousGood } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrDangerousGood.enum.js';
+import { AdrPermittedDangerousGoodsComponent } from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { CustomFormControl, FormNodeTypes } from '@services/dynamic-forms/dynamic-form.types';
+import { SharedModule } from '@shared/shared.module';
+import { State, initialAppState } from '@store/index';
 
 describe('AdrPermittedDangerousGoodsComponent', () => {
-    let component: AdrPermittedDangerousGoodsComponent;
-    let fixture: ComponentFixture<AdrPermittedDangerousGoodsComponent>;
+	let component: AdrPermittedDangerousGoodsComponent;
+	let fixture: ComponentFixture<AdrPermittedDangerousGoodsComponent>;
 
-    const control = new CustomFormControl({
-      name: 'techRecord_adrDetails_permittedDangerousGoods',
-      type: FormNodeTypes.CONTROL,
-      value: [],
-    });
-    beforeEach(async () => {
-      await TestBed.configureTestingModule({
-        declarations: [AdrPermittedDangerousGoodsComponent],
-        imports: [SharedModule],
-        providers: [
-          provideMockStore<State>({ initialState: initialAppState }),
-          { provide: NgControl, useValue: { control } },
-        ],
-      }).compileComponents();
+	const control = new CustomFormControl({
+		name: 'techRecord_adrDetails_permittedDangerousGoods',
+		type: FormNodeTypes.CONTROL,
+		value: [],
+	});
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [AdrPermittedDangerousGoodsComponent],
+			imports: [SharedModule],
+			providers: [
+				provideMockStore<State>({ initialState: initialAppState }),
+				{ provide: NgControl, useValue: { control } },
+			],
+		}).compileComponents();
 
-      fixture = TestBed.createComponent(AdrPermittedDangerousGoodsComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    });
-    describe('getOptions', () => {
-      it('should include explosives type 2 & 3 if adr body type is not tank or battery', () => {
-        component.adrBodyType = ADRBodyType.ARTIC_TRACTOR;
-        const multiOptions = [
-          { value: ADRDangerousGood.EXPLOSIVES_TYPE_2, label: ADRDangerousGood.EXPLOSIVES_TYPE_2 },
-          { value: ADRDangerousGood.EXPLOSIVES_TYPE_3, label: ADRDangerousGood.EXPLOSIVES_TYPE_3 }
-        ]
-        expect(component.getOptions()).toContainEqual(multiOptions[0]);
-        expect(component.getOptions()).toContainEqual(multiOptions[1]);
-      });
-      it('should not include explosives type 2 & 3 if adr body type is tank or battery', () => {
-        component.adrBodyType = ADRBodyType.FULL_DRAWBAR_TANK;
-        const multiOptions = [
-          { value: ADRDangerousGood.EXPLOSIVES_TYPE_2, label: ADRDangerousGood.EXPLOSIVES_TYPE_2 },
-          { value: ADRDangerousGood.EXPLOSIVES_TYPE_3, label: ADRDangerousGood.EXPLOSIVES_TYPE_3 }
-        ]
-        expect(component.getOptions()).not.toContainEqual(multiOptions[0]);
-        expect(component.getOptions()).not.toContainEqual(multiOptions[1]);
-      });
-    });
-  }
-)
+		fixture = TestBed.createComponent(AdrPermittedDangerousGoodsComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+	describe('getOptions', () => {
+		it('should include explosives type 2 & 3 if adr body type is not tank or battery', () => {
+			component.adrBodyType = ADRBodyType.ARTIC_TRACTOR;
+			const multiOptions = [
+				{ value: ADRDangerousGood.EXPLOSIVES_TYPE_2, label: ADRDangerousGood.EXPLOSIVES_TYPE_2 },
+				{ value: ADRDangerousGood.EXPLOSIVES_TYPE_3, label: ADRDangerousGood.EXPLOSIVES_TYPE_3 },
+			];
+			expect(component.getOptions()).toContainEqual(multiOptions[0]);
+			expect(component.getOptions()).toContainEqual(multiOptions[1]);
+		});
+		it('should not include explosives type 2 & 3 if adr body type is tank or battery', () => {
+			component.adrBodyType = ADRBodyType.FULL_DRAWBAR_TANK;
+			const multiOptions = [
+				{ value: ADRDangerousGood.EXPLOSIVES_TYPE_2, label: ADRDangerousGood.EXPLOSIVES_TYPE_2 },
+				{ value: ADRDangerousGood.EXPLOSIVES_TYPE_3, label: ADRDangerousGood.EXPLOSIVES_TYPE_3 },
+			];
+			expect(component.getOptions()).not.toContainEqual(multiOptions[0]);
+			expect(component.getOptions()).not.toContainEqual(multiOptions[1]);
+		});
+	});
+});

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
@@ -1,3 +1,4 @@
 <ng-container *ngIf="control">
-
+  <app-checkbox-group [options]="getOptions()">
+  </app-checkbox-group>
 </ng-container>

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
@@ -1,4 +1,4 @@
 <ng-container *ngIf="control">
-  <app-checkbox-group [options]="getOptions()">
+  <app-checkbox-group *ngIf="options" [options]="options" [label]="control?.value?.meta?.label">
   </app-checkbox-group>
 </ng-container>

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
@@ -1,4 +1,9 @@
-<ng-container *ngIf="control">
-  <app-checkbox-group *ngIf="options" [options]="options" [label]="control?.value?.meta?.label">
+<ng-container *ngIf="control && control.value">
+  <app-checkbox-group
+    *ngIf="options"
+    [options]="options"
+    [label]="control.value.meta?.label"
+    [formControl]="control.value"
+  >
   </app-checkbox-group>
 </ng-container>

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.html
@@ -1,0 +1,3 @@
+<ng-container *ngIf="control">
+
+</ng-container>

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
@@ -1,0 +1,26 @@
+import { BaseControlComponent } from '@forms/components/base-control/base-control.component';
+import { AfterContentInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { CustomFormGroup } from '@services/dynamic-forms/dynamic-form.types';
+import { ADRBodyType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrBodyType.enum.js';
+
+@Component({
+    selector: 'app-adr-permitted-dangerous-goods',
+    templateUrl: './adr-permitted-dangerous-goods.component.html',
+    styleUrls: ['./adr-permitted-dangerous-goods.component.scss'],
+})
+export class AdrPermittedDangerousGoodsComponent extends BaseControlComponent
+  implements OnInit, OnDestroy, AfterContentInit {
+
+  @Input() parentForm?: CustomFormGroup;
+  adrBodyType?: ADRBodyType;
+
+
+  ngOnInit(): void {
+    this.adrBodyType = this.parentForm?.get('techRecord_adrDetails_adrBodyType')?.value;
+  }
+
+  ngOnDestroy(): void {
+    throw new Error('Method not implemented.');
+  }
+
+}

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
@@ -28,13 +28,18 @@ export class AdrPermittedDangerousGoodsComponent
 			const newBodyTypeValue = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
 			if (this.adrBodyType !== newBodyTypeValue) {
 				this.adrBodyType = newBodyTypeValue;
-        if (this.adrBodyType?.includes('battery') || this.adrBodyType?.includes('tank')) {
-          let currentValue: string[] = this.control?.value?.value;
-          if (currentValue.includes(ADRDangerousGood.EXPLOSIVES_TYPE_2) || currentValue.includes(ADRDangerousGood.EXPLOSIVES_TYPE_3)) {
-            currentValue = currentValue.filter((value) => value !== ADRDangerousGood.EXPLOSIVES_TYPE_3 && value !== ADRDangerousGood.EXPLOSIVES_TYPE_2);
-            this.control?.value?.patchValue(currentValue);
-          }
-        }
+				if (this.adrBodyType?.includes('battery') || this.adrBodyType?.includes('tank')) {
+					let currentValue: string[] = this.control?.value?.value;
+					if (
+						currentValue.includes(ADRDangerousGood.EXPLOSIVES_TYPE_2) ||
+						currentValue.includes(ADRDangerousGood.EXPLOSIVES_TYPE_3)
+					) {
+						currentValue = currentValue.filter(
+							(value) => value !== ADRDangerousGood.EXPLOSIVES_TYPE_3 && value !== ADRDangerousGood.EXPLOSIVES_TYPE_2
+						);
+						this.control?.value?.patchValue(currentValue);
+					}
+				}
 				this.options = this.getOptions();
 			}
 		});

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
@@ -1,48 +1,51 @@
-import { BaseControlComponent } from '@forms/components/base-control/base-control.component';
 import { AfterContentInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { CustomFormGroup } from '@services/dynamic-forms/dynamic-form.types';
 import { ADRBodyType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrBodyType.enum.js';
-import { ReplaySubject, takeUntil } from 'rxjs';
-import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { ADRDangerousGood } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrDangerousGood.enum.js';
+import { BaseControlComponent } from '@forms/components/base-control/base-control.component';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
 import { MultiOptions } from '@models/options.model';
+import { CustomFormGroup } from '@services/dynamic-forms/dynamic-form.types';
+import { ReplaySubject, takeUntil } from 'rxjs';
 
 @Component({
-    selector: 'app-adr-permitted-dangerous-goods',
-    templateUrl: './adr-permitted-dangerous-goods.component.html',
-    styleUrls: ['./adr-permitted-dangerous-goods.component.scss'],
+	selector: 'app-adr-permitted-dangerous-goods',
+	templateUrl: './adr-permitted-dangerous-goods.component.html',
+	styleUrls: ['./adr-permitted-dangerous-goods.component.scss'],
 })
-export class AdrPermittedDangerousGoodsComponent extends BaseControlComponent
-  implements OnInit, OnDestroy, AfterContentInit {
+export class AdrPermittedDangerousGoodsComponent
+	extends BaseControlComponent
+	implements OnInit, OnDestroy, AfterContentInit
+{
+	@Input() parentForm?: CustomFormGroup;
+	adrBodyType?: ADRBodyType;
+	destroy$ = new ReplaySubject<boolean>(1);
+	options?: MultiOptions = [];
 
-  @Input() parentForm?: CustomFormGroup;
-  adrBodyType?: ADRBodyType;
-  destroy$ = new ReplaySubject<boolean>(1);
-  options?: MultiOptions = [];
+	ngOnInit(): void {
+		this.adrBodyType = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
+		this.options = this.getOptions();
+		this.parentForm?.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => {
+			const newBodyTypeValue = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
+			if (this.adrBodyType !== newBodyTypeValue) {
+				this.adrBodyType = newBodyTypeValue;
+				this.options = this.getOptions();
+			}
+		});
+	}
 
-  ngOnInit(): void {
-    this.adrBodyType = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
-    this.options = this.getOptions();
-    this.parentForm?.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => {
-      const newBodyTypeValue = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
-      if (this.adrBodyType !== newBodyTypeValue) {
-        this.adrBodyType = newBodyTypeValue;
-        this.options = this.getOptions();
-      }
-    });
-  }
+	getOptions() {
+		let enumValues = getOptionsFromEnum(ADRDangerousGood);
+		if (this.adrBodyType?.includes('battery') || this.adrBodyType?.includes('tank')) {
+			enumValues = enumValues.filter(
+				(option) =>
+					option.value !== ADRDangerousGood.EXPLOSIVES_TYPE_3 && option.value !== ADRDangerousGood.EXPLOSIVES_TYPE_2
+			);
+		}
+		return enumValues;
+	}
 
-  getOptions() {
-    let enumValues = getOptionsFromEnum(ADRDangerousGood);
-    if (this.adrBodyType?.includes('battery') || this.adrBodyType?.includes('tank')) {
-      enumValues = enumValues.filter((option) => option.value !== ADRDangerousGood.EXPLOSIVES_TYPE_3 && option.value !== ADRDangerousGood.EXPLOSIVES_TYPE_2);
-    }
-    return enumValues;
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next(true);
-    this.destroy$.complete();
-  }
-
+	ngOnDestroy(): void {
+		this.destroy$.next(true);
+		this.destroy$.complete();
+	}
 }

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
@@ -28,6 +28,13 @@ export class AdrPermittedDangerousGoodsComponent
 			const newBodyTypeValue = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
 			if (this.adrBodyType !== newBodyTypeValue) {
 				this.adrBodyType = newBodyTypeValue;
+        if (this.adrBodyType?.includes('battery') || this.adrBodyType?.includes('tank')) {
+          let currentValue: string[] = this.control?.value?.value;
+          if (currentValue.includes(ADRDangerousGood.EXPLOSIVES_TYPE_2) || currentValue.includes(ADRDangerousGood.EXPLOSIVES_TYPE_3)) {
+            currentValue = currentValue.filter((value) => value !== ADRDangerousGood.EXPLOSIVES_TYPE_3 && value !== ADRDangerousGood.EXPLOSIVES_TYPE_2);
+            this.control?.value?.patchValue(currentValue);
+          }
+        }
 				this.options = this.getOptions();
 			}
 		});

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
@@ -2,6 +2,9 @@ import { BaseControlComponent } from '@forms/components/base-control/base-contro
 import { AfterContentInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { CustomFormGroup } from '@services/dynamic-forms/dynamic-form.types';
 import { ADRBodyType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrBodyType.enum.js';
+import { ReplaySubject } from 'rxjs';
+import { getOptionsFromEnum } from '@forms/utils/enum-map';
+import { ADRDangerousGood } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/adrDangerousGood.enum.js';
 
 @Component({
     selector: 'app-adr-permitted-dangerous-goods',
@@ -13,14 +16,27 @@ export class AdrPermittedDangerousGoodsComponent extends BaseControlComponent
 
   @Input() parentForm?: CustomFormGroup;
   adrBodyType?: ADRBodyType;
-
+  destroy$ = new ReplaySubject<boolean>(1);
 
   ngOnInit(): void {
-    this.adrBodyType = this.parentForm?.get('techRecord_adrDetails_adrBodyType')?.value;
+    this.adrBodyType = this.parentForm?.get('techRecord_adrDetails_vehicleDetails_type')?.value;
+  }
+
+  getOptions() {
+    console.log(this.parentForm);
+    console.log(this.adrBodyType);
+    let enumValues = getOptionsFromEnum(ADRDangerousGood);
+    // console.log(this.adrBodyType);
+    if (this.adrBodyType?.includes('battery') || this.adrBodyType?.includes('tank')) {
+      enumValues = enumValues.filter((option) => option.value !== ADRDangerousGood.EXPLOSIVES_TYPE_3 && option.value !== ADRDangerousGood.EXPLOSIVES_TYPE_2);
+      console.log(enumValues);
+    }
+    return enumValues;
   }
 
   ngOnDestroy(): void {
-    throw new Error('Method not implemented.');
+    this.destroy$.next(true);
+    this.destroy$.complete();
   }
 
 }

--- a/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
+++ b/src/app/forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component.ts
@@ -30,7 +30,6 @@ export class AdrPermittedDangerousGoodsComponent extends BaseControlComponent
         this.options = this.getOptions();
       }
     });
-    console.log(this.label);
   }
 
   getOptions() {

--- a/src/app/forms/custom-sections/adr/adr.component.html
+++ b/src/app/forms/custom-sections/adr/adr.component.html
@@ -9,4 +9,4 @@
 >
   Download ADR Documentation
 </button>
-<app-dynamic-form-group [template]="template" [data]="techRecord" [edit]="isEditing" (formChange)="handleFormChange($event)"></app-dynamic-form-group>
+<app-dynamic-form-group [parentForm]="form" [template]="template" [data]="techRecord" [edit]="isEditing" (formChange)="handleFormChange($event)"></app-dynamic-form-group>

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -13,6 +13,7 @@ import { SuffixDirective } from '@directives/suffix/suffix.directive';
 import { ApprovalTypeInputComponent } from '@forms/components/approval-type/approval-type.component';
 import { AdrCertificateHistoryComponent } from '@forms/custom-sections/adr-certificate-history/adr-certificate-history.component';
 import { AdrExaminerNotesHistoryEditComponent } from '@forms/custom-sections/adr-examiner-notes-history-edit/adr-examiner-notes-history.component-edit';
+import { AdrPermittedDangerousGoodsComponent } from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
 import { ApprovalTypeComponent } from '@forms/custom-sections/approval-type/approval-type.component';
 import { SharedModule } from '@shared/shared.module';
 import { TruncatePipe } from '../pipes/truncate/truncate.pipe';
@@ -64,9 +65,6 @@ import { RequiredStandardsComponent } from './custom-sections/required-standards
 import { TrlBrakesComponent } from './custom-sections/trl-brakes/trl-brakes.component';
 import { TyresComponent } from './custom-sections/tyres/tyres.component';
 import { WeightsComponent } from './custom-sections/weights/weights.component';
-import {
-  AdrPermittedDangerousGoodsComponent
-} from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
 
 @NgModule({
 	declarations: [
@@ -132,7 +130,7 @@ import {
 		AdrTankDetailsM145ViewComponent,
 		ContingencyAdrGenerateCertComponent,
 		AdrNewCertificateRequiredViewComponent,
-    AdrPermittedDangerousGoodsComponent,
+		AdrPermittedDangerousGoodsComponent,
 	],
 	imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
 	exports: [

--- a/src/app/forms/dynamic-forms.module.ts
+++ b/src/app/forms/dynamic-forms.module.ts
@@ -64,6 +64,9 @@ import { RequiredStandardsComponent } from './custom-sections/required-standards
 import { TrlBrakesComponent } from './custom-sections/trl-brakes/trl-brakes.component';
 import { TyresComponent } from './custom-sections/tyres/tyres.component';
 import { WeightsComponent } from './custom-sections/weights/weights.component';
+import {
+  AdrPermittedDangerousGoodsComponent
+} from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
 
 @NgModule({
 	declarations: [
@@ -129,6 +132,7 @@ import { WeightsComponent } from './custom-sections/weights/weights.component';
 		AdrTankDetailsM145ViewComponent,
 		ContingencyAdrGenerateCertComponent,
 		AdrNewCertificateRequiredViewComponent,
+    AdrPermittedDangerousGoodsComponent,
 	],
 	imports: [CommonModule, FormsModule, ReactiveFormsModule, SharedModule, RouterModule],
 	exports: [

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -24,6 +24,9 @@ import {
 	FormNodeViewTypes,
 	FormNodeWidth,
 } from '@services/dynamic-forms/dynamic-form.types';
+import {
+  AdrPermittedDangerousGoodsComponent
+} from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
 
 export const AdrTemplate: FormNode = {
 	name: 'adrSection',
@@ -225,6 +228,35 @@ export const AdrTemplate: FormNode = {
 				},
 			],
 		},
+    {
+      name: 'techRecord_adrDetails_permittedDangerousGoods2',
+      label: 'Permitted dangerous goods',
+      type: FormNodeTypes.CONTROL,
+      editType: FormNodeEditTypes.CUSTOM,
+      editComponent: AdrPermittedDangerousGoodsComponent,
+      groups: ['adr_details', 'dangerous_goods'],
+      hide: true,
+      validators: [
+        {
+          name: ValidatorNames.ShowGroupsWhenIncludes,
+          args: {
+            values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
+            groups: ['compatibility_group_j'],
+          },
+        },
+        {
+          name: ValidatorNames.HideGroupsWhenExcludes,
+          args: {
+            values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
+            groups: ['compatibility_group_j'],
+          },
+        },
+        {
+          name: ValidatorNames.RequiredIfEquals,
+          args: { sibling: 'techRecord_adrDetails_dangerousGoods', value: [true] },
+        },
+      ],
+    },
 		{
 			name: 'techRecord_adrDetails_compatibilityGroupJ',
 			label: 'Compatibility group J',

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -199,37 +199,8 @@ export const AdrTemplate: FormNode = {
 				{ name: ValidatorNames.DateIsInvalid },
 			],
 		},
-		{
-			name: 'techRecord_adrDetails_permittedDangerousGoods',
-			label: 'Permitted dangerous goods',
-			type: FormNodeTypes.CONTROL,
-			editType: FormNodeEditTypes.CHECKBOXGROUP,
-			groups: ['adr_details', 'dangerous_goods'],
-			hide: true,
-			options: getOptionsFromEnum(ADRDangerousGood),
-			validators: [
-				{
-					name: ValidatorNames.ShowGroupsWhenIncludes,
-					args: {
-						values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
-						groups: ['compatibility_group_j'],
-					},
-				},
-				{
-					name: ValidatorNames.HideGroupsWhenExcludes,
-					args: {
-						values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
-						groups: ['compatibility_group_j'],
-					},
-				},
-				{
-					name: ValidatorNames.RequiredIfEquals,
-					args: { sibling: 'techRecord_adrDetails_dangerousGoods', value: [true] },
-				},
-			],
-		},
     {
-      name: 'techRecord_adrDetails_permittedDangerousGoods2',
+      name: 'techRecord_adrDetails_permittedDangerousGoods',
       label: 'Permitted dangerous goods',
       type: FormNodeTypes.CONTROL,
       editType: FormNodeEditTypes.CUSTOM,

--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -7,6 +7,7 @@ import { ADRTankStatementSubstancePermitted } from '@dvsa/cvs-type-definitions/t
 import { AdrExaminerNotesHistoryEditComponent } from '@forms/custom-sections/adr-examiner-notes-history-edit/adr-examiner-notes-history.component-edit';
 import { AdrExaminerNotesHistoryViewComponent } from '@forms/custom-sections/adr-examiner-notes-history-view/adr-examiner-notes-history-view.component';
 import { AdrNewCertificateRequiredViewComponent } from '@forms/custom-sections/adr-new-certificate-required-view/adr-new-certificate-required-view.component';
+import { AdrPermittedDangerousGoodsComponent } from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
 import { AdrTankDetailsInitialInspectionViewComponent } from '@forms/custom-sections/adr-tank-details-initial-inspection-view/adr-tank-details-initial-inspection-view.component';
 import { AdrTankDetailsM145ViewComponent } from '@forms/custom-sections/adr-tank-details-m145-view/adr-tank-details-m145-view.component';
 import { AdrTankDetailsSubsequentInspectionsEditComponent } from '@forms/custom-sections/adr-tank-details-subsequent-inspections-edit/adr-tank-details-subsequent-inspections-edit.component';
@@ -24,9 +25,6 @@ import {
 	FormNodeViewTypes,
 	FormNodeWidth,
 } from '@services/dynamic-forms/dynamic-form.types';
-import {
-  AdrPermittedDangerousGoodsComponent
-} from '@forms/custom-sections/adr-permitted-dangerous-goods/adr-permitted-dangerous-goods.component';
 
 export const AdrTemplate: FormNode = {
 	name: 'adrSection',
@@ -199,35 +197,35 @@ export const AdrTemplate: FormNode = {
 				{ name: ValidatorNames.DateIsInvalid },
 			],
 		},
-    {
-      name: 'techRecord_adrDetails_permittedDangerousGoods',
-      label: 'Permitted dangerous goods',
-      type: FormNodeTypes.CONTROL,
-      editType: FormNodeEditTypes.CUSTOM,
-      editComponent: AdrPermittedDangerousGoodsComponent,
-      groups: ['adr_details', 'dangerous_goods'],
-      hide: true,
-      validators: [
-        {
-          name: ValidatorNames.ShowGroupsWhenIncludes,
-          args: {
-            values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
-            groups: ['compatibility_group_j'],
-          },
-        },
-        {
-          name: ValidatorNames.HideGroupsWhenExcludes,
-          args: {
-            values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
-            groups: ['compatibility_group_j'],
-          },
-        },
-        {
-          name: ValidatorNames.RequiredIfEquals,
-          args: { sibling: 'techRecord_adrDetails_dangerousGoods', value: [true] },
-        },
-      ],
-    },
+		{
+			name: 'techRecord_adrDetails_permittedDangerousGoods',
+			label: 'Permitted dangerous goods',
+			type: FormNodeTypes.CONTROL,
+			editType: FormNodeEditTypes.CUSTOM,
+			editComponent: AdrPermittedDangerousGoodsComponent,
+			groups: ['adr_details', 'dangerous_goods'],
+			hide: true,
+			validators: [
+				{
+					name: ValidatorNames.ShowGroupsWhenIncludes,
+					args: {
+						values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
+						groups: ['compatibility_group_j'],
+					},
+				},
+				{
+					name: ValidatorNames.HideGroupsWhenExcludes,
+					args: {
+						values: [ADRDangerousGood.EXPLOSIVES_TYPE_2, ADRDangerousGood.EXPLOSIVES_TYPE_3],
+						groups: ['compatibility_group_j'],
+					},
+				},
+				{
+					name: ValidatorNames.RequiredIfEquals,
+					args: { sibling: 'techRecord_adrDetails_dangerousGoods', value: [true] },
+				},
+			],
+		},
 		{
 			name: 'techRecord_adrDetails_compatibilityGroupJ',
 			label: 'Compatibility group J',


### PR DESCRIPTION
## Ticket title
Hide Explosive Type 2 and 3 from Permitted Dangerous Goods when ADR Body Type includes 'Tank' or 'Battery'

_One line description_
Introduces the necessary changes to allow for this behaviour, which includes minor additions to DFS.
[CB2-11687](https://dvsa.atlassian.net/browse/CB2-11687)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
