### PR TITLE
fix(CB2-16009): VTM: Display of TrailerID on Review Screen Missing 'Gap' in Wording

### DIFF
--- a/src/app/features/search/single-search-result/single-search-result.component.html
+++ b/src/app/features/search/single-search-result/single-search-result.component.html
@@ -25,7 +25,7 @@
       @if (searchResult().techRecord_vehicleType === 'trl') {
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            TrailerID:
+            Trailer ID:
           </dt>
           <dd class="govuk-summary-list__value" id="test-trailerId">
             <app-number-plate [vrm]="searchResult().trailerId"></app-number-plate>

--- a/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.html
+++ b/src/app/features/tech-record/components/tech-record-change-type/tech-record-change-type.component.html
@@ -10,7 +10,7 @@
 
   @if (techRecord?.techRecord_vehicleType === VehicleTypes.TRL) {
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">TrailerID</dt>
+      <dt class="govuk-summary-list__key">Trailer ID</dt>
       <dd id="vehicleType" class="govuk-summary-list__value">
         <app-number-plate [vrm]="$any(techRecord)?.trailerId | defaultNullOrEmpty" />
       </dd>

--- a/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary-changes/tech-record-summary-changes.component.html
@@ -14,7 +14,7 @@
     </div>
     @if (techRecordEdited.techRecord_vehicleType === 'trl') {
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">TrailerID</dt>
+        <dt class="govuk-summary-list__key">Trailer ID</dt>
         <dd class="govuk-summary-list__value" id="test-trailerId">
           <app-number-plate [vrm]="techRecordEdited.trailerId | defaultNullOrEmpty" />
         </dd>

--- a/src/app/features/tech-record/create/__tests__/create-tech-record.component.spec.ts
+++ b/src/app/features/tech-record/create/__tests__/create-tech-record.component.spec.ts
@@ -198,7 +198,7 @@ describe('CreateNewVehicleRecordComponent', () => {
 			const result = await component.isTrailerIdUnique();
 
 			expect(addErrorSpy).toHaveBeenCalledWith({
-				error: 'TrailerId not unique',
+				error: 'Trailer ID must be unique',
 				anchorLink: 'input-vrm-or-trailer-id',
 			});
 			expect(result).toBeFalsy();

--- a/src/app/features/tech-record/create/create-tech-record.component.ts
+++ b/src/app/features/tech-record/create/create-tech-record.component.ts
@@ -227,7 +227,7 @@ export class CreateTechRecordComponent implements OnChanges {
 				this.technicalRecordService.isUnique(this.techRecord.trailerId as string, SEARCH_TYPES.TRAILER_ID)
 			);
 			if (!isTrailerIdUnique) {
-				this.globalErrorService.addError({ error: 'TrailerId not unique', anchorLink: 'input-vrm-or-trailer-id' });
+				this.globalErrorService.addError({ error: 'Trailer ID must be unique', anchorLink: 'input-vrm-or-trailer-id' });
 			}
 			return isTrailerIdUnique;
 		}


### PR DESCRIPTION
## VTM: Display of TrailerID on Review Screen Missing 'Gap' in Wording

[CB2-16009](https://dvsa.atlassian.net/browse/CB2-16009)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-16009]: https://dvsa.atlassian.net/browse/CB2-16009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ