### PR TITLE
fix(CB2-21261): only lock axles on amend if there are axles

### DIFF
--- a/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.ts
@@ -138,8 +138,12 @@ export class VehicleTechnicalRecordV2Component implements OnInit, AfterViewInit,
 						techRecord.techRecord_vehicleType === VehicleTypes.HGV ||
 						techRecord.techRecord_vehicleType === VehicleTypes.TRL
 					) {
-						this.form.addControl('techRecord_axles', this.axlesService.generateAxlesForm(techRecord));
-						this.axlesService.setLockAxles(true);
+						const form = this.axlesService.generateAxlesForm(techRecord);
+						this.form.addControl('techRecord_axles', form);
+
+						if (form.controls.length > 0) {
+							this.axlesService.setLockAxles(true);
+						}
 
 						if (
 							techRecord.techRecord_vehicleType === VehicleTypes.TRL ||


### PR DESCRIPTION
## VTM INT: Creating Skeleton Record Disables Number of Axles Button on Amend

[CB2-21261](https://dvsa.atlassian.net/browse/CB2-21261)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21261]: https://dvsa.atlassian.net/browse/CB2-21261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ