### PR TITLE
fix(CB2-18086): VTM - Purchasers section - Email Address validation does not read correctly

### DIFF
--- a/src/app/forms/custom-sections/trl-purchasers-section/trl-purchasers-section-edit/trl-purchasers-section-edit.component.ts
+++ b/src/app/forms/custom-sections/trl-purchasers-section/trl-purchasers-section-edit/trl-purchasers-section-edit.component.ts
@@ -118,7 +118,7 @@ export class TRLPurchasersSectionEditComponent implements OnInit, OnDestroy {
 				this.commonValidators.maxLength(255, 'Email address must be less than or equal to 255 characters'),
 				this.commonValidators.pattern(
 					"^[\\w\\-\\.\\+']+@([\\w-]+\\.)+[\\w-]{2,}$",
-					'Email address Enter an email address in the correct format, like name@example.com'
+					'Enter an email address in the correct format, like name@example.com'
 				),
 			]),
 			techRecord_purchaserDetails_faxNumber: this.fb.control(null, [


### PR DESCRIPTION
## VTM - Purchasers section - Email Address validation does not read correctly

[CB2-18086](https://dvsa.atlassian.net/browse/CB2-18086)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18086]: https://dvsa.atlassian.net/browse/CB2-18086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ