### PR TITLE
chore: resolve double loading

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -106,7 +106,7 @@ const routes: Routes = [
 	},
 ];
 @NgModule({
-	imports: [RouterModule.forRoot(routes, { onSameUrlNavigation: 'reload' })],
+	imports: [RouterModule.forRoot(routes)],
 	exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,8 +4,9 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MsalModule } from '@azure/msal-angular';
+import { MsalGuard, MsalModule } from '@azure/msal-angular';
 import { PageNotFoundComponent } from '@core/components/page-not-found/page-not-found.component';
+import { RoleGuard } from '@guards/role-guard/roles.guard';
 import { GoogleAnalyticsServiceMock } from '@mocks/google-analytics-service.mock';
 import { StoreModule } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -40,6 +41,8 @@ describe('AppComponent', () => {
 				provideHttpClientTesting(),
 				{ provide: LoadingService, useValue: { showSpinner$: of(false) } },
 				{ provide: UserService, useValue: MockUserService },
+				{ provide: MsalGuard, useValue: { canActivate: () => of(true) } },
+				{ provide: RoleGuard, useValue: { canActivate: () => of(true) } },
 				PageNotFoundComponent,
 				{ provide: GoogleTagManagerService, useClass: GoogleAnalyticsServiceMock },
 				{ provide: AnalyticsService, useValue: { pushToDataLayer: jest.fn(), setUserId: jest.fn() } },

--- a/src/app/core/components/header/__tests__/header.component.spec.ts
+++ b/src/app/core/components/header/__tests__/header.component.spec.ts
@@ -37,12 +37,12 @@ describe('HeaderComponent', () => {
 		expect(userNameText.innerHTML).toBe('Test');
 	});
 
-	it('Clicking logout fires off event', (done) => {
-		component.logOutEvent.subscribe(() => {
-			done();
-			expect(done).toHaveBeenCalled();
-		});
+	it('Clicking logout fires off event', () => {
+		const logoutSpy = jest.fn();
+		component.logOutEvent.subscribe(logoutSpy);
 
 		logOutButton.triggerEventHandler('click', null);
+
+		expect(logoutSpy).toHaveBeenCalled();
 	});
 });

--- a/src/app/features/reference-data/reference-data-add/reference-data-add.component.ts
+++ b/src/app/features/reference-data/reference-data-add/reference-data-add.component.ts
@@ -89,7 +89,7 @@ export class ReferenceDataCreateComponent implements OnInit, OnDestroy {
 	handleSubmit() {
 		this.checkForms();
 
-		if (this.isFormInvalid) return;
+		if (this.isFormInvalid || !this.newRefData) return;
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const referenceData: any = {};

--- a/src/app/features/reference-data/reference-data-add/reference-data-add.component.ts
+++ b/src/app/features/reference-data/reference-data-add/reference-data-add.component.ts
@@ -89,7 +89,16 @@ export class ReferenceDataCreateComponent implements OnInit, OnDestroy {
 	handleSubmit() {
 		this.checkForms();
 
-		if (this.isFormInvalid || !this.newRefData) return;
+		if (this.isFormInvalid) return;
+
+		if (!this.newRefData) {
+			const sections = this.sections();
+			if (sections.length) {
+				this.newRefData = sections[0].form.value;
+			}
+		}
+
+		if (!this.newRefData) return;
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const referenceData: any = {};

--- a/src/app/features/reference-data/reference-data-amend/reference-data-amend.component.ts
+++ b/src/app/features/reference-data/reference-data-amend/reference-data-amend.component.ts
@@ -144,6 +144,11 @@ export class ReferenceDataAmendComponent implements OnInit, OnDestroy {
 
 		if (this.isFormInvalid) return;
 
+		const sections = this.sections();
+		if (sections.length) {
+			this.amendedData = { ...this.amendedData, ...sections[0].form.value };
+		}
+
 		this.store.dispatch(
 			amendReferenceDataItem({
 				resourceType: this.type,

--- a/src/app/features/reference-data/reference-data-list/reference-data-list.component.ts
+++ b/src/app/features/reference-data/reference-data-list/reference-data-list.component.ts
@@ -134,9 +134,7 @@ export class ReferenceDataListComponent implements OnInit, OnDestroy {
 	}
 
 	addNew(): void {
-		void this.router.navigate(['create'], { relativeTo: this.route }).then(() => {
-			window.location.reload();
-		});
+		void this.router.navigate(['create'], { relativeTo: this.route });
 	}
 
 	navigateToDeletedItems(): void {
@@ -145,9 +143,7 @@ export class ReferenceDataListComponent implements OnInit, OnDestroy {
 
 	amend(item: ReferenceDataModelBase): void {
 		const key = encodeURIComponent(String(item.resourceKey));
-		void this.router.navigate([key], { relativeTo: this.route }).then(() => {
-			window.location.reload();
-		});
+		void this.router.navigate([key], { relativeTo: this.route });
 	}
 
 	delete(item: ReferenceDataModelBase): void {

--- a/src/app/features/search/search-results-wrapper/search-results-v1/multiple-search-results.component.ts
+++ b/src/app/features/search/search-results-wrapper/search-results-v1/multiple-search-results.component.ts
@@ -9,7 +9,7 @@ import { SEARCH_TYPES } from '@models/search-types-enum';
 import { Store, select } from '@ngrx/store';
 import { TechnicalRecordService } from '@services/technical-record/technical-record.service';
 import { selectQueryParams } from '@store/router/router.selectors';
-import { Observable, Subject, takeUntil } from 'rxjs';
+import { Observable, Subject, distinctUntilChanged, takeUntil } from 'rxjs';
 import { SingleSearchResultComponent } from './single-search-result/single-search-result.component';
 
 @Component({
@@ -28,18 +28,24 @@ export class MultipleSearchResultsComponent implements OnDestroy {
 	ngDestroy$ = new Subject();
 
 	constructor() {
-		this.store.pipe(select(selectQueryParams), takeUntil(this.ngDestroy$)).subscribe((params) => {
-			if (Object.keys(params).length === 1) {
-				const type = Object.keys(params)[0] as SEARCH_TYPES;
-				// eslint-disable-next-line security/detect-object-injection
-				const searchTerm = params[type] as string;
+		this.store
+			.pipe(
+				select(selectQueryParams),
+				distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
+				takeUntil(this.ngDestroy$)
+			)
+			.subscribe((params) => {
+				if (Object.keys(params).length === 1) {
+					const type = Object.keys(params)[0] as SEARCH_TYPES;
+					// eslint-disable-next-line security/detect-object-injection
+					const searchTerm = params[type] as string;
 
-				if (searchTerm && Object.values(SEARCH_TYPES).includes(type)) {
-					this.globalErrorService.clearErrors();
-					this.technicalRecordService.searchBy(type, searchTerm);
+					if (searchTerm && Object.values(SEARCH_TYPES).includes(type)) {
+						this.globalErrorService.clearErrors();
+						this.technicalRecordService.searchBy(type, searchTerm);
+					}
 				}
-			}
-		});
+			});
 
 		this.searchResults$ = this.technicalRecordService.searchResultsWithUniqueSystemNumbers$;
 	}

--- a/src/app/features/search/search-results-wrapper/search-results-v2/search-results-v2.component.ts
+++ b/src/app/features/search/search-results-wrapper/search-results-v2/search-results-v2.component.ts
@@ -8,7 +8,7 @@ import { AsyncPipe } from '@angular/common';
 import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { ReplaySubject, takeUntil } from 'rxjs';
+import { ReplaySubject, distinctUntilChanged, takeUntil } from 'rxjs';
 import { SearchFormComponent } from '../../search-form/search-form.component';
 import { SearchResultComponent } from './search-result/search-result.component';
 
@@ -28,16 +28,26 @@ export class SearchResultsV2Component implements OnInit, OnDestroy {
 	destroy = new ReplaySubject<boolean>(1);
 
 	ngOnInit(): void {
-		this.activatedRoute.queryParamMap.pipe(takeUntil(this.destroy)).subscribe((params) => {
-			const searchTerm = params.get('searchTerm');
-			const searchCriteria = params.get('searchCriteria') as SEARCH_TYPES | null;
-			const includeArchived = params.get('includeArchived') === 'true';
+		this.activatedRoute.queryParamMap
+			.pipe(
+				distinctUntilChanged(
+					(a, b) =>
+						a.get('searchTerm') === b.get('searchTerm') &&
+						a.get('searchCriteria') === b.get('searchCriteria') &&
+						a.get('includeArchived') === b.get('includeArchived')
+				),
+				takeUntil(this.destroy)
+			)
+			.subscribe((params) => {
+				const searchTerm = params.get('searchTerm');
+				const searchCriteria = params.get('searchCriteria') as SEARCH_TYPES | null;
+				const includeArchived = params.get('includeArchived') === 'true';
 
-			if (searchTerm && searchCriteria && Object.values(SEARCH_TYPES).includes(searchCriteria)) {
-				this.globalErrorService.clearErrors();
-				this.technicalRecordService.searchBy(searchCriteria, searchTerm, includeArchived);
-			}
-		});
+				if (searchTerm && searchCriteria && Object.values(SEARCH_TYPES).includes(searchCriteria)) {
+					this.globalErrorService.clearErrors();
+					this.technicalRecordService.searchBy(searchCriteria, searchTerm, includeArchived);
+				}
+			});
 	}
 
 	ngOnDestroy(): void {

--- a/src/app/features/tech-record/__tests__/tech-record.component.spec.ts
+++ b/src/app/features/tech-record/__tests__/tech-record.component.spec.ts
@@ -1,10 +1,11 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, provideRouter } from '@angular/router';
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { Roles } from '@models/roles.enum';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { CustomRouteReuseStrategy } from '@services/router/custom-route-reuse-strategy';
 import { State, initialAppState } from '@store/index';
 import { selectRouteNestedParams } from '@store/router/router.selectors';
 import { TechRecordComponent } from '../tech-record.component';
@@ -22,6 +23,7 @@ describe('TechRecordComponent', () => {
 				provideHttpClient(),
 				provideHttpClientTesting(),
 				provideMockStore({ initialState: initialAppState }),
+				{ provide: RouteReuseStrategy, useClass: CustomRouteReuseStrategy },
 			],
 		}).compileComponents();
 	});
@@ -53,11 +55,9 @@ describe('TechRecordComponent', () => {
 		expect(expectedResult).toBe(expectedError);
 	});
 
-	it('reuse strategy should be set to false', () => {
-		const snapshot = {} as ActivatedRouteSnapshot;
+	it('should use CustomRouteReuseStrategy', () => {
+		const strategy = TestBed.inject(RouteReuseStrategy);
 
-		const expectedResult = component['router'].routeReuseStrategy.shouldReuseRoute(snapshot, snapshot);
-
-		expect(expectedResult).toBeFalsy();
+		expect(strategy).toBeInstanceOf(CustomRouteReuseStrategy);
 	});
 });

--- a/src/app/features/tech-record/components/tech-record-filters/tech-record-filters.component.html
+++ b/src/app/features/tech-record/components/tech-record-filters/tech-record-filters.component.html
@@ -4,12 +4,12 @@
   </dt>
   @for (tag of tags(); track $index) {
     <dd class="govuk-summary-list__value govuk-summary-list__value--filter">
-      @let active = value().includes(tag);
-      <a 
-        class="app-c-filter-summary__remove-filter" 
+      @let active = !!(value()?.includes(tag));
+      <a
+        class="app-c-filter-summary__remove-filter"
         [class.active-filter]="active"
-        href="javascript:void(0)" 
-        [id]="tag.toLowerCase()" 
+        href="javascript:void(0)"
+        [id]="tag.toLowerCase()"
         (click)="toggle(tag)"
       >
         <span class="app-c-filter-summary__remove-filter-text">

--- a/src/app/features/tech-record/tech-record.component.ts
+++ b/src/app/features/tech-record/tech-record.component.ts
@@ -1,6 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { GlobalError } from '@core/components/global-error/global-error.interface';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
 import { RoleRequiredDirective } from '@directives/app-role-required/app-role-required.directive';
@@ -16,16 +16,11 @@ import { VehicleTechnicalRecordWrapperComponent } from './components/vehicle-tec
 })
 export class TechRecordComponent implements OnInit {
 	techRecordService = inject(TechnicalRecordService);
-	router = inject(Router);
 	errorService = inject(GlobalErrorService);
 	route = inject(ActivatedRoute);
 
 	systemNumber?: string;
 	createdTimestamp?: string;
-
-	constructor() {
-		this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-	}
 
 	ngOnInit(): void {
 		this.route.params.pipe(take(1)).subscribe((params) => {

--- a/src/app/features/test-records/amend/views/test-record/test-record.component.ts
+++ b/src/app/features/test-records/amend/views/test-record/test-record.component.ts
@@ -52,10 +52,6 @@ export class TestRecordComponent implements OnInit, OnDestroy {
 	testMode = TestModeEnum.Edit;
 	testNumber$ = this.routerService.routeNestedParams$.pipe(map((params) => params['testNumber']));
 
-	constructor() {
-		this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-	}
-
 	ngOnInit(): void {
 		this.testResult$ = this.testRecordsService.editingTestResult$.pipe(
 			switchMap((editingTestResult) =>

--- a/src/app/features/test-records/create/views/create-test-record/create-test-record.component.ts
+++ b/src/app/features/test-records/create/views/create-test-record/create-test-record.component.ts
@@ -66,10 +66,6 @@ export class CreateTestRecordComponent implements OnInit, OnDestroy, AfterViewIn
 	testTypeId?: string;
 	techRecord: V3TechRecordModel | undefined = undefined;
 
-	constructor() {
-		this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-	}
-
 	ngOnInit(): void {
 		this.testResult$ = this.testRecordsService.editingTestResult$.pipe(
 			tap((editingTestResult) => !editingTestResult && this.backToTechRecord())

--- a/src/app/forms/custom-sections-v2/brakes/brakes.component.ts
+++ b/src/app/forms/custom-sections-v2/brakes/brakes.component.ts
@@ -12,7 +12,7 @@ import { FieldErrorMessageComponent } from '@forms/components/field-error-messag
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
 import { Retarders, V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { FormNodeWidth } from '@services/dynamic-forms/dynamic-form.types';
-import { ReplaySubject, debounceTime, distinctUntilChanged, map, switchMap, takeUntil, withLatestFrom } from 'rxjs';
+import { ReplaySubject, debounceTime, distinctUntilChanged, map, switchMap, takeUntil } from 'rxjs';
 import { FieldWarningMessageComponent } from '../../components/field-warning-message/field-warning-message.component';
 import { GovukFormGroupAutocompleteComponent } from '../../components/govuk-form-group-autocomplete/govuk-form-group-autocomplete.component';
 import { GovukFormGroupCheckboxComponent } from '../../components/govuk-form-group-checkbox/govuk-form-group-checkbox.component';
@@ -142,17 +142,17 @@ export class BrakesComponent extends EditBaseComponent implements OnInit, OnDest
 
 		brakeCode.valueChanges
 			.pipe(
-				takeUntil(this.destroy$),
-				switchMap((value) => this.store.select(selectBrakeByCode(value))),
-				withLatestFrom(brakeCode.valueChanges),
 				debounceTime(400),
-				distinctUntilChanged()
+				distinctUntilChanged(),
+				switchMap((value) => this.store.select(selectBrakeByCode(value))),
+				takeUntil(this.destroy$)
 			)
-			.subscribe(([selectedBrake, value]) => {
-				if (this.mode() === Modes.VIEW || this.mode() === Modes.SUMMARY) return;
+			.subscribe((selectedBrake) => {
+				const mode = this.mode();
+				if (!mode || mode === Modes.VIEW || mode === Modes.SUMMARY) return;
 
 				// Set the brake details automatically based selection
-				if (selectedBrake && value) {
+				if (selectedBrake) {
 					const techRecord_brakeCode = `${this.brakeCodePrefix}${selectedBrake.resourceKey}`;
 					const techRecord_brakes_brakeCode = `${this.brakeCodePrefix}${selectedBrake.resourceKey}`;
 					const techRecord_brakes_dataTrBrakeOne = selectedBrake.service;
@@ -179,7 +179,7 @@ export class BrakesComponent extends EditBaseComponent implements OnInit, OnDest
 					this.form.patchValue(changes, { emitEvent: false });
 				}
 
-				if (value) {
+				if (selectedBrake) {
 					this.store.dispatch(updateBrakeForces({}));
 				}
 			});

--- a/src/app/forms/custom-sections-v2/weights/weights.component.ts
+++ b/src/app/forms/custom-sections-v2/weights/weights.component.ts
@@ -253,7 +253,8 @@ export class WeightsComponent extends EditBaseComponent implements OnInit, OnDes
 		const grossKerbWeight = this.form.get('techRecord_grossKerbWeight');
 		grossKerbWeight?.valueChanges.pipe(skip(1), takeUntil(this.destroy$)).subscribe((value) => {
 			if (!value) return;
-			if (this.mode() === Modes.VIEW || this.mode() === Modes.SUMMARY) return;
+			const mode = this.mode();
+			if (!mode || mode === Modes.VIEW || mode === Modes.SUMMARY) return;
 			this.store.dispatch(
 				updateBrakeForces({
 					grossKerbWeight: value,
@@ -269,7 +270,8 @@ export class WeightsComponent extends EditBaseComponent implements OnInit, OnDes
 		const grossLadenWeight = this.form.get('techRecord_grossLadenWeight');
 		grossLadenWeight?.valueChanges.pipe(skip(1), takeUntil(this.destroy$)).subscribe((value) => {
 			if (!value) return;
-			if (this.mode() === Modes.VIEW || this.mode() === Modes.SUMMARY) return;
+			const mode = this.mode();
+			if (!mode || mode === Modes.VIEW || mode === Modes.SUMMARY) return;
 			this.store.dispatch(
 				updateBrakeForces({
 					grossKerbWeight: this.form.get('techRecord_grossKerbWeight')?.value,
@@ -280,7 +282,8 @@ export class WeightsComponent extends EditBaseComponent implements OnInit, OnDes
 	}
 
 	private handleVehicleTechRecordChange(changes: SimpleChanges): void {
-		if (this.mode() === Modes.VIEW || this.mode() === Modes.SUMMARY) return;
+		const mode = this.mode();
+		if (!mode || mode === Modes.VIEW || mode === Modes.SUMMARY) return;
 
 		const { techRecord } = changes;
 		if (this.form && techRecord) {

--- a/src/app/services/http/http.service.ts
+++ b/src/app/services/http/http.service.ts
@@ -22,7 +22,7 @@ import { SEARCH_TYPES } from '@models/search-types-enum';
 import { TestTypeInfo } from '@models/test-types/testTypeInfo';
 import { TestTypesTaxonomy } from '@models/test-types/testTypesTaxonomy';
 import { V3TechRecordModel } from '@models/vehicle-tech-record.model';
-import { withCache } from '@ngneat/cashew';
+import { CacheBucket, withCache } from '@ngneat/cashew';
 import { cloneDeep } from 'lodash';
 import { lastValueFrom, timeout } from 'rxjs';
 import { FeatureConfig } from '../feature-toggle-service/feature-toggle-service';
@@ -39,6 +39,14 @@ export class HttpService {
 	private static readonly PostPutGzippedPayloadHeaders = new HttpHeaders({
 		[CompressionHeaders.outbound.request]: CompressionHeaders.compressionValue,
 	});
+	private readonly refDataBuckets = new Map<string, CacheBucket>();
+
+	getRefDataBucket(resourceType: string): CacheBucket {
+		if (!this.refDataBuckets.has(resourceType)) {
+			this.refDataBuckets.set(resourceType, new CacheBucket());
+		}
+		return this.refDataBuckets.get(resourceType)!;
+	}
 
 	amendTechRecordVin(newVin: string, systemNumber: string, createdTimestamp: string) {
 		return this.http.patch<TechRecordType<'get'>>(
@@ -298,7 +306,10 @@ export class HttpService {
 			`${environment.VTM_API_URI}/reference/${encodeURIComponent(String(resourceType))}`,
 			{
 				params,
-				context: withCache({ key: CacheKeys.REFERENCE_DATA + resourceType + (paginationToken ?? '') }),
+				context: withCache({
+					key: CacheKeys.REFERENCE_DATA + resourceType + (paginationToken ?? ''),
+					bucket: this.getRefDataBucket(resourceType),
+				}),
 			}
 		);
 	}

--- a/src/app/services/router/custom-route-reuse-strategy.ts
+++ b/src/app/services/router/custom-route-reuse-strategy.ts
@@ -1,0 +1,7 @@
+import { ActivatedRouteSnapshot, BaseRouteReuseStrategy } from '@angular/router';
+
+export class CustomRouteReuseStrategy extends BaseRouteReuseStrategy {
+	override shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
+		return future.routeConfig === curr.routeConfig && JSON.stringify(future.params) === JSON.stringify(curr.params);
+	}
+}

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -6,6 +6,12 @@ import {
 	globalErrorReducer,
 	initialGlobalErrorState,
 } from '@store/global-error/global-error-service.reducer';
+import {
+	GlobalWarningState,
+	STORE_FEATURE_GLOBAL_WARNING_KEY,
+	globalWarningReducer,
+	initialGlobalWarningState,
+} from '@store/global-warning/global-warning-service.reducers';
 import { STORE_FEATURE_LOGS_KEY } from '@store/logs/logs.feature';
 import { initialState as initialLogState, logsReducer } from '@store/logs/logs.reducer';
 import {
@@ -67,6 +73,7 @@ import {
 export interface State {
 	[STORE_FEATURE_DEFECTS_KEY]: DefectsState;
 	[STORE_FEATURE_GLOBAL_ERROR_KEY]: GlobalErrorState;
+	[STORE_FEATURE_GLOBAL_WARNING_KEY]: GlobalWarningState;
 	[STORE_FEATURE_REFERENCE_DATA_KEY]: ReferenceDataState;
 	[STORE_FEATURE_SPINNER_KEY]: SpinnerState;
 	[STORE_FEATURE_TECHNICAL_RECORDS_KEY]: TechnicalRecordServiceState;
@@ -84,6 +91,7 @@ export interface State {
 export const initialAppState = {
 	[STORE_FEATURE_DEFECTS_KEY]: initialDefectsState,
 	[STORE_FEATURE_GLOBAL_ERROR_KEY]: initialGlobalErrorState,
+	[STORE_FEATURE_GLOBAL_WARNING_KEY]: initialGlobalWarningState,
 	[STORE_FEATURE_REFERENCE_DATA_KEY]: initialReferenceDataState,
 	[STORE_FEATURE_SPINNER_KEY]: initialSpinnerState,
 	[STORE_FEATURE_TECHNICAL_RECORDS_KEY]: initialTechnicalRecordsState,
@@ -99,6 +107,7 @@ export const initialAppState = {
 export const reducers = {
 	[STORE_FEATURE_DEFECTS_KEY]: defectsReducer,
 	[STORE_FEATURE_GLOBAL_ERROR_KEY]: globalErrorReducer,
+	[STORE_FEATURE_GLOBAL_WARNING_KEY]: globalWarningReducer,
 	[STORE_FEATURE_REFERENCE_DATA_KEY]: referenceDataReducer,
 	[STORE_FEATURE_SPINNER_KEY]: spinnerReducer,
 	[STORE_FEATURE_TECHNICAL_RECORDS_KEY]: vehicleTechRecordReducer,

--- a/src/app/store/reference-data/__tests__/reference-data.effects.spec.ts
+++ b/src/app/store/reference-data/__tests__/reference-data.effects.spec.ts
@@ -59,7 +59,7 @@ describe('ReferenceDataEffects', () => {
 				provideMockStore({ initialState: initialAppState }),
 				ReferenceDataEffects,
 				ReferenceDataService,
-				{ provide: HttpCacheManager, useValue: { has: jest.fn().mockReturnValue(false) } },
+				{ provide: HttpCacheManager, useValue: { has: jest.fn().mockReturnValue(false), delete: jest.fn() } },
 				{ provide: UserService, useValue: {} },
 			],
 		});

--- a/src/app/store/reference-data/reference-data.effects.ts
+++ b/src/app/store/reference-data/reference-data.effects.ts
@@ -10,6 +10,7 @@ import { VehicleTypes } from '@models/vehicle-tech-record.model';
 import { HttpCacheManager } from '@ngneat/cashew';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
+import { HttpService } from '@services/http/http.service';
 import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { State } from '@store/index';
 import { testResultInEdit } from '@store/test-records';
@@ -53,6 +54,7 @@ export class ReferenceDataEffects {
 	private referenceDataService = inject(ReferenceDataService);
 	private store = inject<Store<State>>(Store);
 	private cacheManager = inject(HttpCacheManager);
+	private httpService = inject(HttpService);
 	private globalErrorService = inject(GlobalErrorService);
 
 	fetchReferenceDataByType$ = createEffect(() =>
@@ -210,6 +212,7 @@ export class ReferenceDataEffects {
 			switchMap(({ resourceType, resourceKey, payload }) => {
 				payload = { ...payload };
 				return this.referenceDataService.createReferenceDataItem(resourceType, resourceKey, payload).pipe(
+					tap(() => this.cacheManager.delete(this.httpService.getRefDataBucket(resourceType))),
 					map((result) => createReferenceDataItemSuccess({ result: result as ReferenceDataModelBase })),
 					catchError((error) => of(createReferenceDataItemFailure({ error: error.message })))
 				);
@@ -217,14 +220,13 @@ export class ReferenceDataEffects {
 		)
 	);
 
-	// The amend effect will work when the referenceData.service.ts is amended on line 395 from <EmptyObject> to <any>
-
 	amendReferenceDataItem$ = createEffect(() =>
 		this.actions$.pipe(
 			ofType(amendReferenceDataItem),
 			switchMap(({ resourceType, resourceKey, payload }) => {
 				payload = { ...payload };
 				return this.referenceDataService.amendReferenceDataItem(resourceType, resourceKey, payload).pipe(
+					tap(() => this.cacheManager.delete(this.httpService.getRefDataBucket(resourceType))),
 					map((result) => amendReferenceDataItemSuccess({ result: result as ReferenceDataModelBase })),
 					catchError((error) => of(amendReferenceDataItemFailure({ error: error.message })))
 				);
@@ -251,8 +253,8 @@ export class ReferenceDataEffects {
 			this.actions$.pipe(
 				ofType(deleteReferenceDataItemSuccess),
 				tap((action) => {
-					// Clear cache, so we refresh delete items list
-					this.cacheManager.delete(`${CacheKeys.REFERENCE_DATA}${action.resourceType}#AUDIT`);
+					// Clear cache, so we refresh the list and deleted items list
+					this.cacheManager.delete(this.httpService.getRefDataBucket(action.resourceType));
 					this.router.navigate([RootRoutes.REFERENCE_DATA, action.resourceType]);
 					this.globalErrorService.clearErrors();
 				})

--- a/src/app/store/tech-record-search/tech-record-search.effect.ts
+++ b/src/app/store/tech-record-search/tech-record-search.effect.ts
@@ -2,20 +2,17 @@ import { Injectable, inject } from '@angular/core';
 import { SEARCH_TYPES } from '@models/search-types-enum';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { HttpService } from '@services/http/http.service';
-import { catchError, distinctUntilChanged, map, of, switchMap } from 'rxjs';
+import { catchError, map, of, switchMap } from 'rxjs';
 import { fetchSearchResult, fetchSearchResultFailed, fetchSearchResultSuccess } from './tech-record-search.actions';
 
 @Injectable()
 export class TechSearchResultsEffects {
-	private actions$ = inject(Actions);
-	private httpService = inject(HttpService);
+	private readonly actions$ = inject(Actions);
+	private readonly httpService = inject(HttpService);
 
 	fetchSearchResults$ = createEffect(() =>
 		this.actions$.pipe(
 			ofType(fetchSearchResult),
-			distinctUntilChanged(
-				(a, b) => a.searchBy === b.searchBy && a.term === b.term && a.includeArchived === b.includeArchived
-			),
 			switchMap(({ searchBy, term }) =>
 				this.httpService.searchTechRecords(searchBy ?? SEARCH_TYPES.ALL, term).pipe(
 					map((results) => fetchSearchResultSuccess({ payload: results })),

--- a/src/app/store/tech-record-search/tech-record-search.effect.ts
+++ b/src/app/store/tech-record-search/tech-record-search.effect.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { SEARCH_TYPES } from '@models/search-types-enum';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { HttpService } from '@services/http/http.service';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, distinctUntilChanged, map, of, switchMap } from 'rxjs';
 import { fetchSearchResult, fetchSearchResultFailed, fetchSearchResultSuccess } from './tech-record-search.actions';
 
 @Injectable()
@@ -13,6 +13,9 @@ export class TechSearchResultsEffects {
 	fetchSearchResults$ = createEffect(() =>
 		this.actions$.pipe(
 			ofType(fetchSearchResult),
+			distinctUntilChanged(
+				(a, b) => a.searchBy === b.searchBy && a.term === b.term && a.includeArchived === b.includeArchived
+			),
 			switchMap(({ searchBy, term }) =>
 				this.httpService.searchTechRecords(searchBy ?? SEARCH_TYPES.ALL, term).pipe(
 					map((results) => fetchSearchResultSuccess({ payload: results })),

--- a/src/app/store/technical-records/technical-record-service.effects.ts
+++ b/src/app/store/technical-records/technical-record-service.effects.ts
@@ -19,6 +19,7 @@ import { State } from '@store/index';
 import { cloneDeep } from 'lodash';
 import { catchError, concatMap, filter, map, mergeMap, of, switchMap, tap, withLatestFrom } from 'rxjs';
 import { selectMergedRouteUrl } from '../router/router.selectors';
+import { selectTechRecordSearchResults } from '../tech-record-search/tech-record-search.selector';
 import {
 	amendVin,
 	amendVinSuccess,
@@ -74,13 +75,17 @@ export class TechnicalRecordServiceEffects {
 	getTechnicalRecordHistory$ = createEffect(() =>
 		this.actions$.pipe(
 			ofType(getBySystemNumber),
-			mergeMap((action) => {
+			withLatestFrom(this.store.select(selectTechRecordSearchResults)),
+			mergeMap(([action, cachedResults]) => {
 				const anchorLink = 'search-term';
+				const cached = cachedResults.filter((r) => r.systemNumber === action.systemNumber);
+
+				if (cached.length) {
+					return of(getBySystemNumberSuccess({ techRecordHistory: cached }));
+				}
 
 				return this.httpService.searchTechRecordBySystemNumber(action.systemNumber).pipe(
-					map((vehicleTechRecords) => {
-						return getBySystemNumberSuccess({ techRecordHistory: vehicleTechRecords });
-					}),
+					map((vehicleTechRecords) => getBySystemNumberSuccess({ techRecordHistory: vehicleTechRecords })),
 					catchError(() =>
 						of(getBySystemNumberFailure({ error: 'could not find technical record history', anchorLink }))
 					)

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 	provideZoneChangeDetection,
 } from '@angular/core';
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
-import { Router } from '@angular/router';
+import { RouteReuseStrategy, Router } from '@angular/router';
 import {
 	MSAL_GUARD_CONFIG,
 	MSAL_INSTANCE,
@@ -35,6 +35,7 @@ import { GoogleTagManagerModule } from 'angular-google-tag-manager';
 import { AppRoutingModule } from './app/app-routing.module';
 import { AppComponent } from './app/app.component';
 import { InterceptorModule } from './app/interceptors/interceptor.module';
+import { CustomRouteReuseStrategy } from './app/services/router/custom-route-reuse-strategy';
 import { UserService } from './app/services/user-service/user-service';
 import { AppStoreModule } from './app/store/app-store.module';
 import { environment } from './environments/environment';
@@ -146,6 +147,7 @@ bootstrapApplication(AppComponent, {
 				showDialog: false,
 			}),
 		},
+		{ provide: RouteReuseStrategy, useClass: CustomRouteReuseStrategy },
 		MsalService,
 		MsalGuard,
 		MsalBroadcastService,


### PR DESCRIPTION
## Ticket title
  - Replaced deprecated router.routeReuseStrategy mutations in 3 component constructors with a proper CustomRouteReuseStrategy class provided via DI at the app level                                            
  - The new strategy only skips route reuse when the route config or params actually differ, instead of blindly returning false for all routes
  - Removed onSameUrlNavigation: 'reload' from the router config — it was compensating for the old blanket () => false strategy and caused double spinner/reload on navigation  

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
