### PR TITLE
fix(CB2-19044): ensure trailer id is always a string

### DIFF
--- a/src/app/features/tech-record/create/create-wrapper/create-v2/create-tech-record-v2.component.ts
+++ b/src/app/features/tech-record/create/create-wrapper/create-v2/create-tech-record-v2.component.ts
@@ -192,7 +192,7 @@ export class CreateTechRecordV2Component implements OnInit, OnChanges {
 			vin: this.form.controls.vin.value,
 			techRecord_statusCode: this.form.controls.vehicleStatus.value,
 			techRecord_vehicleType: this.form.controls.vehicleType.value,
-			trailerId: this.form.controls.vehicleType.value === 'trl' ? this.form.controls.vrmTrm.value : undefined,
+			trailerId: this.form.controls.vehicleType.value === 'trl' ? this.form.controls.vrmTrm.value || '' : undefined,
 			primaryVrm: this.form.controls.vehicleType.value === 'trl' ? undefined : this.form.controls.vrmTrm.value || '',
 		} as unknown as TechRecordType<'put'>;
 


### PR DESCRIPTION
## VTM - Unable to create TRL tech record with "Generate C, T or Z number" checked

[CB2-19044](https://dvsa.atlassian.net/browse/CB2-19044)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-19044]: https://dvsa.atlassian.net/browse/CB2-19044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ