### PR TITLE
feat(cb2-15038): allow current year +1 for year of manufacture

### DIFF
--- a/src/app/forms/templates/car/car-tech-record.template.ts
+++ b/src/app/forms/templates/car/car-tech-record.template.ts
@@ -56,7 +56,7 @@ export const CarTechRecord: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 		},
 		{

--- a/src/app/forms/templates/hgv/hgv-tech-record.template.ts
+++ b/src/app/forms/templates/hgv/hgv-tech-record.template.ts
@@ -66,7 +66,7 @@ export const HgvTechRecord: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 			customTags: [{ colour: TagType.PURPLE, label: TagTypeLabels.PLATES }],
 		},

--- a/src/app/forms/templates/lgv/lgv-tech-record.template.ts
+++ b/src/app/forms/templates/lgv/lgv-tech-record.template.ts
@@ -58,7 +58,7 @@ export const LgvTechRecord: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 		},
 		{

--- a/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
+++ b/src/app/forms/templates/motorcycle/motorcycle-tech-record.template.ts
@@ -57,7 +57,7 @@ export const MotorcycleTechRecord: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 		},
 		{

--- a/src/app/forms/templates/psv/psv-tech-record.template.ts
+++ b/src/app/forms/templates/psv/psv-tech-record.template.ts
@@ -66,7 +66,7 @@ export const PsvTechRecord: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 		},
 		{

--- a/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
+++ b/src/app/forms/templates/small-trailer/small-trailer-tech-record.template.ts
@@ -70,7 +70,7 @@ export const SmallTrailerTechRecord: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 		},
 		{

--- a/src/app/forms/templates/trl/trl-tech-record.template.ts
+++ b/src/app/forms/templates/trl/trl-tech-record.template.ts
@@ -80,7 +80,7 @@ export const TrlTechRecordTemplate: FormNode = {
 			validators: [
 				{ name: ValidatorNames.Max, args: 9999 },
 				{ name: ValidatorNames.Min, args: 1000 },
-				{ name: ValidatorNames.PastYear },
+				{ name: ValidatorNames.XYearsAfterCurrent, args: 1 },
 			],
 			customTags: [{ colour: TagType.PURPLE, label: TagTypeLabels.PLATES }],
 		},

--- a/src/app/forms/utils/error-message-map.ts
+++ b/src/app/forms/utils/error-message-map.ts
@@ -55,6 +55,7 @@ export const ErrorMessageMap: Record<string, Function> = {
 		err.message ?? `${label || DEFAULT_LABEL} is invalid`,
 	[ValidatorNames.Custom]: (err: { message: string }) => err.message,
 	[ValidatorNames.MinArrayLengthIfNotEmpty]: (err: { message: string }) => err.message,
+	[ValidatorNames.XYearsAfterCurrent]: (err: { message: string }) => err.message,
 
 	[AsyncValidatorNames.RequiredIfNotAbandoned]: (err: boolean, label?: string) =>
 		`${label || DEFAULT_LABEL} is required`,

--- a/src/app/forms/validators/custom-validators/__tests__/custom-validators.spec.ts
+++ b/src/app/forms/validators/custom-validators/__tests__/custom-validators.spec.ts
@@ -2146,3 +2146,52 @@ describe('IssueRequired', () => {
 		});
 	});
 });
+
+describe('xYearsAfterCurrent', () => {
+	let control: CustomFormControl;
+
+	beforeEach(() => {
+		// Set current year to 2024
+		jest.useFakeTimers().setSystemTime(new Date('2024-01-01'));
+
+		control = new CustomFormControl({
+			type: FormNodeTypes.CONTROL,
+			name: 'techRecord_manufactureYear',
+			label: 'Year of Manufacture',
+			value: 2024,
+		});
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('should allow the current year', () => {
+		control.patchValue(2024);
+		expect(CustomValidators.xYearsAfterCurrent(2)(control)).toBeNull();
+	});
+
+	it('should allow the current year +2 years', () => {
+		control.patchValue(2026);
+		expect(CustomValidators.xYearsAfterCurrent(2)(control)).toBeNull();
+	});
+
+	it('should allow the current year -2 years', () => {
+		control.patchValue(2022);
+		expect(CustomValidators.xYearsAfterCurrent(2)(control)).toBeNull();
+	});
+
+	it('should not allow the current year +3 years', () => {
+		control.patchValue(2028);
+		expect(CustomValidators.xYearsAfterCurrent(2)(control)).toEqual({
+			xYearsAfterCurrent: { message: 'Year of Manufacture must be equal to or before 2026' },
+		});
+	});
+
+	it('should not allow negative years', () => {
+		control.patchValue(-100);
+		expect(CustomValidators.xYearsAfterCurrent(2)(control)).toEqual({
+			xYearsAfterCurrent: { message: 'Year of Manufacture must be equal to or before 2026' },
+		});
+	});
+});

--- a/src/app/forms/validators/custom-validators/custom-validators.ts
+++ b/src/app/forms/validators/custom-validators/custom-validators.ts
@@ -627,6 +627,19 @@ export class CustomValidators {
 			return CustomValidators.requiredIfEquals('testResult', ['pass'])(control);
 		};
 	};
+
+	// Only the inputted year to be x years after the current year
+	static xYearsAfterCurrent = (xYears: number): ValidatorFn => {
+		return (control: AbstractControl): ValidationErrors | null => {
+			const currentYear = new Date().getFullYear();
+			const inputYear = control.value;
+			const maxYear = currentYear + xYears;
+			if (control instanceof CustomFormControl && inputYear && (inputYear > maxYear || inputYear < 0)) {
+				return { xYearsAfterCurrent: { message: `${control.meta.label} must be equal to or before ${maxYear}` } };
+			}
+			return null;
+		};
+	};
 }
 
 export type EnumValidatorOptions = {

--- a/src/app/models/validators.enum.ts
+++ b/src/app/models/validators.enum.ts
@@ -48,4 +48,5 @@ export enum ValidatorNames {
 	MinArrayLengthIfNotEmpty = 'minArrayLengthIfNotEmpty',
 	IssueRequired = 'issueRequired',
 	SetBodyDeclarationVisibility = 'setBodyDeclarationVisibility',
+	XYearsAfterCurrent = 'xYearsAfterCurrent',
 }

--- a/src/app/services/dynamic-forms/dynamic-form.service.ts
+++ b/src/app/services/dynamic-forms/dynamic-form.service.ts
@@ -98,6 +98,7 @@ export class DynamicFormService {
 			CustomValidators.minArrayLengthIfNotEmpty(args.minimumLength, args.message),
 		[ValidatorNames.IssueRequired]: () => CustomValidators.issueRequired(),
 		[ValidatorNames.SetBodyDeclarationVisibility]: () => AdrValidators.setBodyDeclarationVisibility(),
+		[ValidatorNames.XYearsAfterCurrent]: (xYears: number) => CustomValidators.xYearsAfterCurrent(xYears),
 	};
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## VTM - Allow year of manufacture input field to accept one year into the future when creating/amending technical records

[CB2-15038](https://dvsa.atlassian.net/browse/CB2-15038)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
