### PR TITLE
fix(CB2-20218): add plates tags

### DIFF
--- a/src/app/forms/custom-sections-v2/weights/weights.component.html
+++ b/src/app/forms/custom-sections-v2/weights/weights.component.html
@@ -359,7 +359,7 @@
               [showErrors]="false"
               [suffix]="'kg'"
               appFilterByTags
-              [tagNames]="[]"
+              [tagNames]="['Plates']"
               [filters]="filters()"
             ></govuk-form-group-input>
           }
@@ -373,7 +373,7 @@
               [showErrors]="false"
               [suffix]="'kg'"
               appFilterByTags
-              [tagNames]="[]"
+              [tagNames]="['Plates']"
               [filters]="filters()"
             ></govuk-form-group-input>
           }
@@ -435,7 +435,7 @@
             [showErrors]="false"
             [suffix]="'kg'"
             appFilterByTags
-            [tagNames]="[]"
+            [tagNames]="['Plates']"
             [filters]="filters()"
           ></govuk-form-group-input>
         }
@@ -449,7 +449,7 @@
             [showErrors]="false"
             [suffix]="'kg'"
             appFilterByTags
-            [tagNames]="[]"
+            [tagNames]="['Plates']"
             [filters]="filters()"
           ></govuk-form-group-input>
         }
@@ -463,7 +463,7 @@
             [showErrors]="false"
             [suffix]="'kg'"
             appFilterByTags
-            [tagNames]="[]"
+            [tagNames]="['Plates']"
             [filters]="filters()"
           ></govuk-form-group-input>
         }


### PR DESCRIPTION
## VTM Redesign: Applying HGV Plates Filter hides Train & Max Train Fields

[CB2-20218](https://dvsa.atlassian.net/browse/CB2-20218)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-20218]: https://dvsa.atlassian.net/browse/CB2-20218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ