### PR TITLE
fix(cb2-14242): do not default value of battery list applicable

### DIFF
--- a/src/app/forms/templates/general/adr.template.ts
+++ b/src/app/forms/templates/general/adr.template.ts
@@ -630,7 +630,7 @@ export const AdrTemplate: FormNode = {
 			name: 'techRecord_adrDetails_listStatementApplicable',
 			label: 'Battery List Applicable',
 			width: FormNodeWidth.XS,
-			value: false,
+			value: null,
 			type: FormNodeTypes.CONTROL,
 			editType: FormNodeEditTypes.RADIO,
 			options: [


### PR DESCRIPTION
## Stretch 4.5.2 VTM - ADR Battery List Applicable should not be autofilled

[CB2-14242](https://dvsa.atlassian.net/browse/CB2-14242)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
