### PR TITLE
fix(CB2-18071): axles validation

### DIFF
--- a/src/app/features/tech-record/components/tech-record-summary/__tests__/tech-record-summary.component.spec.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/__tests__/tech-record-summary.component.spec.ts
@@ -8,7 +8,7 @@ import { TechRecordType as TechRecordTypeByVehicle } from '@dvsa/cvs-type-defini
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
 import { LettersComponent } from '@forms/custom-sections/letters/letters.component';
 import { Roles } from '@models/roles.enum';
-import { V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { FitmentCode, SpeedCategorySymbol, V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { FeatureToggleService } from '@services/feature-toggle-service/feature-toggle-service';
 import { MultiOptionsService } from '@services/multi-options/multi-options.service';
@@ -187,6 +187,97 @@ describe('TechRecordSummaryComponent', () => {
 			component.handleFormState({});
 
 			expect(dispatchSpy).toHaveBeenCalledWith(updateEditingTechRecord({ vehicleTechRecord: mockTechRecord }));
+		});
+	});
+
+	describe('getAxleErrors', () => {
+		it('should return an error if PSV has only one axle', () => {
+			const mockTechRecord = {
+				systemNumber: 'foo',
+				createdTimestamp: 'bar',
+				vin: 'testVin',
+				techRecord_vehicleType: VehicleTypes.PSV,
+				techRecord_axles: [
+					{
+						axleNumber: 1,
+						tyres_dataTrAxles: 1,
+						tyres_fitmentCode: FitmentCode.SINGLE,
+						tyres_speedCategorySymbol: SpeedCategorySymbol.A7,
+						weights_gbWeight: 1000,
+						weights_eecWeight: 1000,
+						weights_designWeight: 1000,
+					},
+				],
+			} as unknown as TechRecordType<'put'>;
+			jest.spyOn(component.form, 'getRawValue').mockReturnValue(mockTechRecord);
+
+			const errors = component.getAxleErrors();
+
+			expect(errors).toEqual([
+				{ error: 'You cannot submit a PSV with less than 2 axles', anchorLink: 'weightsAddAxle' },
+			]);
+		});
+
+		it('should return an error if HGV has only one axle', () => {
+			const mockTechRecord = {
+				systemNumber: 'foo',
+				createdTimestamp: 'bar',
+				vin: 'testVin',
+				techRecord_vehicleType: VehicleTypes.HGV,
+				techRecord_axles: [
+					{
+						axleNumber: 1,
+						tyres_dataTrAxles: 1,
+						tyres_fitmentCode: FitmentCode.SINGLE,
+						tyres_speedCategorySymbol: SpeedCategorySymbol.A7,
+						weights_gbWeight: 1000,
+						weights_eecWeight: 1000,
+						weights_designWeight: 1000,
+					},
+				],
+			} as unknown as TechRecordType<'put'>;
+			component.techRecordCalculated = mockTechRecord;
+			jest.spyOn(component.form, 'getRawValue').mockReturnValue(mockTechRecord);
+
+			const errors = component.getAxleErrors();
+
+			expect(errors).toEqual([
+				{ error: 'You cannot submit a HGV with less than 2 axles', anchorLink: 'weightsAddAxle' },
+			]);
+		});
+
+		it('should return an empty array if PSV has two or more axles', () => {
+			const mockTechRecord = {
+				systemNumber: 'foo',
+				createdTimestamp: 'bar',
+				vin: 'testVin',
+				techRecord_vehicleType: VehicleTypes.PSV,
+				techRecord_axles: [
+					{
+						axleNumber: 1,
+						tyres_dataTrAxles: 1,
+						tyres_fitmentCode: FitmentCode.SINGLE,
+						tyres_speedCategorySymbol: SpeedCategorySymbol.A7,
+						weights_gbWeight: 1000,
+						weights_eecWeight: 1000,
+						weights_designWeight: 1000,
+					},
+					{
+						axleNumber: 2,
+						tyres_dataTrAxles: 1,
+						tyres_fitmentCode: FitmentCode.SINGLE,
+						tyres_speedCategorySymbol: SpeedCategorySymbol.A7,
+						weights_gbWeight: 1000,
+						weights_eecWeight: 1000,
+						weights_designWeight: 1000,
+					},
+				],
+			} as unknown as TechRecordType<'put'>;
+			jest.spyOn(component.form, 'getRawValue').mockReturnValue(mockTechRecord);
+
+			const errors = component.getAxleErrors();
+
+			expect(errors).toEqual([]);
 		});
 	});
 });

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -376,6 +376,7 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, AfterViewI
 		errors.push(...this.globalErrorService.extractGlobalErrors(this.form));
 
 		if (errors.length) {
+			this.form.setErrors(errors);
 			this.errorService.setErrors(errors);
 		} else {
 			this.errorService.clearErrors();

--- a/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary/tech-record-summary.component.ts
@@ -372,6 +372,7 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, AfterViewI
 
 		this.form.markAllAsTouched();
 		this.form.updateValueAndValidity();
+		errors.push(...this.getAxleErrors());
 		errors.push(...this.globalErrorService.extractGlobalErrors(this.form));
 
 		if (errors.length) {
@@ -379,6 +380,28 @@ export class TechRecordSummaryComponent implements OnInit, OnDestroy, AfterViewI
 		} else {
 			this.errorService.clearErrors();
 		}
+	}
+
+	getAxleErrors(): GlobalError[] {
+		const value = this.form.getRawValue() as V3TechRecordModel;
+
+		if (
+			value.techRecord_vehicleType === VehicleTypes.PSV &&
+			Array.isArray(value.techRecord_axles) &&
+			value.techRecord_axles.length === 1
+		) {
+			return [{ error: 'You cannot submit a PSV with less than 2 axles', anchorLink: 'weightsAddAxle' }];
+		}
+
+		if (
+			value.techRecord_vehicleType === VehicleTypes.HGV &&
+			Array.isArray(value.techRecord_axles) &&
+			value.techRecord_axles.length === 1
+		) {
+			return [{ error: 'You cannot submit a HGV with less than 2 axles', anchorLink: 'weightsAddAxle' }];
+		}
+
+		return [];
 	}
 
 	private normaliseAxles(record: V3TechRecordModel): V3TechRecordModel {


### PR DESCRIPTION
## VTM INT: Tyres & Weights 'Less Than 2 Axles' Validation Missing

[CB2-18071](https://dvsa.atlassian.net/browse/CB2-18071)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18071]: https://dvsa.atlassian.net/browse/CB2-18071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ