### PR TITLE
fix(CB2-19099): correct spelling

### DIFF
--- a/src/app/models/options.model.ts
+++ b/src/app/models/options.model.ts
@@ -132,7 +132,7 @@ export const ALL_VEHICLE_CLASS_DESCRIPTION_OPTIONS: MultiOptions = [
 
 export const MONTHS: MultiOptions = [
 	{ value: 'January', label: 'January' },
-	{ value: 'February', label: 'Febraury' },
+	{ value: 'February', label: 'February' },
 	{ value: 'March', label: 'March' },
 	{ value: 'April', label: 'April' },
 	{ value: 'May', label: 'May' },


### PR DESCRIPTION
## VTM - Month of manufacture for TRL's - February is spelt wrong. Says Febraury

[CB2-19099](https://dvsa.atlassian.net/browse/CB2-19099)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-19099]: https://dvsa.atlassian.net/browse/CB2-19099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ