### PR TITLE
fix(cb2-18883): fix axles ordering

### DIFF
--- a/src/app/forms/custom-sections/brakes-section/brakes-section-view/brakes-section-view.component.html
+++ b/src/app/forms/custom-sections/brakes-section/brakes-section-view/brakes-section-view.component.html
@@ -109,7 +109,7 @@
   @if (axles.length > 0) {
     <dl class="govuk-summary-list">
       <caption class="govuk-table__caption govuk-table__caption--m">Parking brake</caption>
-      @for (axle of axles; track $index) {
+      @for (axle of axlesService.sortAxles(axles); track $index) {
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Axle {{ axle.axleNumber }}</dt>
           <dd class="govuk-summary-list__value" id="test-parkingBrakeMrk_{{ axle.axleNumber }}"> {{ axle.parkingBrakeMrk | defaultNullOrEmpty }}</dd>

--- a/src/app/forms/custom-sections/brakes-section/brakes-section-view/brakes-section-view.component.ts
+++ b/src/app/forms/custom-sections/brakes-section/brakes-section-view/brakes-section-view.component.ts
@@ -1,8 +1,9 @@
+import { AxlesService } from '@/src/app/services/axles/axles.service';
 import { Component, inject } from '@angular/core';
 import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
 import { TRLAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/skeleton';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
-import { VehicleTypes } from '@models/vehicle-tech-record.model';
+import { Axles, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { DefaultNullOrEmpty } from '@pipes/default-null-or-empty/default-null-or-empty.pipe';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
@@ -20,6 +21,7 @@ export class BrakesSectionViewComponent {
 	protected readonly store = inject<Store<State>>(Store);
 
 	trs = inject(TechnicalRecordService);
+	axlesService = inject(AxlesService);
 	techRecord = this.store.selectSignal(techRecord);
 
 	// TODO: potentially improve this
@@ -28,8 +30,8 @@ export class BrakesSectionViewComponent {
 		return (tr?.techRecord_axles ?? []) as PSVAxles[] | TRLAxles[];
 	}
 
-	getTRLAxles(axles: unknown): TRLAxles[] {
-		return axles as TRLAxles[];
+	getTRLAxles(axles: Axles | null | undefined): TRLAxles[] {
+		return this.axlesService.sortAxles(axles || []) as TRLAxles[];
 	}
 
 	round(n: number): number {

--- a/src/app/forms/custom-sections/tyres-section/tyres-section-view/tyres-section-view.component.html
+++ b/src/app/forms/custom-sections/tyres-section/tyres-section-view/tyres-section-view.component.html
@@ -27,7 +27,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        @for (axle of vm.techRecord_axles; track axle; let i = $index) {
+        @for (axle of axlesService.sortAxles(vm.techRecord_axles || []); track axle; let i = $index) {
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">T{{axle.axleNumber | defaultNullOrEmpty }}</th>
             <td class="govuk-table__cell" id="tyres_tyreCode-{{ i + 1 }}">{{ axle.tyres_tyreCode | defaultNullOrEmpty  }}</td>

--- a/src/app/forms/custom-sections/tyres-section/tyres-section-view/tyres-section-view.component.ts
+++ b/src/app/forms/custom-sections/tyres-section/tyres-section-view/tyres-section-view.component.ts
@@ -1,3 +1,4 @@
+import { AxlesService } from '@/src/app/services/axles/axles.service';
 import { Component, inject } from '@angular/core';
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
@@ -18,6 +19,7 @@ export class TyresSectionViewComponent {
 
 	store = inject(Store);
 	technicalRecordService = inject(TechnicalRecordService);
+	axlesService = inject(AxlesService);
 	techRecord = this.store.selectSignal(techRecord);
 	invalidAxles: Array<number> = [];
 	referenceDataService = inject(ReferenceDataService);

--- a/src/app/forms/custom-sections/weights-section/weights-section-view/weights-section-view.component.html
+++ b/src/app/forms/custom-sections/weights-section/weights-section-view/weights-section-view.component.html
@@ -24,7 +24,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        @for (axle of vm.techRecord_axles; track axle) {
+        @for (axle of axlesService.sortAxles(vm.techRecord_axles || []); track axle) {
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Axle {{axle.axleNumber}}</th>
             @if (vm.techRecord_vehicleType === VehicleTypes.PSV) {

--- a/src/app/forms/custom-sections/weights-section/weights-section-view/weights-section-view.component.ts
+++ b/src/app/forms/custom-sections/weights-section/weights-section-view/weights-section-view.component.ts
@@ -1,3 +1,4 @@
+import { AxlesService } from '@/src/app/services/axles/axles.service';
 import { Component, inject } from '@angular/core';
 import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
@@ -16,5 +17,6 @@ export class WeightsSectionViewComponent {
 
 	store = inject(Store);
 	technicalRecordService = inject(TechnicalRecordService);
+	axlesService = inject(AxlesService);
 	techRecord = this.store.selectSignal(techRecord);
 }

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -15,7 +15,7 @@ export class AxlesService {
 	commonValidators = inject(CommonValidatorsService);
 
 	sortAxles(axles: Axles) {
-		return axles.toSorted((a, b) => (a.axleNumber || 0) - (b.axleNumber || 0));
+		return axles.sort((a, b) => (a.axleNumber || 0) - (b.axleNumber || 0));
 	}
 
 	generateAxlesForm(techRecord: TechRecordType<'hgv' | 'trl' | 'psv'>) {

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -4,7 +4,7 @@ import { HGVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hg
 import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
 import { TRLAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
-import { AxleSpacing, VehicleTypes } from '@models/vehicle-tech-record.model';
+import { AxleSpacing, Axles, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { CommonValidatorsService } from '../../forms/validators/common-validators.service';
 
 @Injectable({
@@ -13,6 +13,10 @@ import { CommonValidatorsService } from '../../forms/validators/common-validator
 export class AxlesService {
 	fb = inject(FormBuilder);
 	commonValidators = inject(CommonValidatorsService);
+
+	sortAxles(axles: Axles) {
+		return axles.toSorted((a, b) => (a.axleNumber || 0) - (b.axleNumber || 0));
+	}
 
 	generateAxlesForm(techRecord: TechRecordType<'hgv' | 'trl' | 'psv'>) {
 		const axles = techRecord.techRecord_axles ?? [];

--- a/src/app/services/axles/axles.service.ts
+++ b/src/app/services/axles/axles.service.ts
@@ -19,11 +19,23 @@ export class AxlesService {
 
 		switch (techRecord.techRecord_vehicleType) {
 			case 'hgv':
-				return this.fb.nonNullable.array(axles.map((axle) => this.generateHGVAxleForm(axle as HGVAxles)));
+				return this.fb.nonNullable.array(
+					axles
+						.map((axle) => this.generateHGVAxleForm(axle as HGVAxles))
+						.sort((a, b) => (a.value.axleNumber || 0) - (b.value.axleNumber || 0))
+				);
 			case 'psv':
-				return this.fb.nonNullable.array(axles.map((axle) => this.generatePSVAxleForm(axle as TRLAxles)));
+				return this.fb.nonNullable.array(
+					axles
+						.map((axle) => this.generatePSVAxleForm(axle as TRLAxles))
+						.sort((a, b) => (a.value.axleNumber || 0) - (b.value.axleNumber || 0))
+				);
 			case 'trl':
-				return this.fb.nonNullable.array(axles.map((axle) => this.generateTRLAxleForm(axle as TRLAxles)));
+				return this.fb.nonNullable.array(
+					axles
+						.map((axle) => this.generateTRLAxleForm(axle as TRLAxles))
+						.sort((a, b) => (a.value.axleNumber || 0) - (b.value.axleNumber || 0))
+				);
 		}
 	}
 


### PR DESCRIPTION
## VTM - Axles displaying in incorrect order for legacy records

[CB2-18883](https://dvsa.atlassian.net/browse/CB2-18883)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18883]: https://dvsa.atlassian.net/browse/CB2-18883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ