### PR TITLE
fix(CB2-16933): display abandon reasons on separate lines

### DIFF
--- a/src/app/forms/components/view-list-item/view-list-item.component.html
+++ b/src/app/forms/components/view-list-item/view-list-item.component.html
@@ -36,15 +36,15 @@
     @default {
       @if (name() === 'reasonForAbandoning') {
         @let reasons = value?.split('.') || [];
-        <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-wrap">
+        <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-line">
           @for (reason of reasons; track reason;let index = $index;) {
-            <tr [id]="customId() ? 'test-' + customId() : 'test-' + name() + index" class="break-all whitespace-pre-wrap">
+            <tr [id]="customId() ? 'test-' + customId() + index : 'test-' + name() + index" class="break-all whitespace-pre-line padding-vertical-half">
               {{ reason | refDataDecode$: control?.meta?.referenceData | async | getControlLabel: control?.meta?.options | defaultNullOrEmpty }}.
             </tr>
           }
         </td>
       } @else {
-        <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-wrap">
+        <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-line">
           {{ value | refDataDecode$: control?.meta?.referenceData | async | getControlLabel: control?.meta?.options | defaultNullOrEmpty }}
         </td>
       }

--- a/src/app/forms/components/view-list-item/view-list-item.component.html
+++ b/src/app/forms/components/view-list-item/view-list-item.component.html
@@ -34,9 +34,20 @@
       }
     }
     @default {
-      <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-wrap">
-        {{ value | refDataDecode$: control?.meta?.referenceData | async | getControlLabel: control?.meta?.options | defaultNullOrEmpty }}
-      </td>
+      @if (name() === 'reasonForAbandoning') {
+        @let reasons = value?.split('.') || [];
+        <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-wrap">
+          @for (reason of reasons; track reason;let index = $index;) {
+            <tr [id]="customId() ? 'test-' + customId() : 'test-' + name() + index" class="break-all whitespace-pre-wrap">
+              {{ reason | refDataDecode$: control?.meta?.referenceData | async | getControlLabel: control?.meta?.options | defaultNullOrEmpty }}.
+            </tr>
+          }
+        </td>
+      } @else {
+        <td [id]="customId() ? 'test-' + customId() : 'test-' + name()" class="govuk-table__cell break-all whitespace-pre-wrap">
+          {{ value | refDataDecode$: control?.meta?.referenceData | async | getControlLabel: control?.meta?.options | defaultNullOrEmpty }}
+        </td>
+      }
     }
   }
 }

--- a/src/global-styles.scss
+++ b/src/global-styles.scss
@@ -22,7 +22,7 @@
 }
 
 .whitespace-pre-wrap {
-  white-space: pre;
+  white-space: pre-line;
   text-wrap: wrap;
 }
 

--- a/src/global-styles.scss
+++ b/src/global-styles.scss
@@ -22,7 +22,7 @@
 }
 
 .whitespace-pre-wrap {
-  white-space: pre-line;
+  white-space: pre;
   text-wrap: wrap;
 }
 
@@ -210,4 +210,9 @@
       @extend .govuk-label--m;
     }
   }
+}
+
+.padding-vertical-half {
+  display: block;
+  padding: .5rem 0 !important;
 }


### PR DESCRIPTION
## display abandon reasons on separate lines

_One line description_
[CB2-16933](https://dvsa.atlassian.net/browse/CB2-16933)

BEFORE:
<img width="1027" alt="Screenshot 2025-05-21 at 20 20 29" src="https://github.com/user-attachments/assets/e4d5713e-800e-4d78-a9df-f04659e752ab" />

AFTER:
- 1 reason
<img width="1041" alt="Screenshot 2025-05-21 at 20 19 34" src="https://github.com/user-attachments/assets/fe173010-c27c-4dd6-8f79-491547ce04a9" />

- multiple reasons 
<img width="1021" alt="Screenshot 2025-05-21 at 20 20 07" src="https://github.com/user-attachments/assets/6c9f44e8-262d-4d5d-bc32-4940a0342226" />

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-16933]: https://dvsa.atlassian.net/browse/CB2-16933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ