### PR TITLE
fix(CB2-21257): decimal only on smoke absorbtion coefficient

### DIFF
--- a/src/app/forms/components/govuk-form-group-input/govuk-form-group-input.component.html
+++ b/src/app/forms/components/govuk-form-group-input/govuk-form-group-input.component.html
@@ -102,6 +102,7 @@
         inputmode="decimal"
         pattern="^\d*\.?\d*$"
         (blur)="onTouched(); onBlur($event)"
+        (wheel)="$event.preventDefault()"
         [class]="style"
         [disabled]="control?.disabled || disabled() || false"
         />

--- a/src/app/forms/custom-sections-v2/emissions-and-exemptions/emissions-and-exemptions.component.html
+++ b/src/app/forms/custom-sections-v2/emissions-and-exemptions/emissions-and-exemptions.component.html
@@ -30,6 +30,7 @@
       formControlName="techRecord_emissionsLimit"
       type="decimal"
       [width]="FormNodeWidth.XXS"
+      appDecimalOnly
       appFilterByTags
       [tagNames]="[]"
       [filters]="filters()"

--- a/src/app/forms/custom-sections-v2/emissions-and-exemptions/emissions-and-exemptions.component.ts
+++ b/src/app/forms/custom-sections-v2/emissions-and-exemptions/emissions-and-exemptions.component.ts
@@ -1,3 +1,4 @@
+import { DecimalOnlyDirective } from '@/src/app/directives/app-decimal-only/app-decimal-only.directive';
 import { FilterByTagsDirective } from '@/src/app/directives/filter-by-tags/filter-by-tags.directive';
 import { Modes } from '@/src/app/models/modes.enum';
 import { EMISSION_STANDARD_OPTIONS, EXEMPT_OR_NOT_OPTIONS, YES_NO_OPTIONS } from '@/src/app/models/options.model';
@@ -15,7 +16,13 @@ import { GovukFormGroupRadioComponent } from '../../components/govuk-form-group-
 	selector: 'app-emissions-and-exemptions',
 	templateUrl: './emissions-and-exemptions.component.html',
 	styleUrls: ['./emissions-and-exemptions.component.scss'],
-	imports: [ReactiveFormsModule, GovukFormGroupRadioComponent, GovukFormGroupInputComponent, FilterByTagsDirective],
+	imports: [
+		ReactiveFormsModule,
+		GovukFormGroupRadioComponent,
+		GovukFormGroupInputComponent,
+		FilterByTagsDirective,
+		DecimalOnlyDirective,
+	],
 })
 export class EmissionsAndExemptionsComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	tcs = inject(TechnicalRecordChangesService);


### PR DESCRIPTION
## The decimal input field accepts invalid numeric formats and incorrectly stores them as NULL instead of displaying validation errors.

[CB2-21257](https://dvsa.atlassian.net/browse/CB2-21257)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21257]: https://dvsa.atlassian.net/browse/CB2-21257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ