### PR TITLE
feat(CB2-16786): hide prepare name and id for DBA tests

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-psv-hgv-vehicle-section.template.ts
@@ -80,6 +80,7 @@ export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
 			value: '',
 			type: FormNodeTypes.CONTROL,
 			viewType: FormNodeViewTypes.HIDDEN,
+			editType: FormNodeEditTypes.HIDDEN,
 		},
 		{
 			name: 'preparerId',
@@ -87,6 +88,7 @@ export const DeskBasedVehicleSectionDefaultPsvHgv: FormNode = {
 			value: '',
 			type: FormNodeTypes.CONTROL,
 			viewType: FormNodeViewTypes.HIDDEN,
+			editType: FormNodeEditTypes.HIDDEN,
 		},
 		{
 			name: 'make',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-default-trl-vehicle-section.template.ts
@@ -59,6 +59,7 @@ export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
 			value: '',
 			type: FormNodeTypes.CONTROL,
 			viewType: FormNodeViewTypes.HIDDEN,
+			editType: FormNodeEditTypes.HIDDEN,
 		},
 		{
 			name: 'preparerId',
@@ -66,6 +67,7 @@ export const DeskBasedVehicleSectionDefaultTrl: FormNode = {
 			value: '',
 			type: FormNodeTypes.CONTROL,
 			viewType: FormNodeViewTypes.HIDDEN,
+			editType: FormNodeEditTypes.HIDDEN,
 		},
 		{
 			name: 'make',

--- a/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/vehicle/desk-based-test-hgv-vehicle-section-group1And2And4.template.ts
@@ -73,6 +73,7 @@ export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
 			value: '',
 			type: FormNodeTypes.CONTROL,
 			viewType: FormNodeViewTypes.HIDDEN,
+			editType: FormNodeEditTypes.HIDDEN,
 		},
 		{
 			name: 'preparerId',
@@ -80,6 +81,7 @@ export const DeskBasedVehicleSectionHgvGroup1And2And4: FormNode = {
 			value: '',
 			type: FormNodeTypes.CONTROL,
 			viewType: FormNodeViewTypes.HIDDEN,
+			editType: FormNodeEditTypes.HIDDEN,
 		},
 		{
 			name: 'make',


### PR DESCRIPTION
## VTM - Hide Preparer name and Preparer id when creating a Desk Based Assessment

_One line description_
[CB2-16786](https://dvsa.atlassian.net/browse/CB2-16786)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-16786]: https://dvsa.atlassian.net/browse/CB2-16786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ