### PR TITLE
fix(CB2-16500): consistent ordering of fields

### DIFF
--- a/src/app/forms/custom-sections/dimensions-section/dimensions-section-summary/dimensions-section-summary.component.html
+++ b/src/app/forms/custom-sections/dimensions-section/dimensions-section-summary/dimensions-section-summary.component.html
@@ -14,6 +14,12 @@
           {{ vm.techRecord_dimensions_width }}
         </dd>
       </div>
+      <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_frontAxleToRearAxle')">
+        <dt class="govuk-summary-list__key">Front axle to rear axle</dt>
+        <dd class="govuk-summary-list__value" id="test-techRecord_frontAxleToRearAxle">
+          {{ vm.techRecord_frontAxleToRearAxle }}
+        </dd>
+      </div>
       <ng-container *ngFor="let axleSpacing of vm.techRecord_dimensions_axleSpacing; let i = index">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
@@ -24,12 +30,6 @@
           </dd>
         </div>
       </ng-container>
-      <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_frontAxleToRearAxle')">
-        <dt class="govuk-summary-list__key">Front axle to rear axle</dt>
-        <dd class="govuk-summary-list__value" id="test-techRecord_frontAxleToRearAxle">
-          {{ vm.techRecord_frontAxleToRearAxle }}
-        </dd>
-      </div>
     </dl>
 
     <h3 class="govuk-heading-m">Front of vehicle to 5th wheel coupling</h3>
@@ -110,16 +110,6 @@
           {{ vm.techRecord_dimensions_width }}
         </dd>
       </div>
-      <ng-container *ngFor="let axleSpacing of vm.techRecord_dimensions_axleSpacing; let i = index">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Axle {{ i + 1 }} to axle {{ i + 2 }} (mm)
-          </dt>
-          <dd class="govuk-summary-list__value" id="techRecord_dimensions_axleSpacing-{{ i + 1 }}">
-            {{ axleSpacing?.value | defaultNullOrEmpty }}
-          </dd>
-        </div>
-      </ng-container>
       <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_frontAxleToRearAxle')">
         <dt class="govuk-summary-list__key">Front axle to rear axle</dt>
         <dd class="govuk-summary-list__value" id="test-techRecord_frontAxleToRearAxle">
@@ -132,12 +122,16 @@
           {{ vm.techRecord_rearAxleToRearTrl }}
         </dd>
       </div>
-      <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_centreOfRearmostAxleToRearOfTrl')">
-        <dt class="govuk-summary-list__key">Centre of rear axle to rear of trailer</dt>
-        <dd class="govuk-summary-list__value" id="test-techRecord_centreOfRearmostAxleToRearOfTrl">
-          {{ vm.techRecord_centreOfRearmostAxleToRearOfTrl }}
-        </dd>
-      </div>
+      <ng-container *ngFor="let axleSpacing of vm.techRecord_dimensions_axleSpacing; let i = index">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Axle {{ i + 1 }} to axle {{ i + 2 }} (mm)
+          </dt>
+          <dd class="govuk-summary-list__value" id="techRecord_dimensions_axleSpacing-{{ i + 1 }}">
+            {{ axleSpacing?.value | defaultNullOrEmpty }}
+          </dd>
+        </div>
+      </ng-container>
     </dl>
 
     <h3 class="govuk-heading-m">Coupling centre to rear axle</h3>
@@ -168,6 +162,15 @@
         <dt class="govuk-summary-list__key">Maximum</dt>
         <dd class="govuk-summary-list__value" id="test-techRecord_couplingCenterToRearTrlMax">
           {{ vm.techRecord_couplingCenterToRearTrlMax }}
+        </dd>
+      </div>
+    </dl>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row" *ngIf="hasChanged('techRecord_centreOfRearmostAxleToRearOfTrl')">
+        <dt class="govuk-summary-list__key">Centre of rear axle to rear of trailer</dt>
+        <dd class="govuk-summary-list__value" id="test-techRecord_centreOfRearmostAxleToRearOfTrl">
+          {{ vm.techRecord_centreOfRearmostAxleToRearOfTrl }}
         </dd>
       </div>
     </dl>

--- a/src/app/forms/custom-sections/dimensions-section/dimensions-section-view/dimensions-section-view.component.html
+++ b/src/app/forms/custom-sections/dimensions-section/dimensions-section-view/dimensions-section-view.component.html
@@ -18,6 +18,14 @@
           {{ tr.techRecord_dimensions_width | defaultNullOrEmpty}}
         </dd>
       </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Front axle to rear axle
+        </dt>
+        <dd class="govuk-summary-list__value" id="techRecord_frontAxleToRearAxle">
+          {{ tr.techRecord_frontAxleToRearAxle | defaultNullOrEmpty }}
+        </dd>
+      </div>
       <ng-container *ngFor="let axleSpacing of tr.techRecord_dimensions_axleSpacing; let i = index">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
@@ -28,14 +36,6 @@
           </dd>
         </div>
       </ng-container>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Front axle to rear axle
-        </dt>
-        <dd class="govuk-summary-list__value" id="techRecord_frontAxleToRearAxle">
-          {{ tr.techRecord_frontAxleToRearAxle | defaultNullOrEmpty }}
-        </dd>
-      </div>
     </dl>
     
     <h3 class="govuk-heading-m">Front of vehicle to 5th wheel coupling</h3>
@@ -136,16 +136,6 @@
           {{ tr.techRecord_dimensions_width | defaultNullOrEmpty }}
         </dd>
       </div>
-      <ng-container *ngFor="let axleSpacing of tr.techRecord_dimensions_axleSpacing; let i = index">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Axle {{ i + 1 }} to axle {{ i + 2 }} (mm)
-          </dt>
-          <dd class="govuk-summary-list__value" id="techRecord_dimensions_axleSpacing-{{ i + 1 }}">
-            {{ axleSpacing?.value | defaultNullOrEmpty }}
-          </dd>
-        </div>
-      </ng-container>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Front axle to rear axle
@@ -162,14 +152,16 @@
           {{ tr.techRecord_rearAxleToRearTrl | defaultNullOrEmpty }}
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Centre of rear axle to rear of trailer
-        </dt>
-        <dd class="govuk-summary-list__value" id="techRecord_centreOfRearmostAxleToRearOfTrl">
-          {{ tr.techRecord_centreOfRearmostAxleToRearOfTrl | defaultNullOrEmpty }}
-        </dd>
-      </div>
+      <ng-container *ngFor="let axleSpacing of tr.techRecord_dimensions_axleSpacing; let i = index">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Axle {{ i + 1 }} to axle {{ i + 2 }} (mm)
+          </dt>
+          <dd class="govuk-summary-list__value" id="techRecord_dimensions_axleSpacing-{{ i + 1 }}">
+            {{ axleSpacing?.value | defaultNullOrEmpty }}
+          </dd>
+        </div>
+      </ng-container>
     </dl>
 
     <h3 class="govuk-heading-m">Coupling centre to rear axle</h3>
@@ -208,6 +200,17 @@
         </dt>
         <dd class="govuk-summary-list__value" id="techRecord_couplingCenterToRearTrlMax">
           {{ tr.techRecord_couplingCenterToRearTrlMax | defaultNullOrEmpty }}
+        </dd>
+      </div>
+    </dl>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Centre of rear axle to rear of trailer
+        </dt>
+        <dd class="govuk-summary-list__value" id="techRecord_centreOfRearmostAxleToRearOfTrl">
+          {{ tr.techRecord_centreOfRearmostAxleToRearOfTrl | defaultNullOrEmpty }}
         </dd>
       </div>
     </dl>


### PR DESCRIPTION
## VTM - DFS - Dimensions - TRL - View mode/Review screen has fields in a different place to create/amend mode

[CB2-16500](https://dvsa.atlassian.net/browse/CB2-16500)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-16500]: https://dvsa.atlassian.net/browse/CB2-16500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ