### PR TITLE
feat(CB2-21757): add not applicable checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@azure/msal-angular": "^3.0.24",
         "@azure/msal-browser": "^3.24.0",
         "@dvsa/cvs-microservice-common": "^1.6.0",
-        "@dvsa/cvs-type-definitions": "^13.0.0",
+        "@dvsa/cvs-type-definitions": "^13.1.0",
         "@ngneat/cashew": "^4.1.0",
         "@ngrx/effects": "^21.1.0",
         "@ngrx/entity": "^21.1.0",
@@ -3927,9 +3927,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-13.0.0.tgz",
-      "integrity": "sha512-hmGC1B9ZLCTtNpt0w4SdS1fiXJX0DC7PomtS+mjdRknsm76fmSWzPA+OfkoMokmiWkMHXWmwdNgixjLJkyYW+w==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-13.1.0.tgz",
+      "integrity": "sha512-rDf0cz/CT0TPgEDsvpsHbjKfJoH027mQRF3W9PHDhwXD+WF2xRyFbkBj4TQHSNyj6RkNIHC1vKfWDGFL7G/+rA==",
       "license": "ISC",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@azure/msal-angular": "^3.0.24",
     "@azure/msal-browser": "^3.24.0",
     "@dvsa/cvs-microservice-common": "^1.6.0",
-    "@dvsa/cvs-type-definitions": "^13.0.0",
+    "@dvsa/cvs-type-definitions": "^13.1.0",
     "@ngneat/cashew": "^4.1.0",
     "@ngrx/effects": "^21.1.0",
     "@ngrx/entity": "^21.1.0",

--- a/src/app/forms/custom-sections/weights/__tests__/weights.component.spec.ts
+++ b/src/app/forms/custom-sections/weights/__tests__/weights.component.spec.ts
@@ -160,4 +160,24 @@ describe('WeightsComponent', () => {
 			});
 		});
 	});
+
+	describe('handleTrainWeightNotApplicable', () => {
+		it('should set the designGrossTrainWeight to null when the value is true', () => {
+			component.form.controls.weights.controls.designGrossTrainWeight.patchValue(1000);
+			component.form.controls.weights.controls.designTrainWeightRequired.patchValue(undefined);
+			component.handleTrainWeightNotApplicable(true);
+			expect(component.form.controls.weights.controls.designGrossTrainWeight.getRawValue()).toBe(null);
+			expect(component.form.controls.weights.controls.designTrainWeightRequired.getRawValue()).toBe(
+				component.NOT_APPLICABLE
+			);
+		});
+
+		it('should set the designTrainWeightRequired to undefined when the value is false', () => {
+			component.form.controls.weights.controls.designGrossTrainWeight.patchValue(1000);
+			component.form.controls.weights.controls.designTrainWeightRequired.patchValue(undefined);
+			component.handleTrainWeightNotApplicable(false);
+			expect(component.form.controls.weights.controls.designGrossTrainWeight.getRawValue()).toBe(1000);
+			expect(component.form.controls.weights.controls.designTrainWeightRequired.getRawValue()).toBe(undefined);
+		});
+	});
 });

--- a/src/app/forms/custom-sections/weights/weights.component.html
+++ b/src/app/forms/custom-sections/weights/weights.component.html
@@ -14,13 +14,32 @@
 
         @if (testResult.vehicleType === VehicleTypes.HGV) {
           <ng-container formGroupName="weights">
-            <govuk-form-group-input
-              [suffix]="'kg'"
-              [width]="FormNodeWidth.M"
-              type="number"
-              label="Design gross train weight"
-              formControlName="designGrossTrainWeight"
-            />
+            @if (form.controls.weights.controls.designGrossTrainWeight.disabled) {
+              <govuk-form-group-input
+                [suffix]="'kg'"
+                [width]="FormNodeWidth.M"
+                type="number"
+                label="Design gross train weight"
+                formControlName="designGrossTrainWeight"
+              />
+            } @else {
+              <h2 class="govuk-heading-m">Design train weight</h2>
+
+              <govuk-form-group-checkbox
+                label="Train weight not applicable"
+                [value]="form.controls.weights.controls.designTrainWeightRequired.getRawValue() === NOT_APPLICABLE"
+                (valueChange)="handleTrainWeightNotApplicable($event)"
+              />
+
+              @if (form.controls.weights.controls.designTrainWeightRequired.getRawValue() !== NOT_APPLICABLE) {
+                <govuk-form-group-input
+                  [suffix]="'kg'"
+                  [width]="FormNodeWidth.M"
+                  type="number"
+                  formControlName="designGrossTrainWeight"
+                />
+              }
+            }
           </ng-container>
         }
 
@@ -52,7 +71,11 @@
               Design gross train weight
             </td>
             <td class="govuk-table__cell" id="test-designGrossTrainWeight">
-              {{ testResult.weights?.designGrossTrainWeight ? `${testResult.weights?.designGrossTrainWeight || 0} kg` : '-' }}
+              @if (testResult.weights?.designTrainWeightRequired === NOT_APPLICABLE) {
+                Not applicable
+              } @else {
+                {{ testResult.weights?.designGrossTrainWeight ? `${testResult.weights?.designGrossTrainWeight || 0} kg` : '-' }}
+              } 
             </td>
           </tr>
         }

--- a/src/app/forms/custom-sections/weights/weights.component.ts
+++ b/src/app/forms/custom-sections/weights/weights.component.ts
@@ -5,9 +5,10 @@ import { selectTechRecord } from '@/src/app/store/technical-records';
 import { testResultInEdit, toEditOrNotToEdit } from '@/src/app/store/test-records';
 import { Component, OnDestroy, OnInit, inject, input, output } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TestResultSchema } from '@dvsa/cvs-type-definitions/types/v1/test-result';
+import { type DesignTrainWeightRequired, TestResultSchema } from '@dvsa/cvs-type-definitions/types/v1/test-result';
 import { Store } from '@ngrx/store';
 import { ReplaySubject, takeUntil } from 'rxjs';
+import { GovukFormGroupCheckboxComponent } from '../../components/govuk-form-group-checkbox/govuk-form-group-checkbox.component';
 import { GovukFormGroupInputComponent } from '../../components/govuk-form-group-input/govuk-form-group-input.component';
 import { CommonValidatorsService } from '../../validators/common-validators.service';
 
@@ -15,7 +16,7 @@ import { CommonValidatorsService } from '../../validators/common-validators.serv
 	selector: 'app-weights',
 	templateUrl: './weights.component.html',
 	styleUrls: ['./weights.component.scss'],
-	imports: [FormsModule, ReactiveFormsModule, GovukFormGroupInputComponent],
+	imports: [FormsModule, ReactiveFormsModule, GovukFormGroupInputComponent, GovukFormGroupCheckboxComponent],
 })
 export class WeightsComponent implements OnInit, OnDestroy {
 	store = inject(Store);
@@ -42,6 +43,10 @@ export class WeightsComponent implements OnInit, OnDestroy {
 				this.commonValidators.min(1, 'Design total axle weight', 'kg'),
 				this.commonValidators.max(99999, 'Design total axle weight', 'kg'),
 			]),
+			designTrainWeightRequired: this.fb.control<DesignTrainWeightRequired | undefined>({
+				value: undefined,
+				disabled: false,
+			}),
 		}),
 	});
 
@@ -51,6 +56,9 @@ export class WeightsComponent implements OnInit, OnDestroy {
 	destroy = new ReplaySubject<boolean>(1);
 	VehicleTypes = VehicleTypes;
 	FormNodeWidth = FormNodeWidth;
+
+	// @TODO: replace with enum when exposed as a .js file in the type definitions package
+	NOT_APPLICABLE = 'N/A' as DesignTrainWeightRequired.NOT_APPLICABLE;
 
 	ngOnInit(): void {
 		this.handleFormChange();
@@ -110,7 +118,12 @@ export class WeightsComponent implements OnInit, OnDestroy {
 				designGrossTrainWeight.patchValue(dgtw);
 				designGrossTrainWeight.disable();
 			}
-			designGrossTrainWeight.addValidators(this.commonValidators.required('Design gross train weight'));
+			designGrossTrainWeight.addValidators(
+				this.commonValidators.applyWhen(
+					() => this.form.controls.weights.controls.designTrainWeightRequired.getRawValue() !== this.NOT_APPLICABLE,
+					this.commonValidators.required('Design gross train weight')
+				)
+			);
 		}
 
 		// If the tech record has a total axle weight, pre-populate the form and disable the field, otherwise require manual input (in create mode)
@@ -121,6 +134,19 @@ export class WeightsComponent implements OnInit, OnDestroy {
 				designGrossAxleWeight.disable();
 			}
 			designGrossAxleWeight.addValidators(this.commonValidators.required('Design total axle weight'));
+		}
+	}
+
+	handleTrainWeightNotApplicable(value: unknown): void {
+		if (typeof value !== 'boolean') return;
+
+		const dgtw = this.form.controls.weights.controls.designGrossTrainWeight;
+		const dtwr = this.form.controls.weights.controls.designTrainWeightRequired;
+		if (value) {
+			dtwr.patchValue(this.NOT_APPLICABLE);
+			dgtw.patchValue(null); // clear design gross train weight
+		} else {
+			dtwr.patchValue(undefined);
 		}
 	}
 }


### PR DESCRIPTION
## VTM -Capture value N/A if vehicle does not have a train weight to record during Roadworthiness tests

[CB2-21757](https://dvsa.atlassian.net/browse/CB2-21757)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21757]: https://dvsa.atlassian.net/browse/CB2-21757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ