### PR TITLE
fix(CB2-16141): only show UN numbers that have changed

### DIFF
--- a/src/app/forms/custom-sections/adr-section/adr-section-summary/adr-section-summary.component.html
+++ b/src/app/forms/custom-sections/adr-section/adr-section-summary/adr-section-summary.component.html
@@ -168,7 +168,7 @@
               </div>
               <ng-container *ngIf="hasChanged('techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo')">
                 <ng-container *ngFor="let unNo of amended.techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo; let i = index">
-                  <div class="govuk-summary-list__row">
+                  <div class="govuk-summary-list__row" *ngIf="hasUNNumberChanged(i)">
                     <dt class="govuk-summary-list__key">UN number {{ i + 1 }}</dt>
                     <dd class="govuk-summary-list__value" id="test-techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo-{{ i }}">
                       {{ unNo | defaultNullOrEmpty }}

--- a/src/app/forms/custom-sections/adr-section/adr-section-summary/adr-section-summary.component.ts
+++ b/src/app/forms/custom-sections/adr-section/adr-section-summary/adr-section-summary.component.ts
@@ -107,5 +107,14 @@ export class AdrSectionSummaryComponent {
 		].some((hasChanged) => hasChanged);
 	}
 
-	protected readonly techRecord = techRecord;
+	hasUNNumberChanged(index: number) {
+		const current = this.currentTechRecord() as ADRTechRecord;
+		const amended = this.amendedTechRecord() as ADRTechRecord;
+		if (!current || !amended) return true;
+
+		return !isEqual(
+			current.techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?.[index],
+			amended.techRecord_adrDetails_tank_tankDetails_tankStatement_productListUnNo?.[index]
+		);
+	}
 }


### PR DESCRIPTION
## VTM - Adding another "UN Numbers" should only show the new "UN Numbers" added on the review page

_One line description_
[CB2-16141](https://dvsa.atlassian.net/browse/CB2-16141)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
