### PR TITLE
feat(CB2-21461): increase defect notes character limit from 200 to 500

### DIFF
--- a/src/app/forms/templates/test-records/section-templates/additionalDefects/additional-defects-section.template.ts
+++ b/src/app/forms/templates/test-records/section-templates/additionalDefects/additional-defects-section.template.ts
@@ -33,7 +33,7 @@ export const AdditionalDefectsSection: FormNode = {
 											name: 'defectNotes',
 											label: 'Defect Notes',
 											type: FormNodeTypes.CONTROL,
-											validators: [{ name: ValidatorNames.Required }, { name: ValidatorNames.MaxLength, args: 200 }],
+											validators: [{ name: ValidatorNames.Required }, { name: ValidatorNames.MaxLength, args: 500 }],
 										},
 									],
 								},


### PR DESCRIPTION
## FE- VTM-  Increase Character Limit on the Custom Defect Details Notes Fields when conducting an Approvals test on VTM

[CB2-21461](https://dvsa.atlassian.net/browse/CB2-21461)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21461]: https://dvsa.atlassian.net/browse/CB2-21461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ