### PR TITLE
feat(CB2-15809): fix notes not showing dash when empty

### DIFF
--- a/src/app/forms/custom-sections/notes-section/notes-section-view/notes-section-view.component.html
+++ b/src/app/forms/custom-sections/notes-section/notes-section-view/notes-section-view.component.html
@@ -3,19 +3,19 @@
     <div class="govuk-summary-list__row" *ngIf="vm.techRecord_vehicleType !== VehicleTypes.PSV">
       <dt class="govuk-summary-list__key">Notes</dt>
       <dd class="govuk-summary-list__value" id="test-techRecord_notes">
-        {{ vm.techRecord_notes }}
+        {{ vm.techRecord_notes | defaultNullOrEmpty  }}
       </dd>
     </div>
     <div class="govuk-summary-list__row" *ngIf="vm.techRecord_vehicleType === VehicleTypes.PSV">
       <dt class="govuk-summary-list__key">Notes</dt>
       <dd class="govuk-summary-list__value" id="test-techRecord_remarks">
-        {{ vm.techRecord_remarks }}
+        {{ vm.techRecord_remarks | defaultNullOrEmpty  }}
       </dd>
     </div>
     <div class="govuk-summary-list__row" *ngIf="vm.techRecord_vehicleType === VehicleTypes.PSV">
       <dt class="govuk-summary-list__key">Dispensations</dt>
       <dd class="govuk-summary-list__value" id="test-techRecord_dispensations">
-        {{ vm.techRecord_dispensations }}
+        {{ vm.techRecord_dispensations | defaultNullOrEmpty  }}
       </dd>
     </div>
   </dl>


### PR DESCRIPTION
## VTM - DFS - Notes field does not have dashes on empty field in view mode in dev1

[CB2-15809](https://dvsa.atlassian.net/browse/CB2-15809)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
