### PR TITLE
fix(CB2-19261): sort examiner notes without breaking amend

### DIFF
--- a/src/app/forms/custom-sections/adr-section/adr-section-view/adr-section-view.component.html
+++ b/src/app/forms/custom-sections/adr-section/adr-section-view/adr-section-view.component.html
@@ -322,7 +322,7 @@
         </div>
       </dl>
       <h2 class="govuk-heading-m">Additional Examiner Notes History</h2>
-      @if (vm.techRecord_adrDetails_additionalExaminerNotes; as notes) {
+      @if (sortAdditionalExaminerNotes(vm.techRecord_adrDetails_additionalExaminerNotes); as notes) {
         @if (notes?.length; as notesCount) {
           <table class="govuk-table">
             <tbody class="govuk-table__body">

--- a/src/app/forms/custom-sections/adr-section/adr-section-view/adr-section-view.component.ts
+++ b/src/app/forms/custom-sections/adr-section/adr-section-view/adr-section-view.component.ts
@@ -1,10 +1,12 @@
 import { DatePipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { PaginationComponent } from '@components/pagination/pagination.component';
+import { AdditionalExaminerNotes } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
 import { Store } from '@ngrx/store';
 import { DefaultNullOrEmpty } from '@pipes/default-null-or-empty/default-null-or-empty.pipe';
 import { AdrService } from '@services/adr/adr.service';
 import { techRecord } from '@store/technical-records';
+import _ from 'lodash';
 
 @Component({
 	selector: 'app-adr-section-view',
@@ -17,4 +19,10 @@ export class AdrSectionViewComponent {
 	adrService = inject(AdrService);
 
 	techRecord = this.store.selectSignal(techRecord);
+
+	sortAdditionalExaminerNotes(notes?: AdditionalExaminerNotes[] | null) {
+		if (!notes) return [];
+
+		return _.orderBy(notes, ['createdAtDate'], ['desc']);
+	}
 }

--- a/src/app/resolvers/tech-record-clean/__tests__/tech-record-clean.resolver.spec.ts
+++ b/src/app/resolvers/tech-record-clean/__tests__/tech-record-clean.resolver.spec.ts
@@ -117,4 +117,53 @@ describe('techRecordCleanResolver', () => {
 			);
 		});
 	});
+
+	it('should sort additional examiner notes by createdAtDate in descending order', async () => {
+		const dispatchSpy = jest.spyOn(store, 'dispatch');
+		jest.spyOn(store, 'select').mockReturnValue(
+			of({
+				techRecord_vehicleType: 'hgv',
+				techRecord_adrDetails_additionalExaminerNotes: [
+					{
+						createdAtDate: '2023-01-01T00:00:00.000Z',
+						note: 'Note 2',
+					},
+					{
+						createdAtDate: '2025-12-31T00:00:00.000Z',
+						note: 'Note 3',
+					},
+					{
+						createdAtDate: '2022-12-30T00:00:00.000Z',
+						note: 'Note 1',
+					},
+				],
+			})
+		);
+		const result = executeResolver(activatedRouteSnapshot, {} as RouterStateSnapshot) as Observable<boolean>;
+		const resolveResult = await firstValueFrom(result);
+
+		expect(resolveResult).toBe(true);
+		expect(dispatchSpy).toHaveBeenCalledTimes(1);
+		expect(dispatchSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				vehicleTechRecord: {
+					techRecord_vehicleType: 'hgv',
+					techRecord_adrDetails_additionalExaminerNotes: [
+						{
+							createdAtDate: '2025-12-31T00:00:00.000Z',
+							note: 'Note 3',
+						},
+						{
+							createdAtDate: '2023-01-01T00:00:00.000Z',
+							note: 'Note 2',
+						},
+						{
+							createdAtDate: '2022-12-30T00:00:00.000Z',
+							note: 'Note 1',
+						},
+					],
+				},
+			})
+		);
+	});
 });

--- a/src/app/resolvers/tech-record-clean/tech-record-clean.resolver.ts
+++ b/src/app/resolvers/tech-record-clean/tech-record-clean.resolver.ts
@@ -28,11 +28,13 @@ const sortAdditionalExaminerNotes = (record: TechRecordType<'put'>, route: Activ
 
 	const type = record.techRecord_vehicleType;
 	if (type === VehicleTypes.HGV || type === VehicleTypes.LGV || type === VehicleTypes.TRL) {
-		record.techRecord_adrDetails_additionalExaminerNotes = _.orderBy(
-			record.techRecord_adrDetails_additionalExaminerNotes,
-			['createdAtDate'],
-			['desc']
-		);
+		if (Array.isArray(record.techRecord_adrDetails_additionalExaminerNotes)) {
+			record.techRecord_adrDetails_additionalExaminerNotes = _.orderBy(
+				record.techRecord_adrDetails_additionalExaminerNotes,
+				['createdAtDate'],
+				['desc']
+			);
+		}
 	}
 
 	return record;

--- a/src/app/resolvers/tech-record-clean/tech-record-clean.resolver.ts
+++ b/src/app/resolvers/tech-record-clean/tech-record-clean.resolver.ts
@@ -6,6 +6,7 @@ import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Store } from '@ngrx/store';
 import { State } from '@store/index';
 import { selectTechRecord, updateEditingTechRecord } from '@store/technical-records';
+import _ from 'lodash';
 import { Observable, map, take, tap } from 'rxjs';
 
 export const techRecordCleanResolver: ResolveFn<Observable<boolean>> = (route) => {
@@ -14,11 +15,27 @@ export const techRecordCleanResolver: ResolveFn<Observable<boolean>> = (route) =
 	return store.select(selectTechRecord).pipe(
 		take(1),
 		map((vehicleTechRecord) => vehicleTechRecord as TechRecordType<'put'>),
+		map((vehicleTechRecord) => sortAdditionalExaminerNotes(vehicleTechRecord, route)),
 		map((vehicleTechRecord) => cleanseApprovalType(vehicleTechRecord, route)),
 		map((vehicleTechRecord) => cleanseADRDetails(vehicleTechRecord, route)),
 		tap((vehicleTechRecord) => store.dispatch(updateEditingTechRecord({ vehicleTechRecord }))),
 		map(() => true)
 	);
+};
+
+const sortAdditionalExaminerNotes = (record: TechRecordType<'put'>, route: ActivatedRouteSnapshot) => {
+	if (!route.data['isEditing']) return record;
+
+	const type = record.techRecord_vehicleType;
+	if (type === VehicleTypes.HGV || type === VehicleTypes.LGV || type === VehicleTypes.TRL) {
+		record.techRecord_adrDetails_additionalExaminerNotes = _.orderBy(
+			record.techRecord_adrDetails_additionalExaminerNotes,
+			['createdAtDate'],
+			['desc']
+		);
+	}
+
+	return record;
 };
 
 export const cleanseApprovalType = (record: TechRecordType<'put'>, route: ActivatedRouteSnapshot) => {


### PR DESCRIPTION
## VTM - INC0370239 - Sort ADR examiner notes history

[CB2-19261](https://dvsa.atlassian.net/browse/CB2-19261)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-19261]: https://dvsa.atlassian.net/browse/CB2-19261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ