### PR TITLE
fix(cb2-13642): when prohibition issue is hidden in edit mode, hide it on the review screen

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group1.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group1.template.ts
@@ -119,6 +119,7 @@ export const ContingencyTestSectionGroup1: FormNode = {
 							label: 'Prohibition issued',
 							type: FormNodeTypes.CONTROL,
 							value: null,
+							viewType: FormNodeViewTypes.HIDDEN,
 							editType: FormNodeEditTypes.HIDDEN,
 							required: true,
 						},

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group12and14.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group12and14.template.ts
@@ -113,6 +113,7 @@ export const ContingencyTestSectionGroup12and14: FormNode = {
 							label: 'Prohibition issued',
 							type: FormNodeTypes.CONTROL,
 							value: null,
+							viewType: FormNodeViewTypes.HIDDEN,
 							editType: FormNodeEditTypes.HIDDEN,
 							required: true,
 						},

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group6And11.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group6And11.template.ts
@@ -120,6 +120,7 @@ export const ContingencyTestSectionGroup6And11: FormNode = {
 							label: 'Prohibition issued',
 							type: FormNodeTypes.CONTROL,
 							value: null,
+							viewType: FormNodeViewTypes.HIDDEN,
 							editType: FormNodeEditTypes.HIDDEN,
 							required: true,
 						},

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group9And10.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group9And10.template.ts
@@ -121,6 +121,7 @@ export const ContingencyTestSectionGroup9And10: FormNode = {
 							label: 'Prohibition issued',
 							type: FormNodeTypes.CONTROL,
 							value: null,
+							viewType: FormNodeViewTypes.HIDDEN,
 							editType: FormNodeEditTypes.HIDDEN,
 							required: true,
 						},

--- a/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group9And10CentralDocs.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/test/contingency/contingency-test-section-group9And10CentralDocs.template.ts
@@ -154,6 +154,7 @@ export const ContingencyTestSectionGroup9And10CentralDocs: FormNode = {
 							label: 'Prohibition issued',
 							type: FormNodeTypes.CONTROL,
 							value: null,
+							viewType: FormNodeViewTypes.HIDDEN,
 							editType: FormNodeEditTypes.HIDDEN,
 							required: true,
 						},


### PR DESCRIPTION
## VTM - ' Prohibition Issued' Field Removal/Hiding 

[CB2-13642](https://dvsa.atlassian.net/browse/CB2-13642)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
