### PR TITLE
fix(CB2-20605): only populate dropdown once reference data has finish…

### DIFF
--- a/src/app/forms/components/autocomplete/__tests__/autocomplete.component.spec.ts
+++ b/src/app/forms/components/autocomplete/__tests__/autocomplete.component.spec.ts
@@ -1,7 +1,9 @@
+import { initialAppState } from '@/src/app/store';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { provideMockStore } from '@ngrx/store/testing';
 import { CustomFormControl, FormNodeTypes } from '@services/dynamic-forms/dynamic-form.types';
 import { of } from 'rxjs';
 import { FieldErrorMessageComponent } from '../../field-error-message/field-error-message.component';
@@ -41,6 +43,7 @@ describe('AutocompleteComponent', () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			imports: [HostComponent],
+			providers: [provideMockStore({ initialState: initialAppState })],
 		}).compileComponents();
 	});
 

--- a/src/app/forms/components/autocomplete/autocomplete.component.ts
+++ b/src/app/forms/components/autocomplete/autocomplete.component.ts
@@ -1,10 +1,12 @@
+import { referenceDataLoadingState } from '@/src/app/store/reference-data';
 import { NgTemplateOutlet } from '@angular/common';
 import { AfterContentInit, AfterViewInit, Component, DOCUMENT, inject, input } from '@angular/core';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TagComponent } from '@components/tag/tag.component';
 import { CustomValidators } from '@forms/validators/custom-validators/custom-validators';
+import { Store } from '@ngrx/store';
 import { enhanceSelectElement } from 'accessible-autocomplete/dist/accessible-autocomplete.min';
-import { Observable, lastValueFrom, takeWhile } from 'rxjs';
+import { Observable, ReplaySubject, combineLatest, lastValueFrom, takeWhile } from 'rxjs';
 import { BaseControlComponent } from '../base-control/base-control.component';
 import { FieldErrorMessageComponent } from '../field-error-message/field-error-message.component';
 
@@ -22,7 +24,10 @@ import { FieldErrorMessageComponent } from '../field-error-message/field-error-m
 	imports: [TagComponent, FieldErrorMessageComponent, NgTemplateOutlet, FormsModule],
 })
 export class AutocompleteComponent extends BaseControlComponent implements AfterViewInit, AfterContentInit {
+	store = inject(Store);
 	document = inject(DOCUMENT);
+
+	refDataLoading = this.store.select(referenceDataLoadingState);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	readonly options$ = input.required<Observable<any[]>>();
@@ -33,13 +38,18 @@ export class AutocompleteComponent extends BaseControlComponent implements After
 		'<svg class="autocomplete__dropdown-arrow-down" style="height: 17px;" viewBox="0 0 512 512"  ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>';
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	options: any[] = [];
+	destroy = new ReplaySubject<boolean>(1);
 
 	ngAfterViewInit(): void {
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this;
 
-		lastValueFrom(this.options$().pipe(takeWhile((options) => !options || options.length === 0, true)))
-			.then((options) => {
+		lastValueFrom(
+			combineLatest({
+				options: this.options$(),
+				refDataLoading: this.refDataLoading,
+			}).pipe(takeWhile(({ options, refDataLoading }) => !options || options.length === 0 || refDataLoading, true))
+		)
+			.then(({ options }) => {
 				this.options = options;
 				this.cdr.detectChanges();
 


### PR DESCRIPTION
…… (#2236)

* fix(CB2-20605): only populate dropdown once reference data has finished loading

* fix(CB2-20605): fix unit tests

## FE - Allow the tester details to contain more than 1000 entries

[CB2-20605](https://dvsa.atlassian.net/browse/CB2-20605)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-20605]: https://dvsa.atlassian.net/browse/CB2-20605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ