### PR TITLE
fix(CB2-15660): fix issue where delete of tc3 inspection was not propagated

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -156,7 +156,10 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, AfterViewI
 		});
 
 		this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => {
-			this.handleFormState(changes);
+			// prevent merging of array of objects - always override
+			const isArray = (a: unknown, b: unknown) => (Array.isArray(a) ? b : undefined);
+			this.techRecordCalculated = mergeWith(cloneDeep(this.techRecordCalculated), changes, isArray);
+			this.technicalRecordService.updateEditingTechRecord(this.techRecordCalculated as TechRecordType<'put'>);
 		});
 	}
 


### PR DESCRIPTION
## VTM - Adding then removing a Subsequent tank field still keeps the subsequent field upon submitting tech record

[CB2-15660](https://dvsa.atlassian.net/browse/CB2-15660)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
