### PR TITLE
fix(CB2-20991): remove hyperlink for voluntary brake test

### DIFF
--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
@@ -188,6 +188,7 @@ export class VehicleHeaderComponent {
 		if (this.isTestTypeOldIvaOrMsva()) return false; // Old IVA or MSVA tests
 		const { testTypeId, testResult } = test.testTypes[0];
 		if (testTypeId === '201') return false; // LEC without linked test
+		if (['30', '85'].includes(testTypeId)) return false; // Voluntary brake tests
 		if (TEST_TYPES_GROUP7.includes(testTypeId)) return false; // ADR tests
 		if (ADR_DESK_BASED_TEST_TYPE_IDS.includes(testTypeId)) return false; // Desk-base ADR tests
 		if (TEST_TYPES_GROUP1_SPEC_TEST.includes(testTypeId) && testResult !== TestResults.FAIL) return false; // IVA tests


### PR DESCRIPTION
## VTM - VTM - Voluntary brake contingency test missing cert/test number in certificate field

[CB2-20991](https://dvsa.atlassian.net/browse/CB2-20991)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-20991]: https://dvsa.atlassian.net/browse/CB2-20991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ