### PR TITLE
fix(CB2-17395): allow input focus from global error message

### DIFF
--- a/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
+++ b/src/app/features/tech-record/components/tech-record-amend-vin/tech-record-amend-vin.component.ts
@@ -117,7 +117,7 @@ export class AmendVinComponent implements OnDestroy, OnInit {
 		this.form = new FormGroup({
 			vin: new CustomFormControl(
 				{
-					name: 'input-vin',
+					name: 'vin',
 					label: 'VIN',
 					type: FormNodeTypes.CONTROL,
 				},


### PR DESCRIPTION
## VTM: Changing VIN Global Validation Does Not Focus On The Property

[CB2-17395](https://dvsa.atlassian.net/browse/CB2-17395)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-17395]: https://dvsa.atlassian.net/browse/CB2-17395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ