### PR TITLE
fix(cb2-21829): use absolute route to ensure correct redirect

### DIFF
--- a/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
+++ b/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
@@ -15,7 +15,6 @@ import {
 	selectedTestResultState,
 	testResultInEdit,
 	toEditOrNotToEdit,
-	updateTestResultSuccess,
 } from '@/src/app/store/test-records';
 import { selectTestType } from '@/src/app/store/test-types/test-types.selectors';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
@@ -39,7 +38,7 @@ import { VisitComponent } from '@features/test-records/custom-sections/visit/vis
 import { Modes } from '@models/modes.enum';
 import { Roles } from '@models/roles.enum';
 import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
-import { Actions, ofType } from '@ngrx/effects';
+import { Actions } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TestRecordsService } from '@services/test-records/test-records.service';
 import { Observable, ReplaySubject, takeUntil } from 'rxjs';
@@ -103,20 +102,6 @@ export class TestRecordV2Component implements OnDestroy, OnInit {
 			if (this.mode() === Modes.EDIT || this.mode() === Modes.AMEND) {
 				this.testRecordService.updateEditingTestResult(this.form.getRawValue() as TestResultSchema);
 			}
-		});
-
-		this.actions$.pipe(ofType(updateTestResultSuccess), takeUntil(this.destroy$)).subscribe((action) => {
-			// Navigate to test record page
-			const testResult = action.payload.changes;
-			this.router.navigate([
-				'tech-records',
-				testResult.systemNumber,
-				testResult.createdAt,
-				'test-records',
-				'test-result',
-				testResult.testResultId,
-				testResult.testTypes?.at(0)?.testNumber,
-			]);
 		});
 	}
 

--- a/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
+++ b/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
@@ -106,8 +106,18 @@ export class TestRecordV2Component implements OnDestroy, OnInit {
 			}
 		});
 
-		this.actions$.pipe(ofType(updateTestResultSuccess), takeUntil(this.destroy$)).subscribe(() => {
-			void this.router.navigate(['..'], { relativeTo: this.route.parent });
+		this.actions$.pipe(ofType(updateTestResultSuccess), takeUntil(this.destroy$)).subscribe((action) => {
+			// Navigate to test record page
+			const testResult = action.payload.changes;
+			this.router.navigate([
+				'tech-records',
+				testResult.systemNumber,
+				testResult.createdAt,
+				'test-records',
+				'test-result',
+				testResult.testResultId,
+				testResult.testTypes?.at(0)?.testNumber,
+			]);
 		});
 	}
 

--- a/src/app/store/test-records/__tests__/test-records.effects.spec.ts
+++ b/src/app/store/test-records/__tests__/test-records.effects.spec.ts
@@ -140,6 +140,7 @@ jest.mock('@forms/templates/test-records/master.template', () => ({
 // This must be imported here to avoid the test suite failing -
 // https://stackoverflow.com/questions/65554910/jest-referenceerror-cannot-access-before-initialization/67114668#67114668
 import { createMockHgv } from '@/src/mocks/hgv-record.mock';
+import { Router } from '@angular/router';
 import { RecallsSchema } from '@dvsa/cvs-type-definitions/types/v1/recalls';
 import { TestResultSchema, VehicleType } from '@dvsa/cvs-type-definitions/types/v1/test-result';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb';
@@ -154,6 +155,7 @@ describe('TestResultsEffects', () => {
 	let store: MockStore<State>;
 	let featureToggleService: FeatureToggleService;
 	let httpService: HttpService;
+	let router: Router;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -203,6 +205,7 @@ describe('TestResultsEffects', () => {
 		testResultsService = TestBed.inject(TestRecordsService);
 		featureToggleService = TestBed.inject(FeatureToggleService);
 		httpService = TestBed.inject(HttpService);
+		router = TestBed.inject(Router);
 	});
 
 	beforeEach(() => {
@@ -887,6 +890,42 @@ describe('TestResultsEffects', () => {
 				expectObservable(effects.onGetRecalls$).toBe('---b', {
 					b: getRecallsFailure({ error: 'Bad Gateway' }),
 				});
+			});
+		});
+	});
+
+	describe('updateTestRecordSuccess$', () => {
+		it('should navigate to test record page', () => {
+			const spy = jest.spyOn(router, 'navigate');
+			const routeParams = {
+				systemNumber: '123456789',
+				createdTimestamp: '2022-01-01T00:00:00.000Z',
+				testResultId: '123456789',
+				testNumber: '123456789',
+			};
+
+			store.overrideSelector(selectRouteNestedParams, routeParams);
+
+			testScheduler.run(({ hot, flush }) => {
+				actions$ = hot('-a', {
+					a: updateTestResultSuccess({
+						payload: { id: '123456789', changes: {} as Partial<TestResultSchema> },
+					}),
+				});
+
+				effects.updateTestResultSuccess.subscribe();
+
+				flush();
+
+				expect(spy).toHaveBeenCalledWith([
+					'tech-records',
+					routeParams.systemNumber,
+					routeParams.createdTimestamp,
+					'test-records',
+					'test-result',
+					routeParams.testResultId,
+					routeParams.testNumber,
+				]);
 			});
 		});
 	});

--- a/src/app/store/test-records/test-records.effects.ts
+++ b/src/app/store/test-records/test-records.effects.ts
@@ -24,7 +24,7 @@ import { createFailedFirstTestResultSuccess, updateResultOfTest } from '@store/t
 import { getTestStationFromProperty } from '@store/test-stations';
 import { selectTestType } from '@store/test-types/test-types.selectors';
 import merge from 'lodash.merge';
-import { catchError, concatMap, filter, map, mergeMap, of, switchMap, take, withLatestFrom } from 'rxjs';
+import { catchError, concatMap, filter, map, mergeMap, of, switchMap, take, tap, withLatestFrom } from 'rxjs';
 import { GlobalErrorService } from '../../core/components/global-error/global-error.service';
 import { techRecord } from '../technical-records';
 import {
@@ -178,6 +178,26 @@ export class TestResultsEffects {
 					);
 			})
 		)
+	);
+
+	updateTestResultSuccess = createEffect(
+		() =>
+			this.actions$.pipe(
+				ofType(updateTestResultSuccess),
+				concatLatestFrom(() => this.store.select(selectRouteNestedParams)),
+				tap(([_, routeParams]) => {
+					this.router.navigate([
+						'tech-records',
+						routeParams['systemNumber'],
+						routeParams['createdTimestamp'],
+						'test-records',
+						'test-result',
+						routeParams['testResultId'],
+						routeParams['testNumber'],
+					]);
+				})
+			),
+		{ dispatch: false }
 	);
 
 	generateSectionTemplatesAndtestResultToUpdate$ = createEffect(() =>

--- a/src/app/store/test-records/test-records.reducer.ts
+++ b/src/app/store/test-records/test-records.reducer.ts
@@ -282,6 +282,11 @@ export function cleanTestResultPayload(testResult: TestResultSchema | undefined)
 			testType.reasonForAbandoning = testType.reasonForAbandoning.join('.');
 		}
 
+		// If required standards is an empty array, convert it to undefined
+		if (Array.isArray(testType.requiredStandards) && testType.requiredStandards.length === 0) {
+			testType.requiredStandards = undefined;
+		}
+
 		return testType;
 	});
 


### PR DESCRIPTION
## VTM - DFS Test types - Submitting an amended test brings the user back to the incorrect page

[CB2-21829](https://dvsa.atlassian.net/browse/CB2-21829)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-21829]: https://dvsa.atlassian.net/browse/CB2-21829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ