### PR TITLE
fix(CB2-18873): VTM - Brakes table is empty when amending a tech record

### DIFF
--- a/src/app/forms/custom-sections/brakes-section/brakes-section-edit/brakes-section-edit.component.ts
+++ b/src/app/forms/custom-sections/brakes-section/brakes-section-edit/brakes-section-edit.component.ts
@@ -146,7 +146,6 @@ export class BrakesSectionEditComponent extends EditBaseComponent implements OnI
 
 	public get psvOnlyFields(): Partial<Record<keyof TechRecordType<'psv'>, FormControl | FormArray>> {
 		return {
-			techRecord_axles: this.fb.array([]),
 			techRecord_brakes_brakeCode: this.fb.control<string | null>(null, []),
 			techRecord_brakes_brakeCodeOriginal: this.fb.control<string | null>(null),
 			techRecord_brakes_dataTrBrakeOne: this.fb.control<string | null>({ value: null, disabled: true }, []),
@@ -161,7 +160,6 @@ export class BrakesSectionEditComponent extends EditBaseComponent implements OnI
 		return {
 			techRecord_brakes_loadSensingValve: this.fb.control<boolean | null>(null, []),
 			techRecord_brakes_antilockBrakingSystem: this.fb.control<boolean | null>(null, []),
-			techRecord_axles: this.fb.array([]),
 		};
 	}
 

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -165,13 +165,13 @@ export class AxlesService {
 			axleNumber: this.fb.control<number | null>(axle?.axleNumber || null),
 
 			// Brakes fields
-			brakes_brakeActuator: this.fb.control<number | null>(null, [
+			brakes_brakeActuator: this.fb.control<number | null>(axle?.brakes_brakeActuator || null, [
 				this.commonValidators.max(999, 'This field must be less than or equal to 999'),
 			]),
-			brakes_leverLength: this.fb.control<number | null>(null, [
+			brakes_leverLength: this.fb.control<number | null>(axle?.brakes_leverLength || null, [
 				this.commonValidators.max(999, 'This field must be less than or equal to 999'),
 			]),
-			brakes_springBrakeParking: this.fb.control<boolean | null>(null, []),
+			brakes_springBrakeParking: this.fb.control<boolean | null>(axle?.brakes_springBrakeParking || null, []),
 			parkingBrakeMrk: this.fb.control<boolean | null>(axle?.parkingBrakeMrk || false, []),
 
 			// Tyres fields

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -171,7 +171,10 @@ export class AxlesService {
 			brakes_leverLength: this.fb.control<number | null>(axle?.brakes_leverLength || null, [
 				this.commonValidators.max(999, 'This field must be less than or equal to 999'),
 			]),
-			brakes_springBrakeParking: this.fb.control<boolean | null>(axle?.brakes_springBrakeParking || null, []),
+			brakes_springBrakeParking: this.fb.control<boolean | null>(
+				typeof axle?.brakes_springBrakeParking === 'boolean' ? axle?.brakes_springBrakeParking : null,
+				[]
+			),
 			parkingBrakeMrk: this.fb.control<boolean | null>(axle?.parkingBrakeMrk || false, []),
 
 			// Tyres fields


### PR DESCRIPTION
## VTM - Brakes table is empty when amending a tech record

[CB2-18873](https://dvsa.atlassian.net/browse/CB2-18873)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18873]: https://dvsa.atlassian.net/browse/CB2-18873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ