### PR TITLE
fix(cb2-13831): retry on status of 0

### DIFF
--- a/src/app/interceptors/interceptor.module.ts
+++ b/src/app/interceptors/interceptor.module.ts
@@ -10,7 +10,7 @@ import { ErrorInterceptorModule } from './error-handling/error-handling.module';
 		DelayedRetryModule.forRoot({
 			count: 3,
 			delay: 2000,
-			httpStatusRetry: [504],
+			httpStatusRetry: [0, 504],
 			backoff: true,
 			whiteList: ['document-retrieval'],
 		}),


### PR DESCRIPTION
## VTM Sentry - Http failure response for /v1/document-retrieval: 0 Unknown Error

Have checked common causes for this occurring (see [https://javascript-code.dev/articles/263765532](https://javascript-code.dev/articles/263765532)), and can confirm this is neither a misconfigured http client or an invalid URL. It is likely a network/firewall issue or a CORs issue which cannot be fixed client side, so I'm following the recommendation to simply handle and retry the request when a 0 status code is received.

[CB2-13831](https://dvsa.atlassian.net/browse/CB2-13831)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
