### PR TITLE
fix(CB2-16507): add headers in view mode

### DIFF
--- a/src/app/forms/custom-sections/dimensions-section/dimensions-section-view/dimensions-section-view.component.html
+++ b/src/app/forms/custom-sections/dimensions-section/dimensions-section-view/dimensions-section-view.component.html
@@ -170,6 +170,10 @@
           {{ tr.techRecord_centreOfRearmostAxleToRearOfTrl | defaultNullOrEmpty }}
         </dd>
       </div>
+    </dl>
+
+    <h3 class="govuk-heading-m">Coupling centre to rear axle</h3>
+    <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Minimum
@@ -186,6 +190,10 @@
           {{ tr.techRecord_couplingCenterToRearAxleMax | defaultNullOrEmpty }}
         </dd>
       </div>
+    </dl>
+
+    <h3 class="govuk-heading-m">Coupling centre to rear trailer</h3>
+    <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Minimum


### PR DESCRIPTION
## VTM - DFS - Dimensions - TRL - Coupling centre headings missing in view mode

[CB2-16507](https://dvsa.atlassian.net/browse/CB2-16507)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-16507]: https://dvsa.atlassian.net/browse/CB2-16507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ