### PR TITLE
fix(CB2-18520): VTM - Weights section Axle 1/Axle 2/etc validation messages does not show number of axle and does not focus when clicked on in global validation message

### DIFF
--- a/src/app/core/components/global-error/global-error.service.ts
+++ b/src/app/core/components/global-error/global-error.service.ts
@@ -87,14 +87,20 @@ export class GlobalErrorService {
 			if (control instanceof FormGroup || control instanceof FormArray) {
 				if (control.invalid && control.errors) {
 					Object.values(control.errors).forEach((error) => {
-						errors.push({ error, anchorLink: key });
+						errors.push({
+							error: typeof error === 'string' ? error : error.error,
+							anchorLink: typeof error === 'string' ? key : error.anchorLink,
+						});
 					});
 				}
 
 				errors.push(...this.extractGlobalErrors(control));
 			} else if (control.invalid && control.errors) {
 				Object.values(control.errors).forEach((error) => {
-					errors.push({ error, anchorLink: key });
+					errors.push({
+						error: typeof error === 'string' ? error : error.error,
+						anchorLink: typeof error === 'string' ? key : error.anchorLink,
+					});
 				});
 			}
 		});

--- a/src/app/forms/components/govuk-form-group-input/govuk-form-group-input.component.html
+++ b/src/app/forms/components/govuk-form-group-input/govuk-form-group-input.component.html
@@ -19,9 +19,10 @@
   }
 
   @if (hasError) {
+    @let firstError = (control?.errors | keyvalue)?.[0]?.value;
     <p class="govuk-error-message" id="{{ errorId }}">
       <span class="govuk-visually-hidden">Error: </span>
-      <span>{{ (control?.errors | keyvalue)?.[0]?.value }}</span>
+      <span>{{ (typeof firstError === 'string' ? firstError : firstError.error) }}</span>
     </p>
   }
 

--- a/src/app/forms/custom-sections/weights-section/weights-section-edit/weights-section-edit.component.ts
+++ b/src/app/forms/custom-sections/weights-section/weights-section-edit/weights-section-edit.component.ts
@@ -1,6 +1,6 @@
 import { KeyValuePipe } from '@angular/common';
 import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input, output } from '@angular/core';
-import { FormArray, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { AbstractControl, FormArray, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TagComponent } from '@components/tag/tag.component';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
@@ -8,6 +8,7 @@ import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions, ofType } from '@ngrx/effects';
 import { FormNodeWidth } from '@services/dynamic-forms/dynamic-form.types';
 import { addAxle, removeAxle, updateBrakeForces } from '@store/technical-records';
+import _ from 'lodash';
 import { ReplaySubject, takeUntil } from 'rxjs';
 import { withLatestFrom } from 'rxjs/operators';
 import { GovukFormGroupInputComponent } from '../../../components/govuk-form-group-input/govuk-form-group-input.component';
@@ -111,7 +112,13 @@ export class WeightsSectionEditComponent extends EditBaseComponent implements On
 		return this.fb.group({
 			axleNumber: this.fb.control<number | null>(null),
 			weights_gbWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle GB Weight must be less than or equal to 99999'),
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} GB Weight must be less than or equal to 99999`,
+						anchorLink: `weights_gbWeight-${index + 1}`,
+					};
+				}),
 			]),
 			weights_eecWeight: this.fb.control<number | null>(null, [
 				this.commonValidators.max(99999, 'Axle EEC Weight must be less than or equal to 99999'),

--- a/src/app/forms/custom-sections/weights-section/weights-section-edit/weights-section-edit.component.ts
+++ b/src/app/forms/custom-sections/weights-section/weights-section-edit/weights-section-edit.component.ts
@@ -121,10 +121,22 @@ export class WeightsSectionEditComponent extends EditBaseComponent implements On
 				}),
 			]),
 			weights_eecWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle EEC Weight must be less than or equal to 99999'),
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} EEC Weight must be less than or equal to 99999`,
+						anchorLink: `weights_eecWeight-${index + 1}`,
+					};
+				}),
 			]),
 			weights_designWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle Design Weight must be less than or equal to 99999'),
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} Design Weight must be less than or equal to 99999`,
+						anchorLink: `weights_designWeight-${index + 1}`,
+					};
+				}),
 			]),
 		});
 	}
@@ -133,16 +145,41 @@ export class WeightsSectionEditComponent extends EditBaseComponent implements On
 		return this.fb.group({
 			axleNumber: this.fb.control<number | null>(null),
 			weights_kerbWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle Kerb Weight must be less than or equal to 99999'),
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} Kerb Weight must be less than or equal to 99999`,
+						anchorLink: `weights_kerbWeight-${index + 1}`,
+					};
+				}),
 			]),
 			weights_ladenWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle Laden Weight must be less than or equal to 99999'),
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} Laden Weight must be less than or equal to 99999`,
+						anchorLink: `weights_ladenbWeight-${index + 1}`,
+					};
+				}),
 			]),
-			weights_gbWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle GB Weight must be less than or equal to 99999'),
-			]),
+			weights_gbWeight: this.fb.control<number | null>(
+				null,
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} GB Weight must be less than or equal to 99999`,
+						anchorLink: `weights_gbWeight-${index + 1}`,
+					};
+				})
+			),
 			weights_designWeight: this.fb.control<number | null>(null, [
-				this.commonValidators.max(99999, 'Axle Design Weight must be less than or equal to 99999'),
+				this.commonValidators.max(99999, (control: AbstractControl) => {
+					const index = _.indexOf(this.techRecordAxles.controls, control.parent);
+					return {
+						error: `Axle ${index + 1} Design Weight must be less than or equal to 99999`,
+						anchorLink: `weights_designWeight-${index + 1}`,
+					};
+				}),
 			]),
 		});
 	}

--- a/src/app/forms/validators/common-validators.service.ts
+++ b/src/app/forms/validators/common-validators.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 import validateDate from 'validate-govuk-date';
+import { GlobalError } from '../../core/components/global-error/global-error.interface';
 
 @Injectable({ providedIn: 'root' })
 export class CommonValidatorsService {
@@ -14,10 +15,12 @@ export class CommonValidatorsService {
 		};
 	}
 
-	max(size: number, message: string): ValidatorFn {
+	max(size: number, func: (control: AbstractControl) => GlobalError): ValidatorFn;
+	max(size: number, message: string): ValidatorFn;
+	max(size: number, message: string | ((control: AbstractControl) => GlobalError)): ValidatorFn {
 		return (control) => {
 			if (control.value && control.value > size) {
-				return { max: message };
+				return { max: typeof message === 'string' ? message : message(control) };
 			}
 
 			return null;


### PR DESCRIPTION
## VTM - Weights section Axle 1/Axle 2/etc validation messages does not show number of axle and does not focus when clicked on in global validation message

Draft PR to highlight syntax.

[CB2-18520](https://dvsa.atlassian.net/browse/CB2-18520)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18520]: https://dvsa.atlassian.net/browse/CB2-18520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ