### PR TITLE
fix(CB2-19388): prepopulate amended data object

### DIFF
--- a/src/app/features/reference-data/reference-data-amend/reference-data-amend.component.ts
+++ b/src/app/features/reference-data/reference-data-amend/reference-data-amend.component.ts
@@ -66,7 +66,7 @@ export class ReferenceDataAmendComponent implements OnInit {
 			}
 		});
 
-		// Set amended data initial to the value of reference data item
+		// Initially set the amended data to the value of reference data item
 		this.data$
 			.pipe(
 				skipWhile((data) => !data),

--- a/src/app/features/reference-data/reference-data-amend/reference-data-amend.component.ts
+++ b/src/app/features/reference-data/reference-data-amend/reference-data-amend.component.ts
@@ -17,7 +17,7 @@ import { DynamicFormService } from '@services/dynamic-forms/dynamic-form.service
 import { CustomFormGroup } from '@services/dynamic-forms/dynamic-form.types';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { ReferenceDataState, amendReferenceDataItem, selectReferenceDataByResourceKey } from '@store/reference-data';
-import { Observable, first } from 'rxjs';
+import { Observable, first, skipWhile, take } from 'rxjs';
 import { ReferenceDataAmendHistoryComponent } from '../reference-data-amend-history/reference-data-amend-history.component';
 
 @Component({
@@ -65,6 +65,16 @@ export class ReferenceDataAmendComponent implements OnInit {
 				this.referenceDataService.loadReferenceDataByKey(this.type, this.key);
 			}
 		});
+
+		// Set amended data initial to the value of reference data item
+		this.data$
+			.pipe(
+				skipWhile((data) => !data),
+				take(1)
+			)
+			.subscribe((data) => {
+				this.amendedData = data;
+			});
 	}
 
 	get roles(): typeof Roles {


### PR DESCRIPTION
## VTM INT - Amending a reference data item a second time removes all essential information

[CB2-19388](https://dvsa.atlassian.net/browse/CB2-19388)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-19388]: https://dvsa.atlassian.net/browse/CB2-19388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ