### PR TITLE
feat(CB2-17680): default eu vehicle category when changing vehicle type

### DIFF
--- a/src/app/store/technical-records/__tests__/technical-record-service.effects.spec.ts
+++ b/src/app/store/technical-records/__tests__/technical-record-service.effects.spec.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, fakeAsync, flush } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { TechRecordType as V3TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb-vehicle-type';
 import { V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
@@ -274,6 +275,7 @@ describe('TechnicalRecordServiceEffects', () => {
 			const techRecordServiceSpy = jest.spyOn(technicalRecordService, 'updateEditingTechRecord');
 			const expectedTechRecord = getEmptyTechRecord();
 			expectedTechRecord.techRecord_vehicleType = VehicleTypes.CAR;
+			expectedTechRecord.techRecord_euVehicleCategory = EUVehicleCategory.M1;
 
 			store.overrideSelector(editingTechRecord, {
 				vin: 'foo',

--- a/src/app/store/technical-records/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.ts
@@ -1,9 +1,13 @@
 import { Injectable, inject } from '@angular/core';
+import { EUVehicleCategory as EUVehicleCategoryCAR } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryCar.enum.js';
+import { EUVehicleCategory as EUVehicleCategoryLGV } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryLgv.enum.js';
 import { EUVehicleCategory as EUVehicleCategoryTRL } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategoryTrl.enum.js';
 import { VehicleClassDescription } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/vehicleClassDescription.enum.js';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import {
+	TechRecordGETCar,
 	TechRecordGETHGV,
+	TechRecordGETLGV,
 	TechRecordGETPSV,
 	TechRecordGETTRL,
 } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb-vehicle-type';
@@ -265,9 +269,24 @@ export class TechnicalRecordServiceEffects {
 						(mergedForms as TechRecordGETHGV).techRecord_vehicleClass_description =
 							VehicleClassDescription.HeavyGoodsVehicle;
 					}
+
 					if (techRecord_vehicleType === VehicleTypes.TRL) {
 						(mergedForms as TechRecordGETTRL).techRecord_vehicleClass_description = VehicleClassDescription.Trailer;
 						(mergedForms as TechRecordGETTRL).techRecord_euVehicleCategory = null;
+					}
+
+					if (
+						techRecord_vehicleType === VehicleTypes.CAR &&
+						(mergedForms as TechRecordGETCar).techRecord_euVehicleCategory !== EUVehicleCategoryCAR.M1
+					) {
+						(mergedForms as TechRecordGETCar).techRecord_euVehicleCategory = EUVehicleCategoryCAR.M1;
+					}
+
+					if (
+						techRecord_vehicleType === VehicleTypes.LGV &&
+						(mergedForms as TechRecordGETLGV).techRecord_euVehicleCategory !== EUVehicleCategoryLGV.N1
+					) {
+						(mergedForms as TechRecordGETLGV).techRecord_euVehicleCategory = EUVehicleCategoryLGV.N1;
 					}
 
 					return of(mergedForms);


### PR DESCRIPTION
## VTM: Strip Out EU Vehicle Category When Changing Vehicle Type

[CB2-17680](https://dvsa.atlassian.net/browse/CB2-17680)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-17680]: https://dvsa.atlassian.net/browse/CB2-17680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ