### PR TITLE
feat(CB2-16684): enable hgv and psv eu vehicle category filtering

### DIFF
--- a/src/app/forms/validators/custom-async-validator/custom-async-validators.ts
+++ b/src/app/forms/validators/custom-async-validator/custom-async-validators.ts
@@ -4,7 +4,9 @@ import { Condition, operatorEnum } from '@models/condition.model';
 import {
 	ALL_EU_VEHICLE_CATEGORY_OPTIONS,
 	CAR_EU_VEHICLE_CATEGORY_OPTIONS,
+	HGV_EU_VEHICLE_CATEGORY_OPTIONS,
 	LGV_EU_VEHICLE_CATEGORY_OPTIONS,
+	PSV_EU_VEHICLE_CATEGORY_OPTIONS,
 	SMALL_TRL_EU_VEHICLE_CATEGORY_OPTIONS,
 	TRL_EU_VEHICLE_CATEGORY_OPTIONS,
 } from '@models/options.model';
@@ -242,13 +244,12 @@ export class CustomAsyncValidators {
 						case VehicleTypes.SMALL_TRL:
 							control.meta.options = SMALL_TRL_EU_VEHICLE_CATEGORY_OPTIONS;
 							break;
-						// TODO uncomment these to enable HGV and PSV filtering
-						// case VehicleTypes.HGV:
-						//   control.meta.options = HGV_EU_VEHICLE_CATEGORY_OPTIONS;
-						//   break;
-						// case VehicleTypes.PSV:
-						//   control.meta.options = PSV_EU_VEHICLE_CATEGORY_OPTIONS;
-						//   break;
+						case VehicleTypes.HGV:
+							control.meta.options = HGV_EU_VEHICLE_CATEGORY_OPTIONS;
+							break;
+						case VehicleTypes.PSV:
+							control.meta.options = PSV_EU_VEHICLE_CATEGORY_OPTIONS;
+							break;
 						default:
 							control.meta.options = ALL_EU_VEHICLE_CATEGORY_OPTIONS;
 							break;


### PR DESCRIPTION
## VTM - EU Vehicle Category selection applies to specific vehicle types for HGV and PSV test result

[CB2-16684](https://dvsa.atlassian.net/browse/CB2-16684)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-16684]: https://dvsa.atlassian.net/browse/CB2-16684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ