### PR TITLE
fix(CB2-15824): fix tyre use code styling on review page

### DIFF
--- a/src/app/forms/custom-sections/tyres-section/tyres-section-summary/tyres-section-summary.component.html
+++ b/src/app/forms/custom-sections/tyres-section/tyres-section-summary/tyres-section-summary.component.html
@@ -1,14 +1,14 @@
 <ng-container *ngIf="amendedTechRecord() as vm">
-  <dl class="govuk-summary-list" *ngIf="vm.techRecord_vehicleType === VehicleTypes.PSV || vm.techRecord_vehicleType === VehicleTypes.HGV || vm.techRecord_vehicleType === VehicleTypes.TRL">
+  <ng-container *ngIf="vm.techRecord_vehicleType === VehicleTypes.PSV || vm.techRecord_vehicleType === VehicleTypes.HGV || vm.techRecord_vehicleType === VehicleTypes.TRL">
     <!-- Speed Restriction (PSV Only) -->
-    <ng-container *ngIf="vm.techRecord_vehicleType === VehicleTypes.PSV">
+    <dl class="govuk-summary-list"  *ngIf="vm.techRecord_vehicleType === VehicleTypes.PSV">
       <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_speedRestriction')">
         <dt class="govuk-summary-list__key">Speed Restriction</dt>
         <dd class="govuk-summary-list__value" id="test-techRecord_speedRestriction">
           {{ vm.techRecord_speedRestriction | defaultNullOrEmpty }}
         </dd>
       </div>
-    </ng-container>
+    </dl>
 
     <!-- Tyre Details -->
     <table class="govuk-table">
@@ -40,13 +40,13 @@
     </table>
 
     <!-- Tyre Use Code (HGV/TRL Only) -->
-    <ng-container *ngIf="vm.techRecord_vehicleType === VehicleTypes.HGV || vm.techRecord_vehicleType === VehicleTypes.TRL">
+    <dl class="govuk-summary-list"  *ngIf="vm.techRecord_vehicleType === VehicleTypes.HGV || vm.techRecord_vehicleType === VehicleTypes.TRL">
       <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_tyreUseCode')">
         <dt class="govuk-summary-list__key">Tyre Use Code</dt>
         <dd class="govuk-summary-list__value" id="test-techRecord_tyreUseCode">
           {{ vm.techRecord_tyreUseCode | defaultNullOrEmpty }}
         </dd>
       </div>
-    </ng-container>
-  </dl>
+    </dl>
+  </ng-container>
 </ng-container>


### PR DESCRIPTION
## VTM - DFS - Tyre use code field results on the review page looks to be far too right on the page in dev2

[CB2-15824](https://dvsa.atlassian.net/browse/CB2-15824)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
