### PR TITLE
fix(CB2-18077): VTM INT: Changing HGV Configuration From Artic to Rigid Bypasses Body Type Validation

### DIFF
--- a/src/app/forms/custom-sections/body-section/body-section-edit/__tests__/body-section-edit.component.spec.ts
+++ b/src/app/forms/custom-sections/body-section/body-section-edit/__tests__/body-section-edit.component.spec.ts
@@ -162,6 +162,19 @@ describe('BodySectionEditComponent', () => {
 			});
 		});
 
+		it('should, for HGVs, set the body type description to null and code to null if rigid is selected, and articulated was previously selected', () => {
+			const formSpy = jest.spyOn(component.form, 'patchValue');
+			const mockTechRecord = mockVehicleTechnicalRecord('hgv');
+			componentRef.setInput('techRecord', mockTechRecord);
+			component.handleUpdateVehicleConfiguration();
+			actions$.next(updateVehicleConfiguration({ vehicleConfiguration: 'articulated' }));
+			actions$.next(updateVehicleConfiguration({ vehicleConfiguration: 'rigid' }));
+			expect(formSpy).toHaveBeenCalledWith({
+				techRecord_bodyType_description: null,
+				techRecord_bodyType_code: null,
+			});
+		});
+
 		it('should, for HGVs set the function code to R if rigid is selected', () => {
 			const formSpy = jest.spyOn(component.form, 'patchValue');
 			const mockTechRecord = mockVehicleTechnicalRecord('hgv');


### PR DESCRIPTION
## VTM INT: Changing HGV Configuration From Artic to Rigid Bypasses Body Type Validation

[CB2-18077](https://dvsa.atlassian.net/browse/CB2-18077)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18077]: https://dvsa.atlassian.net/browse/CB2-18077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ