### PR TITLE
feat(CB2-18954): hide certificate link for LEC without linked test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cvs-app-vtm",
-  "version": "1.38",
+  "version": "1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cvs-app-vtm",
-      "version": "1.38",
+      "version": "1.39",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^19.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvs-app-vtm",
-  "version": "1.38",
+  "version": "1.39",
   "description": "DVSA CVS Vehicle Testing Management Application",
   "main": "index.js",
   "engines": {

--- a/src/app/components/test-certificate/test-certificate.component.ts
+++ b/src/app/components/test-certificate/test-certificate.component.ts
@@ -31,8 +31,10 @@ export class TestCertificateComponent implements OnInit, OnDestroy {
 			.subscribe(([testResult, isOldIvaOrMsva]) => {
 				if (testResult) {
 					const { testResult: result, testTypeId: id } = testResult.testTypes[0];
+					const isLECWithoutLinkedTest = id === '201';
 					const isIvaOrMsvaTest = TEST_TYPES_GROUP1_SPEC_TEST.includes(id) || TEST_TYPES_GROUP5_SPEC_TEST.includes(id);
-					this.certNotNeeded = isOldIvaOrMsva || (isIvaOrMsvaTest && result !== resultOfTestEnum.fail);
+					this.certNotNeeded =
+						isOldIvaOrMsva || isLECWithoutLinkedTest || (isIvaOrMsvaTest && result !== resultOfTestEnum.fail);
 				}
 			});
 	}


### PR DESCRIPTION
## VTM -  LEC certificate number viewed on test record screen (not displayed as a hyperlink)

[CB2-18954](https://dvsa.atlassian.net/browse/CB2-18954)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18954]: https://dvsa.atlassian.net/browse/CB2-18954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ