### PR TITLE
fix(CB2-14452): reset autocomplete to default value when cleared

### DIFF
--- a/src/app/forms/components/autocomplete/__tests__/autocomplete.component.spec.ts
+++ b/src/app/forms/components/autocomplete/__tests__/autocomplete.component.spec.ts
@@ -80,15 +80,15 @@ describe('AutocompleteComponent', () => {
 		expect(control?.touched).toBeTruthy();
 	});
 
-	it('should propagate "" to form control when input is left empty', () => {
+	it('should propagate null and reset to form control when input is cleared', () => {
 		const findOptionValueSpy = jest.spyOn(autocompleteComponent, 'findOptionValue');
 		const control = component.form.get('foo');
 
 		autocompleteComponent.handleChange({ target: { value: '' } } as unknown as Event);
 
 		expect(findOptionValueSpy).toHaveBeenCalled();
-		expect(control?.value).toBe('');
-		expect(control?.touched).toBeTruthy();
+		expect(control?.value).toBeNull(); // use null to indicate the field is empty
+		expect(control?.touched).toBe(false);
 	});
 
 	it('should propagate "[INVALID_OPTION]" to form control when value is not an option', () => {

--- a/src/app/forms/components/autocomplete/autocomplete.component.ts
+++ b/src/app/forms/components/autocomplete/autocomplete.component.ts
@@ -88,6 +88,13 @@ export class AutocompleteComponent extends BaseControlComponent implements After
 	handleChangeForOption(value: string) {
 		const optionValue = this.findOptionValue(value);
 
+		// Handle case where input is cleared fully, so it returns to default state without triggering validation
+		if (optionValue === '') {
+			this.control?.patchValue(null);
+			this.control?.markAsPristine();
+			return;
+		}
+
 		this.control?.patchValue(optionValue ?? '[INVALID_OPTION]');
 		this.control?.markAsTouched();
 		this.control?.updateValueAndValidity();


### PR DESCRIPTION
## VTM - Inputting and then deleting text in the "Microfilm document type" field does not allow submitting tech record

[CB2-14452](https://dvsa.atlassian.net/browse/CB2-14452)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
