### PR TITLE
fix(CB2-21176): hide link on desk-based cat e IVA

### DIFF
--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
@@ -188,6 +188,7 @@ export class VehicleHeaderComponent {
 		if (this.isTestTypeOldIvaOrMsva()) return false; // Old IVA or MSVA tests
 		const { testTypeId, testResult } = test.testTypes[0];
 		if (testTypeId === '201') return false; // LEC without linked test
+		if (testTypeId === '420' && testResult === TestResults.PASS) return false; // Desk-based Cat E IVA
 		if (['30', '85'].includes(testTypeId)) return false; // Voluntary brake tests
 		if (TEST_TYPES_GROUP7.includes(testTypeId)) return false; // ADR tests
 		if (ADR_DESK_BASED_TEST_TYPE_IDS.includes(testTypeId)) return false; // Desk-base ADR tests


### PR DESCRIPTION
## VTM - Mutual Recognition Cat E Statutory (YSZ) shows certificate link when there is no certificate

[CB2-21176](https://dvsa.atlassian.net/browse/CB2-21176)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21176]: https://dvsa.atlassian.net/browse/CB2-21176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ