### PR TITLE
feat(cb2-18524): show test number for roadworthiness certificates

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -65,4 +65,24 @@ ignore:
       reason: Remediation not yet available
       expires: 2026-03-20T08:30:00.000Z
       created: 2026-02-20T08:30:00.000Z
+  SNYK-JS-BRACEEXPANSION-16755174:
+    - '*':
+      reason: Remediation not yet available
+      expires: 2026-03-20T09:00:00.000Z  
+      created: 2026-02-20T09:00:00.000Z
+  SNYK-JS-FASTURI-16642394:
+    - '*':
+      reason: Remediation not yet available
+      expires: 2026-03-20T09:00:00.000Z  
+      created: 2026-02-20T09:00:00.000Z
+  SNYK-JS-FASTURI-16642399:
+    - '*':
+      reason: Remediation not yet available
+      expires: 2026-03-20T09:00:00.000Z  
+      created: 2026-02-20T09:00:00.000Z
+  SNYK-JS-QS-16721866:
+    - '*':
+      reason: Remediation not yet available
+      expires: 2026-03-20T08:30:00.000Z
+      created: 2026-02-20T08:30:00.000Z
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/router": "21.2.6",
         "@azure/msal-angular": "^3.0.24",
         "@azure/msal-browser": "^3.24.0",
-        "@dvsa/cvs-microservice-common": "^1.5.1",
+        "@dvsa/cvs-microservice-common": "^1.6.0",
         "@dvsa/cvs-type-definitions": "^12.5.0",
         "@ngneat/cashew": "^4.1.0",
         "@ngrx/effects": "^21.1.0",
@@ -3916,9 +3916,9 @@
       "license": "ISC"
     },
     "node_modules/@dvsa/cvs-microservice-common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-microservice-common/-/cvs-microservice-common-1.5.1.tgz",
-      "integrity": "sha512-O+rEzwn007acf2an75SyL8raGtmEedbTAlPLqzFDlxKVuikG3cCu8Zr1YnwG5ySj3rR0JpjV8DT24VI0F7KstQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-microservice-common/-/cvs-microservice-common-1.6.0.tgz",
+      "integrity": "sha512-Awhb8CTjw1iJKYYcpRjt6G51KSB9V0lnqmBq6BjR6Rthway1A8qe47S0eSY2EjJdIqjnccGreAsHoqxT4kxoPg==",
       "license": "ISC",
       "dependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/router": "21.2.6",
     "@azure/msal-angular": "^3.0.24",
     "@azure/msal-browser": "^3.24.0",
-    "@dvsa/cvs-microservice-common": "^1.5.1",
+    "@dvsa/cvs-microservice-common": "^1.6.0",
     "@dvsa/cvs-type-definitions": "^12.5.0",
     "@ngneat/cashew": "^4.1.0",
     "@ngrx/effects": "^21.1.0",

--- a/src/app/features/test-records/components/vehicle-header/__tests__/vehicle-header.component.spec.ts
+++ b/src/app/features/test-records/components/vehicle-header/__tests__/vehicle-header.component.spec.ts
@@ -129,4 +129,22 @@ describe('VehicleHeaderComponent', () => {
 			expect(component.shouldShowAbandonCert).toBe(false);
 		});
 	});
+
+	describe('getCertificateLinkText', () => {
+		it('should return null if test is undefined', () => {
+			expect(component.getCertificateLinkText(undefined)).toBe(null);
+		});
+
+		it('should return testNumber for roadworthiness tests', () => {
+			expect(
+				component.getCertificateLinkText({ testTypeId: '62', testNumber: '12345' } as TestResultTestTypeSchema)
+			).toBe('12345');
+		});
+
+		it('should return certificateNumber for other tests', () => {
+			expect(component.getCertificateLinkText({ certificateNumber: '12345' } as TestResultTestTypeSchema)).toBe(
+				'12345'
+			);
+		});
+	});
 });

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.html
@@ -213,10 +213,10 @@
                   [fileName]="`${testNumber()}_${testResult.vin}`"
                   [documentType]="DocumentType.CERTIFICATE"
                 >
-                  {{ test?.certificateNumber | defaultNullOrEmpty }}
+                  {{ getCertificateLinkText(test) | defaultNullOrEmpty }}
                 </a>
               } @else {
-                {{ test?.certificateNumber | defaultNullOrEmpty }}
+                {{ getCertificateLinkText(test) | defaultNullOrEmpty }}
               }
             </dd>
           </div>

--- a/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
+++ b/src/app/features/test-records/components/vehicle-header/vehicle-header.component.ts
@@ -23,6 +23,7 @@ import {
 	ADR_DESK_BASED_TEST_TYPE_IDS,
 	TEST_TYPES_GROUP1_SPEC_TEST,
 	TEST_TYPES_GROUP5_SPEC_TEST,
+	TEST_TYPES_GROUP6_11,
 	TEST_TYPES_GROUP7,
 	TEST_TYPES_VTP_VTG_12,
 } from '@models/testTypeId.enum';
@@ -196,6 +197,13 @@ export class VehicleHeaderComponent {
 		if (TEST_TYPES_GROUP1_SPEC_TEST.includes(testTypeId) && testResult !== TestResults.FAIL) return false; // IVA tests
 		if (TEST_TYPES_GROUP5_SPEC_TEST.includes(testTypeId) && testResult !== TestResults.FAIL) return false; // MSVA tests
 		return true;
+	}
+
+	getCertificateLinkText(test: TestResultTestTypeSchema | undefined): string | null | undefined {
+		if (!test) return null;
+		const { certificateNumber, testTypeId, testNumber } = test;
+		if (TEST_TYPES_GROUP6_11.includes(testTypeId)) return testNumber; // For roadworthiness tests, use testNumber
+		return certificateNumber;
 	}
 
 	protected readonly VehicleTypes = VehicleType;


### PR DESCRIPTION
## VTM: Voluntary Roadworthiness Fail Certificate Number Missing in Test Record

[CB2-18524](https://dvsa.atlassian.net/browse/CB2-18524)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-18524]: https://dvsa.atlassian.net/browse/CB2-18524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ