### PR TITLE
fix(CB2-19930): ensure body model is null if empty

### DIFF
--- a/src/app/forms/custom-sections-v2/general-vehicle-details/general-vehicle-details.component.html
+++ b/src/app/forms/custom-sections-v2/general-vehicle-details/general-vehicle-details.component.html
@@ -126,6 +126,7 @@
       formControlName="techRecord_bodyModel"
       label="Body model"
       [width]="FormNodeWidth.L"
+      [nullIfEmpty]="true"
     />
   }
 <!--  End of PSV only fields -->

--- a/src/app/forms/custom-sections/body-section/body-section-edit/body-section-edit.component.html
+++ b/src/app/forms/custom-sections/body-section/body-section-edit/body-section-edit.component.html
@@ -26,6 +26,7 @@
         label="Body model"
         [tags]="[{ label: TagTypeLabels.PLATES, colour: TagType.PURPLE }]"
         [width]="FormNodeWidth.L"
+        [nullIfEmpty]="true"
         >
       </govuk-form-group-input>
     </div>

--- a/src/app/store/test-records/test-records.reducer.ts
+++ b/src/app/store/test-records/test-records.reducer.ts
@@ -201,6 +201,11 @@ function cleanTestResultPayload(testResult: TestResultModel | undefined) {
 		return testResult;
 	}
 
+	// Ensure body model is null when empty, so it doesn't affect downstream services
+	if (testResult.model === '') {
+		testResult.model = null;
+	}
+
 	// Remove recalls from non HGV/PSV/TRL tests
 	const vehicleType = testResult.vehicleType;
 	const isHGV = vehicleType === VehicleTypes.HGV;


### PR DESCRIPTION
## VTM- Contingency Test Blocked: Empty Vehicle Body Model

[CB2-19930](https://dvsa.atlassian.net/browse/CB2-19930)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-19930]: https://dvsa.atlassian.net/browse/CB2-19930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ