### PR TITLE
fix(CB2-17793): ensure disabled fields propagate their values

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -222,7 +222,9 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, AfterViewI
 			}
 		});
 
-		this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((changes) => {
+		this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+			const changes = this.form.getRawValue();
+
 			// TODO: remove hacky solution
 			let techRecord = this.techRecordCalculated as TechRecordType<'put'>;
 			if (


### PR DESCRIPTION
## VTM - EU Vehicle Category does not auto-populate in view mode upon creation or amending of a vehicle that auto-populates field (CAR/LGV)

_One line description_
[CB2-17793](https://dvsa.atlassian.net/browse/CB2-17793)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-17793]: https://dvsa.atlassian.net/browse/CB2-17793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ