### PR TITLE
fix(CB2-21243): handle dimensions amendment change edge case

### DIFF
--- a/src/app/services/technical-record/technical-record-change.service.ts
+++ b/src/app/services/technical-record/technical-record-change.service.ts
@@ -166,17 +166,29 @@ export class TechnicalRecordChangesService {
 		);
 	}
 
+	hasAxlesSpacingsChanged(): boolean {
+		const a = this.currentTechRecord();
+		const b = this.amendedTechRecord();
+
+		// Edge case 1: If we're going from a n-axle TRL to a 1-axle TRL ignore the spacings
+		if (a && b && a.techRecord_noOfAxles && a.techRecord_noOfAxles > 1 && b.techRecord_noOfAxles === 1) {
+			return false;
+		}
+
+		return this.hasChanged('techRecord_dimensions_axleSpacing', 'techRecord_frontAxleToRearAxle');
+	}
+
 	hasDimensionsSectionChanged(): boolean {
+		if (this.hasAxlesSpacingsChanged()) return true;
+
 		return this.hasChanged(
 			'techRecord_dimensions_length',
 			'techRecord_dimensions_width',
-			'techRecord_dimensions_axleSpacing',
-			'techRecord_frontAxleToRearAxle',
+			'techRecord_dimensions_height',
 			'techRecord_frontVehicleTo5thWheelCouplingMin',
 			'techRecord_frontVehicleTo5thWheelCouplingMax',
 			'techRecord_frontAxleTo5thWheelMin',
 			'techRecord_frontAxleTo5thWheelMax',
-			'techRecord_frontAxleToRearAxle',
 			'techRecord_rearAxleToRearTrl',
 			'techRecord_centreOfRearmostAxleToRearOfTrl',
 			'techRecord_couplingCenterToRearAxleMin',


### PR DESCRIPTION
## VTM - INT - removing 1 axle from 2 axle trl, on review page dimension sections shows up empty.

[CB2-21243](https://dvsa.atlassian.net/browse/CB2-21243)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21243]: https://dvsa.atlassian.net/browse/CB2-21243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ