### PR TITLE
feat: perf improvements

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -3,3 +3,6 @@
 # modern baseline that supports the JS APIs we now use natively (e.g. Object.groupBy / Map.groupBy).
 last 2 years
 not dead
+not android > 0
+not opera > 0
+not samsung > 0

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+# Supported browsers for the application build (drives esbuild downleveling + CSS autoprefixing).
+# "last 2 years" gives the org leeway (no need to be on the very latest browser) while keeping a
+# modern baseline that supports the JS APIs we now use natively (e.g. Object.groupBy / Map.groupBy).
+last 2 years
+not dead

--- a/.claude/skills/angular-performance/SKILL.md
+++ b/.claude/skills/angular-performance/SKILL.md
@@ -1,0 +1,325 @@
+---
+
+name: angular-performance
+description: Audit and optimise Angular application performance. Use when reviewing Angular components, templates, routes, RxJS flows, signals, rendering, change detection, bundle size, startup time, memory usage, SSR, hydration, or runtime responsiveness. Do not apply speculative rewrites without identifying the likely bottleneck and expected impact.
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+# Angular Performance Optimisation
+
+Analyse Angular code for measurable or strongly evidenced performance problems, then make the smallest safe improvements.
+
+Prioritise changes that improve:
+
+1. Runtime rendering and interaction speed
+2. Network and bundle loading
+3. Change-detection work
+4. Memory usage and subscription cleanup
+5. SSR and hydration performance
+6. Maintainability without premature optimisation
+
+## Workflow
+
+When asked to review or optimise Angular code:
+
+1. Inspect the Angular version, project configuration, relevant dependencies, and application architecture.
+2. Establish the reported symptom:
+
+  * slow startup
+  * slow navigation
+  * delayed rendering
+  * repeated API calls
+  * UI jank
+  * high memory usage
+  * excessive bundle size
+  * slow tests or builds
+3. Identify likely bottlenecks before editing.
+4. Rank findings as:
+
+  * Critical
+  * High impact
+  * Moderate impact
+  * Minor or speculative
+5. Prefer targeted changes over broad rewrites.
+6. Preserve existing behaviour and public interfaces unless a breaking change is explicitly approved.
+7. Run the project's existing lint, typecheck, tests, and production build after changes.
+8. Explain what changed, why it should help, and how to measure the result.
+
+Do not claim a performance improvement is proven unless it was measured.
+
+## Change Detection
+
+Prefer modern Angular reactive patterns appropriate to the project's Angular version.
+
+Check for:
+
+* Components using default change detection where `OnPush` would safely reduce work
+* Mutable inputs that undermine `OnPush`
+* Methods, getters, object creation, or expensive expressions executed from templates
+* Manual `detectChanges()` or `markForCheck()` calls masking a design problem
+* Large component trees updated by unrelated state changes
+* Zone-triggered work caused by timers, event listeners, or third-party libraries
+* Opportunities for zoneless change detection when the project and dependencies support it
+
+Do not mechanically add `OnPush` without checking mutation patterns and view update behaviour.
+
+## Signals
+
+Prefer signals for local synchronous UI state when they simplify dependency tracking.
+
+Check for:
+
+* State copied unnecessarily between observables, component properties, and signals
+* Effects used where `computed()` is sufficient
+* Effects that write to their own dependencies or create update loops
+* Expensive computed values recreated unnecessarily
+* Signal reads spread across templates that could be grouped into meaningful computed state
+* Observable-to-signal conversions created repeatedly rather than once
+* Missing initial values or error handling in observable conversions
+
+Do not convert working RxJS orchestration into signals merely for stylistic consistency.
+
+## Templates and Rendering
+
+Inspect templates for repeated or unnecessary work.
+
+Prefer:
+
+* `@for` with a stable `track` expression
+* `trackBy` for projects using `*ngFor`
+* `@if`, `@switch`, and modern control flow when supported
+* Pure pipes for reusable deterministic transformations
+* Precomputed view models for expensive presentation logic
+* Virtual scrolling for genuinely large visible collections
+* Pagination or incremental loading where virtual scrolling is unsuitable
+* `@defer` for expensive below-the-fold or conditionally needed UI
+* Appropriate image dimensions, lazy loading, and Angular image optimisation
+
+Flag:
+
+* Function calls in templates
+* Getters performing filtering, sorting, mapping, parsing, or allocation
+* Inline object or array creation passed to child components
+* Missing or unstable list tracking
+* Nested loops over large collections
+* Re-sorting or re-filtering unchanged data
+* Rendering large hidden DOM trees
+* Excessive use of `ngClass` or `ngStyle` expressions with expensive calculations
+
+Do not recommend virtual scrolling for short or simple lists.
+
+## RxJS and Asynchronous Work
+
+Check observable flows for:
+
+* Sequential requests that could safely run concurrently
+* Nested subscriptions
+* Duplicate subscriptions causing duplicate HTTP requests
+* Missing sharing or caching where the same cold observable is consumed repeatedly
+* Incorrect use of `switchMap`, `mergeMap`, `concatMap`, or `exhaustMap`
+* Subscriptions that outlive their component or service
+* Manual subscription management where `async`, `toSignal`, or `takeUntilDestroyed` is clearer
+* Repeated high-frequency emissions that need debouncing, throttling, or deduplication
+* Expensive synchronous work inside operators
+* Waterfalls caused by awaiting independent operations one after another
+
+Use concurrency only when operations are independent and ordering is not required.
+
+Avoid adding `shareReplay` without defining:
+
+* cache lifetime
+* invalidation behaviour
+* error behaviour
+* whether stale values are acceptable
+
+## Dependency Injection and Services
+
+Check for:
+
+* Services accidentally provided multiple times
+* Heavy services instantiated eagerly
+* Repeated construction of clients, formatters, parsers, or configuration objects
+* Component-level providers that prevent intended sharing
+* Large global stores causing unrelated updates
+* State duplicated across multiple services
+* Side effects performed during service construction
+
+Prefer lazy creation when it materially reduces startup work.
+
+## Routing and Lazy Loading
+
+Inspect routing for:
+
+* Eagerly loaded feature areas
+* Components that can use `loadComponent`
+* Routes that can use `loadChildren`
+* Large guards or resolvers delaying navigation
+* Unnecessary resolver waterfalls
+* Preloading strategies that download too much too early
+* Shared modules that accidentally pull large dependencies into the initial bundle
+
+Preserve route behaviour and access control.
+
+## Bundle Size
+
+Use the production build and available bundle statistics before drawing conclusions.
+
+Check for:
+
+* Large third-party dependencies
+* Whole-library imports where supported subpath imports exist
+* Barrel exports that accidentally widen dependency graphs
+* Duplicate packages or incompatible dependency versions
+* Locale data loaded globally
+* Heavy editor, charting, PDF, mapping, or date libraries in the initial bundle
+* Development-only packages included in production paths
+* Polyfills no longer required by supported browsers
+* CommonJS dependencies reducing optimisation
+* Assets significantly larger than necessary
+
+Prefer lazy imports for expensive optional functionality.
+
+Do not replace a dependency solely because another package has a smaller advertised size. Consider functionality, tree-shaking, maintenance, compatibility, and migration cost.
+
+## Server-Side Rendering and Hydration
+
+For SSR applications, inspect:
+
+* Duplicate browser and server data requests
+* Missing transfer-state usage
+* Hydration mismatches
+* Browser-only APIs accessed during server rendering
+* Large serialised application state
+* Blocking route resolvers
+* Expensive synchronous server rendering
+* Components that should use incremental hydration or deferred loading
+* Event replay and hydration configuration appropriate to the Angular version
+
+Do not disable hydration merely to hide a mismatch. Find the mismatched state or markup.
+
+## Memory and Resource Management
+
+Check for:
+
+* Unreleased subscriptions
+* Event listeners not removed
+* Timers or intervals not cleared
+* Long-lived references to components or DOM nodes
+* Unbounded caches
+* Large replay buffers
+* Blob URLs not revoked
+* Observers not disconnected
+* Repeated registration of global handlers
+* Detached DOM retained by third-party libraries
+
+Prefer `DestroyRef` and `takeUntilDestroyed` when supported.
+
+## Network Performance
+
+Inspect:
+
+* Duplicate HTTP requests
+* APIs called during every change-detection or navigation cycle
+* Requests that fetch substantially more data than needed
+* Missing pagination
+* Waterfalls between independent requests
+* Polling without sensible intervals or visibility handling
+* Missing request cancellation
+* Large JSON transformations on the main thread
+* Cache behaviour that does not match data freshness requirements
+
+Do not introduce client caching without defining invalidation and consistency expectations.
+
+## Event Performance
+
+For frequent browser events such as scroll, pointer movement, resize, input, or drag:
+
+* Avoid triggering full application change detection unnecessarily
+* Use passive listeners where appropriate
+* Throttle or debounce only according to the interaction requirements
+* Move non-UI work outside Angular's change-detection context when safe
+* Re-enter Angular only when view state needs updating
+* Prefer `requestAnimationFrame` for visual updates tied to frames
+
+Do not debounce controls where every input event is semantically required.
+
+## Code Review Output
+
+For review-only requests, respond with:
+
+### Summary
+
+A brief assessment of the dominant performance risks.
+
+### Findings
+
+For each finding include:
+
+* Severity
+* File and relevant code
+* Why it may be slow
+* Likely impact
+* Recommended change
+* Any behavioural risk
+* How to verify it
+
+### Suggested order
+
+List fixes in expected impact-to-effort order.
+
+Avoid presenting minor stylistic preferences as performance findings.
+
+## Editing Behaviour
+
+When making changes:
+
+* Follow the repository's existing formatting and architecture
+* Avoid unrelated cleanup
+* Do not silently change API contracts
+* Add or update tests where behaviour could regress
+* Use framework APIs available in the installed Angular version
+* Do not install dependencies unless there is a clear benefit
+* Keep changes reviewable
+* Include before-and-after code only where useful
+
+## Verification
+
+Use the project's own commands where available.
+
+Common checks include:
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+Also consider:
+
+* Angular production build output
+* Bundle statistics
+* Angular DevTools profiler
+* Browser Performance panel
+* Network request counts
+* Lighthouse
+* Web Vitals
+* Memory heap snapshots
+* Rendering and scripting time
+* Change-detection counts
+
+Do not optimise solely against a synthetic score when it worsens real user behaviour.
+
+## Performance Principles
+
+Follow these principles:
+
+* Measure before and after when practical
+* Optimise the actual hot path
+* Fix architecture before adding micro-optimisations
+* Avoid repeated work
+* Avoid unnecessary rendering
+* Avoid unnecessary network sequencing
+* Load expensive functionality only when needed
+* Keep state ownership clear
+* Prefer stable object identities where they reduce downstream work
+* Balance performance, correctness, accessibility, and maintainability

--- a/src/app/features/search/search-results-wrapper/search-results-v2/search-results-v2.component.ts
+++ b/src/app/features/search/search-results-wrapper/search-results-v2/search-results-v2.component.ts
@@ -5,7 +5,7 @@ import { Roles } from '@/src/app/models/roles.enum';
 import { SEARCH_TYPES } from '@/src/app/models/search-types-enum';
 import { TechnicalRecordService } from '@/src/app/services/technical-record/technical-record.service';
 import { AsyncPipe } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { ReplaySubject, distinctUntilChanged, takeUntil } from 'rxjs';
@@ -17,6 +17,7 @@ import { SearchResultComponent } from './search-result/search-result.component';
 	templateUrl: './search-results-v2.component.html',
 	styleUrls: ['./search-results-v2.component.scss'],
 	imports: [SearchFormComponent, SearchResultComponent, RoleRequiredDirective, AsyncPipe, PaginationComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchResultsV2Component implements OnInit, OnDestroy {
 	store = inject(Store);

--- a/src/app/features/search/search-wrapper/search-v2/search-v2.component.ts
+++ b/src/app/features/search/search-wrapper/search-v2/search-v2.component.ts
@@ -1,6 +1,6 @@
 import { RoleRequiredDirective } from '@/src/app/directives/app-role-required/app-role-required.directive';
 import { Roles } from '@/src/app/models/roles.enum';
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { SearchFormComponent } from '../../search-form/search-form.component';
 
 @Component({
@@ -8,6 +8,7 @@ import { SearchFormComponent } from '../../search-form/search-form.component';
 	templateUrl: './search-v2.component.html',
 	styleUrls: ['./search-v2.component.scss'],
 	imports: [RoleRequiredDirective, SearchFormComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchV2Component {
 	roles = Roles;

--- a/src/app/features/tech-record/components/tech-record-summary-changes-wrapper/tech-record-summary-changes-v2/tech-record-summary-changes-v2.component.html
+++ b/src/app/features/tech-record/components/tech-record-summary-changes-wrapper/tech-record-summary-changes-v2/tech-record-summary-changes-v2.component.html
@@ -8,6 +8,7 @@
     <h1 class="govuk-heading-xl">Review technical record</h1>
 
     @if (amendedTechRecord(); as techRecord) {
+      @let vm = vehicleMeta();
       <div class="govuk-grid-row">
         <!-- Summary card -->
         <div class="govuk-grid-column-one-third-from-desktop vehicle-summary">
@@ -52,7 +53,7 @@
                         <app-accordion
                           [id]="'approval-type'"
                           [title]="'Approval type'"
-                          [description]="technicalRecordService.getApprovalTypeAccordionDescription(techRecord)"
+                          [description]="vm.approvalTypeDescription"
                           [type]="'condensed'"
                           [isExpanded]="true"
                         >
@@ -92,7 +93,7 @@
                         <app-accordion
                           [id]="'weights'"
                           [title]="'Weights'"
-                          [description]="technicalRecordService.getWeightsAccordionDescription(techRecord)"
+                          [description]="vm.weightsDescription"
                           [type]="'condensed'"
                           [isExpanded]="true"
                         >
@@ -105,7 +106,7 @@
                         <app-accordion
                           [id]="'tyres'"
                           [title]="'Tyres'"
-                          [description]="technicalRecordService.getTyresAccordionDescription(techRecord)"
+                          [description]="vm.tyresDescription"
                           [type]="'condensed'"
                           [isExpanded]="true"
                         >
@@ -118,7 +119,7 @@
                         <app-accordion
                           [id]="'configuration'"
                           [title]="'Configuration'"
-                          [description]="technicalRecordService.getConfigAccordionDescription(techRecord)"
+                          [description]="vm.configDescription"
                           [type]="'condensed'"
                           [isExpanded]="true"                        
                         >
@@ -157,7 +158,7 @@
                         <app-accordion
                           [id]="'brakes'"
                           [title]="'Brakes'"
-                          [description]="technicalRecordService.getBrakesAccordionDescription(techRecord)"
+                          [description]="vm.brakesDescription"
                           [type]="'condensed'"
                           [isExpanded]="true"
                         >

--- a/src/app/features/tech-record/components/tech-record-summary-changes-wrapper/tech-record-summary-changes-v2/tech-record-summary-changes-v2.component.ts
+++ b/src/app/features/tech-record/components/tech-record-summary-changes-wrapper/tech-record-summary-changes-v2/tech-record-summary-changes-v2.component.ts
@@ -38,7 +38,7 @@ import {
 	updateTechRecord,
 } from '@/src/app/store/technical-records';
 import { NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, OnDestroy, OnInit, computed, inject } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Actions } from '@ngrx/effects';
@@ -81,6 +81,7 @@ import { TechRecordSummaryCardComponent } from '../../tech-record-summary-card/t
 		ButtonComponent,
 		ButtonGroupComponent,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TechRecordSummaryChangesV2Component implements OnInit, AfterViewInit, OnDestroy {
 	store = inject(Store);
@@ -98,6 +99,20 @@ export class TechRecordSummaryChangesV2Component implements OnInit, AfterViewIni
 	currentTechRecord = this.store.selectSignal(techRecord);
 	amendedTechRecord = this.store.selectSignal(editingTechRecord);
 	sectionStates$ = this.store.selectSignal(selectSectionState);
+
+	// Precompute accordion descriptions once per edited record change. Vehicle-type type-guard
+	// predicates stay inline in the template so their narrowing of `techRecord` is preserved.
+	vehicleMeta = computed(() => {
+		const record = this.amendedTechRecord();
+		const svc = this.technicalRecordService;
+		return {
+			approvalTypeDescription: record ? svc.getApprovalTypeAccordionDescription(record) : '',
+			weightsDescription: record ? svc.getWeightsAccordionDescription(record) : '',
+			tyresDescription: record ? svc.getTyresAccordionDescription(record) : '',
+			configDescription: record ? svc.getConfigAccordionDescription(record) : '',
+			brakesDescription: record ? svc.getBrakesAccordionDescription(record) : '',
+		};
+	});
 
 	form = this.fb.group({});
 

--- a/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.html
+++ b/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.html
@@ -10,10 +10,11 @@
     <h1 class="govuk-heading-xl govuk-!-font-weight-bold">{{ isEditing ? 'Amend' : 'View' }} technical record</h1>
 
     @if (techRecord(); as techRecord) {
+      @let vm = vehicleMeta();
       <div class="govuk-grid-row">
         <!-- Summary card -->
         <div class="govuk-grid-column-one-third-from-desktop vehicle-summary">
-          <app-tech-record-summary-card [mode]=getCurrentMode() [techRecord]="techRecord" />
+          <app-tech-record-summary-card [mode]="isEditing ? Modes.EDIT : Modes.VIEW" [techRecord]="techRecord" />
 
           <div class="govuk-button-group govuk-button-group-record">
             <app-edit-tech-record-button
@@ -67,7 +68,7 @@
                         <app-accordion
                           [id]="'approval-type'"
                           [title]="'Approval type'"
-                          [description]="technicalRecordService.getApprovalTypeAccordionDescription(techRecord)"
+                          [description]="vm.approvalTypeDescription"
                           [type]="'condensed'"
                           [isExpanded]="false"
                           appFilterByTags
@@ -132,7 +133,7 @@
                         <app-accordion
                           [id]="'weights'"
                           [title]="'Weights'"
-                          [description]="technicalRecordService.getWeightsAccordionDescription(techRecord)"
+                          [description]="vm.weightsDescription"
                           [type]="'condensed'"
                           [isExpanded]="false"
                           appFilterByTags
@@ -154,7 +155,7 @@
                         <app-accordion
                           [id]="'tyres'"
                           [title]="'Tyres'"
-                          [description]="technicalRecordService.getTyresAccordionDescription(techRecord)"
+                          [description]="vm.tyresDescription"
                           [type]="'condensed'"
                           [isExpanded]="false"
                           appFilterByTags
@@ -176,7 +177,7 @@
                         <app-accordion
                           [id]="'configuration'"
                           [title]="'Configuration'"
-                          [description]="technicalRecordService.getConfigAccordionDescription(techRecord)"
+                          [description]="vm.configDescription"
                           [type]="'condensed'"
                           [isExpanded]="false"
                           appFilterByTags
@@ -242,7 +243,7 @@
                         <app-accordion
                           [id]="'brakes'"
                           [title]="'Brakes'"
-                          [description]="technicalRecordService.getBrakesAccordionDescription(techRecord)"
+                          [description]="vm.brakesDescription"
                           [type]="'condensed'"
                           [isExpanded]="false"
                           appFilterByTags

--- a/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.ts
@@ -59,7 +59,7 @@ import { TechnicalRecordsHistoryComponent } from '@forms/custom-sections-v2/tech
 import { TestResultsComponent } from '@forms/custom-sections-v2/test-history/test-records.component';
 import { Store } from '@ngrx/store';
 import { TestRecordsService } from '@services/test-records/test-records.service';
-import { ReplaySubject, skipWhile, take, takeUntil } from 'rxjs';
+import { ReplaySubject, debounceTime, skipWhile, take, takeUntil } from 'rxjs';
 import { EditTechRecordButtonComponent } from '../../edit-tech-record-button/edit-tech-record-button.component';
 import { TechRecordFiltersComponent } from '../../tech-record-filters/tech-record-filters.component';
 import { TechRecordSummaryCardComponent } from '../../tech-record-summary-card/tech-record-summary-card.component';
@@ -205,15 +205,21 @@ export class VehicleTechnicalRecordV2Component implements OnInit, AfterViewInit,
 	}
 
 	private handleFormChanges(): void {
-		this.form.valueChanges.pipe(takeUntil(this.destroy)).subscribe(() => {
-			this.technicalRecordService.updateEditingTechRecord(this.form.getRawValue() as TechRecordTypeVerb<'put'>);
-		});
+		// Debounce the live store mirror so rapid typing does not push a new editing record
+		// (which re-feeds every section's techRecord input) on every keystroke. Submit flushes synchronously.
+		this.form.valueChanges.pipe(debounceTime(100), takeUntil(this.destroy)).subscribe(() => this.syncFormToStore());
+	}
+
+	/** Immediately mirror the form into the store editing record (flushes any pending debounced change). */
+	private syncFormToStore(): void {
+		this.technicalRecordService.updateEditingTechRecord(this.form.getRawValue() as TechRecordTypeVerb<'put'>);
 	}
 
 	handleSubmit(): void {
 		this.globalErrorService.markAllAsTouched(this.form);
 
 		if (this.form.valid) {
+			this.syncFormToStore(); // flush before the change-summary route reads the store editing record
 			this.router.navigate(['change-summary'], { relativeTo: this.route });
 		}
 

--- a/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.ts
+++ b/src/app/features/tech-record/components/vehicle-technical-record-wrapper/vehicle-technical-record-v2/vehicle-technical-record-v2.component.ts
@@ -38,7 +38,17 @@ import { TechnicalRecordService } from '@/src/app/services/technical-record/tech
 import { selectQueryParam } from '@/src/app/store/router/router.selectors';
 import { selectSectionState } from '@/src/app/store/technical-records';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, Component, OnDestroy, OnInit, inject, input, model } from '@angular/core';
+import {
+	AfterViewInit,
+	ChangeDetectionStrategy,
+	Component,
+	OnDestroy,
+	OnInit,
+	computed,
+	inject,
+	input,
+	model,
+} from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
@@ -97,6 +107,7 @@ import { TechRecordSummaryCardComponent } from '../../tech-record-summary-card/t
 		TestResultsComponent,
 		AsyncPipe,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VehicleTechnicalRecordV2Component implements OnInit, AfterViewInit, OnDestroy {
 	fb = inject(FormBuilder);
@@ -122,6 +133,21 @@ export class VehicleTechnicalRecordV2Component implements OnInit, AfterViewInit,
 	destroy = new ReplaySubject<boolean>(1);
 
 	readonly VehicleTypes = VehicleTypes;
+
+	// Precompute accordion descriptions once per techRecord change instead of on every
+	// change-detection cycle. Vehicle-type type-guard predicates stay inline in the template
+	// so their control-flow narrowing of `techRecord` is preserved for child inputs.
+	vehicleMeta = computed(() => {
+		const techRecord = this.techRecord();
+		const svc = this.technicalRecordService;
+		return {
+			approvalTypeDescription: techRecord ? svc.getApprovalTypeAccordionDescription(techRecord) : '',
+			weightsDescription: techRecord ? svc.getWeightsAccordionDescription(techRecord) : '',
+			tyresDescription: techRecord ? svc.getTyresAccordionDescription(techRecord) : '',
+			configDescription: techRecord ? svc.getConfigAccordionDescription(techRecord) : '',
+			brakesDescription: techRecord ? svc.getBrakesAccordionDescription(techRecord) : '',
+		};
+	});
 
 	ngOnInit(): void {
 		this.handleFormChanges();
@@ -165,10 +191,6 @@ export class VehicleTechnicalRecordV2Component implements OnInit, AfterViewInit,
 					}
 				}
 			});
-	}
-
-	getCurrentMode(): Modes {
-		return this.isEditing ? Modes.EDIT : Modes.VIEW;
 	}
 
 	ngAfterViewInit(): void {

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record-wrapper/hydrate-new-vehicle-record-v2/hydrate-new-vehicle-record-v2.component.html
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record-wrapper/hydrate-new-vehicle-record-v2/hydrate-new-vehicle-record-v2.component.html
@@ -4,6 +4,7 @@
   </h1>
 
   @if (techRecord$(); as techRecord) {
+    @let vm = vehicleMeta();
     <div class="govuk-grid-row">
       <!-- Summary card -->
       <div class="govuk-grid-column-one-third-from-desktop vehicle-summary">
@@ -52,7 +53,7 @@
                       <app-accordion
                         [id]="'approval-type'"
                         [title]="'Approval type'"
-                        [description]="technicalRecordService.getApprovalTypeAccordionDescription(techRecord)"
+                        [description]="vm.approvalTypeDescription"
                         [type]="'condensed'"
                         [isExpanded]="false"
                         appFilterByTags
@@ -111,7 +112,7 @@
                       <app-accordion
                         [id]="'weights'"
                         [title]="'Weights'"
-                        [description]="technicalRecordService.getWeightsAccordionDescription(techRecord)"
+                        [description]="vm.weightsDescription"
                         [type]="'condensed'"
                         [isExpanded]="false"
                         appFilterByTags
@@ -131,7 +132,7 @@
                       <app-accordion
                         [id]="'tyres'"
                         [title]="'Tyres'"
-                        [description]="technicalRecordService.getTyresAccordionDescription(techRecord)"
+                        [description]="vm.tyresDescription"
                         [type]="'condensed'"
                         [isExpanded]="false"
                         appFilterByTags
@@ -151,7 +152,7 @@
                       <app-accordion
                         [id]="'configuration'"
                         [title]="'Configuration'"
-                        [description]="technicalRecordService.getConfigAccordionDescription(techRecord)"
+                        [description]="vm.configDescription"
                         [type]="'condensed'"
                         [isExpanded]="false"
                         appFilterByTags
@@ -211,7 +212,7 @@
                       <app-accordion
                         [id]="'brakes'"
                         [title]="'Brakes'"
-                        [description]="technicalRecordService.getBrakesAccordionDescription(techRecord)"
+                        [description]="vm.brakesDescription"
                         [type]="'condensed'"
                         [isExpanded]="false"
                         appFilterByTags
@@ -382,7 +383,7 @@
               </app-accordion-control>
             </div>
 
-            <app-tech-record-filters [tags]="tags" [(ngModel)]="filters" />
+            <app-tech-record-filters [tags]="tags()" [(ngModel)]="filters" />
 
             <!-- Accordions appear here -->
             <ng-container [ngTemplateOutlet]="template"></ng-container>

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record-wrapper/hydrate-new-vehicle-record-v2/hydrate-new-vehicle-record-v2.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record-wrapper/hydrate-new-vehicle-record-v2/hydrate-new-vehicle-record-v2.component.ts
@@ -18,7 +18,7 @@ import {
 	updateADRAdditionalExaminerNotes,
 } from '@/src/app/store/technical-records';
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, computed, inject, model } from '@angular/core';
 import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { GlobalErrorService } from '@core/components/global-error/global-error.service';
@@ -79,6 +79,7 @@ import { TechRecordSummaryCardComponent } from '../../../../components/tech-reco
 		FormsModule,
 		FilterByTagsDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HydrateNewVehicleRecordV2Component implements OnInit, OnDestroy {
 	store = inject(Store);
@@ -103,6 +104,19 @@ export class HydrateNewVehicleRecordV2Component implements OnInit, OnDestroy {
 
 	isEditing = false;
 	filters = model<string[]>([]);
+
+	// Precompute accordion descriptions once per record change instead of every change-detection cycle.
+	vehicleMeta = computed(() => {
+		const record = this.techRecord$();
+		const svc = this.technicalRecordService;
+		return {
+			approvalTypeDescription: record ? svc.getApprovalTypeAccordionDescription(record) : '',
+			weightsDescription: record ? svc.getWeightsAccordionDescription(record) : '',
+			tyresDescription: record ? svc.getTyresAccordionDescription(record) : '',
+			configDescription: record ? svc.getConfigAccordionDescription(record) : '',
+			brakesDescription: record ? svc.getBrakesAccordionDescription(record) : '',
+		};
+	});
 
 	ngOnInit(): void {
 		this.isEditing$.pipe(takeUntil(this.destroy)).subscribe((editing) => {
@@ -177,7 +191,7 @@ export class HydrateNewVehicleRecordV2Component implements OnInit, OnDestroy {
 		}
 	}
 
-	get tags(): string[] {
+	tags = computed<string[]>(() => {
 		switch (this.techRecord$()?.techRecord_vehicleType as VehicleTypes) {
 			case VehicleTypes.HGV:
 				return ['Plates', 'Required', 'ADR'];
@@ -196,5 +210,5 @@ export class HydrateNewVehicleRecordV2Component implements OnInit, OnDestroy {
 			default:
 				return [];
 		}
-	}
+	});
 }

--- a/src/app/features/tech-record/create/components/hydrate-new-vehicle-record-wrapper/hydrate-new-vehicle-record-v2/hydrate-new-vehicle-record-v2.component.ts
+++ b/src/app/features/tech-record/create/components/hydrate-new-vehicle-record-wrapper/hydrate-new-vehicle-record-v2/hydrate-new-vehicle-record-v2.component.ts
@@ -41,7 +41,7 @@ import { Store } from '@ngrx/store';
 import { AxlesService } from '@services/axles/axles.service';
 import { RouterService } from '@services/router/router.service';
 import { name } from '@store/user/user-service.reducer';
-import { ReplaySubject, map, skipWhile, take, takeUntil } from 'rxjs';
+import { ReplaySubject, debounceTime, map, skipWhile, take, takeUntil } from 'rxjs';
 import { TechRecordFiltersComponent } from '../../../../components/tech-record-filters/tech-record-filters.component';
 import { TechRecordSummaryCardComponent } from '../../../../components/tech-record-summary-card/tech-record-summary-card.component';
 
@@ -169,6 +169,7 @@ export class HydrateNewVehicleRecordV2Component implements OnInit, OnDestroy {
 
 		if (this.form.valid) {
 			this.globalErrorService.clearErrors();
+			this.syncFormToStore(); // flush pending debounced change so the ADR fix-up and create use the latest form value
 
 			// TODO: modify if new design is included in batch create
 			this.store.dispatch(updateADRAdditionalExaminerNotes({ username: this.username$() }));
@@ -180,9 +181,14 @@ export class HydrateNewVehicleRecordV2Component implements OnInit, OnDestroy {
 	}
 
 	private handleFormChanges(): void {
-		this.form.valueChanges.pipe(takeUntil(this.destroy)).subscribe(() => {
-			this.techRecordService.updateEditingTechRecord(this.form.getRawValue() as TechRecordType<'put'>);
-		});
+		// Debounce the live store mirror so rapid typing does not re-feed every section's techRecord
+		// input on every keystroke. onCreateNewRecord flushes synchronously before reading the store.
+		this.form.valueChanges.pipe(debounceTime(100), takeUntil(this.destroy)).subscribe(() => this.syncFormToStore());
+	}
+
+	/** Immediately mirror the form into the store editing record (flushes any pending debounced change). */
+	private syncFormToStore(): void {
+		this.techRecordService.updateEditingTechRecord(this.form.getRawValue() as TechRecordType<'put'>);
 	}
 
 	private handleEmptyEditingTechRecord(): void {

--- a/src/app/features/test-records/amend/views/test-record-wrapper/test-record-v2/test-record-v2.component.ts
+++ b/src/app/features/test-records/amend/views/test-record-wrapper/test-record-v2/test-record-v2.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
 	selector: 'app-test-record-v2',
 	templateUrl: './test-record-v2.component.html',
 	styleUrls: ['./test-record-v2.component.scss'],
 	imports: [],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TestRecordV2Component {}

--- a/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
+++ b/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
@@ -20,7 +20,18 @@ import {
 } from '@/src/app/store/test-records';
 import { selectTestType } from '@/src/app/store/test-types/test-types.selectors';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { Component, DOCUMENT, OnDestroy, OnInit, Signal, computed, inject, input, linkedSignal } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	DOCUMENT,
+	OnDestroy,
+	OnInit,
+	Signal,
+	computed,
+	inject,
+	input,
+	linkedSignal,
+} from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -71,6 +82,7 @@ import { AbandonComponent } from '../../../../custom-sections/abandon/abandon.co
 		RoleRequiredDirective,
 		TestAmendmentHistoryComponent,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TestRecordV2Component implements OnDestroy, OnInit {
 	store = inject(Store);

--- a/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
+++ b/src/app/features/test-records/create/views/create-test-record-wrapper/create-test-record-v2/test-record-v2.component.ts
@@ -54,7 +54,7 @@ import { StatusCodes, VehicleTypes } from '@models/vehicle-tech-record.model';
 import { Actions } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TestRecordsService } from '@services/test-records/test-records.service';
-import { Observable, ReplaySubject, takeUntil } from 'rxjs';
+import { Observable, ReplaySubject, debounceTime, takeUntil } from 'rxjs';
 import { VehicleHeaderComponent } from '../../../../components/vehicle-header/vehicle-header.component';
 import { AbandonComponent } from '../../../../custom-sections/abandon/abandon.component';
 @Component({
@@ -116,11 +116,18 @@ export class TestRecordV2Component implements OnDestroy, OnInit {
 	testNumber = computed(() => this.routeParams()['testNumber']);
 
 	private handleFormChanges(): void {
-		this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+		// Debounce the live store mirror so rapid typing does not push a new editing test result
+		// (and re-render every section) on every keystroke. Explicit actions flush synchronously.
+		this.form.valueChanges.pipe(debounceTime(100), takeUntil(this.destroy$)).subscribe(() => {
 			if (this.mode() === Modes.EDIT || this.mode() === Modes.AMEND) {
-				this.testRecordService.updateEditingTestResult(this.form.getRawValue() as TestResultSchema);
+				this.flushFormToStore();
 			}
 		});
+	}
+
+	/** Immediately mirror the form into the store editing test result (flushes any pending debounced change). */
+	private flushFormToStore(): void {
+		this.testRecordService.updateEditingTestResult(this.form.getRawValue() as TestResultSchema);
 	}
 
 	private handleMissingTestResult(): void {
@@ -210,6 +217,7 @@ export class TestRecordV2Component implements OnDestroy, OnInit {
 
 	onReview(): void {
 		this.form.markAllAsTouched();
+		this.flushFormToStore(); // ensure the store has the latest form value before the summary view reads it
 
 		const errors = this.globalErrorService.extractGlobalErrors(this.form);
 
@@ -302,6 +310,7 @@ export class TestRecordV2Component implements OnDestroy, OnInit {
 
 	onMarkAsAbandoned(): void {
 		this.form.markAllAsTouched();
+		this.flushFormToStore(); // capture any pending debounced change before leaving edit mode
 
 		const errors = this.globalErrorService.extractGlobalErrors(this.form);
 

--- a/src/app/features/test-records/custom-sections/abandon/abandon.component.ts
+++ b/src/app/features/test-records/custom-sections/abandon/abandon.component.ts
@@ -17,7 +17,7 @@ import { MultiOptionsService } from '@/src/app/services/multi-options/multi-opti
 import { TestService } from '@/src/app/services/test/test.service';
 import { selectAllReferenceDataByResourceType } from '@/src/app/store/reference-data';
 import { testResultInEdit } from '@/src/app/store/test-records';
-import { Component, OnInit, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, computed, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Store } from '@ngrx/store';
 
@@ -26,6 +26,7 @@ import { Store } from '@ngrx/store';
 	templateUrl: './abandon.component.html',
 	styleUrls: ['./abandon.component.scss'],
 	imports: [FormsModule, ReactiveFormsModule, GovukCheckboxGroupComponent, GovukFormGroupTextareaComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AbandonComponent implements OnInit {
 	store = inject(Store);

--- a/src/app/features/test-records/custom-sections/custom-defects/custom-defects.component.ts
+++ b/src/app/features/test-records/custom-sections/custom-defects/custom-defects.component.ts
@@ -1,5 +1,5 @@
 import { TestService } from '@/src/app/services/test/test.service';
-import { Component, forwardRef, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, input } from '@angular/core';
 import { FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { Modes } from '@models/modes.enum';
 
@@ -15,6 +15,7 @@ import { Modes } from '@models/modes.enum';
 			multi: true,
 		},
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CustomDefectsComponent {
 	testService = inject(TestService);

--- a/src/app/features/test-records/custom-sections/defects/defects.component.ts
+++ b/src/app/features/test-records/custom-sections/defects/defects.component.ts
@@ -9,7 +9,7 @@ import { DocumentsService } from '@/src/app/services/documents/documents.service
 import { TestService } from '@/src/app/services/test/test.service';
 import { toEditOrNotToEdit } from '@/src/app/store/test-records';
 import { HttpClient } from '@angular/common/http';
-import { Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { DefectDetailsSchema } from '@dvsa/cvs-type-definitions/types/v1/test-result';
 import { Store } from '@ngrx/store';
@@ -19,6 +19,7 @@ import { Store } from '@ngrx/store';
 	templateUrl: './defects.component.html',
 	imports: [ButtonComponent, RouterLink, TruncatePipe, TagComponent, DefectMediaDownloadComponent],
 	styleUrls: ['./defects.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DefectsComponent {
 	http = inject(HttpClient);

--- a/src/app/features/test-records/custom-sections/notes/notes.component.ts
+++ b/src/app/features/test-records/custom-sections/notes/notes.component.ts
@@ -2,7 +2,7 @@ import { CommonValidatorsService } from '@/src/app/forms/validators/common-valid
 import { DefaultNullOrEmpty } from '@/src/app/pipes/default-null-or-empty/default-null-or-empty.pipe';
 import { TestService } from '@/src/app/services/test/test.service';
 import { toEditOrNotToEdit } from '@/src/app/store/test-records';
-import { Component, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, input } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { GovukFormGroupTextareaComponent } from '@forms/components/govuk-form-group-textarea/govuk-form-group-textarea.component';
 import { Modes } from '@models/modes.enum';
@@ -13,6 +13,7 @@ import { Store } from '@ngrx/store';
 	templateUrl: './notes.component.html',
 	imports: [FormsModule, ReactiveFormsModule, GovukFormGroupTextareaComponent, DefaultNullOrEmpty],
 	styleUrls: ['./notes.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NotesComponent implements OnInit {
 	store = inject(Store);

--- a/src/app/features/test-records/custom-sections/reason-for-creation/reason-for-creation.component.ts
+++ b/src/app/features/test-records/custom-sections/reason-for-creation/reason-for-creation.component.ts
@@ -1,6 +1,6 @@
 import { CommonValidatorsService } from '@/src/app/forms/validators/common-validators.service';
 import { TestService } from '@/src/app/services/test/test.service';
-import { Component, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, input } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { GovukFormGroupTextareaComponent } from '@forms/components/govuk-form-group-textarea/govuk-form-group-textarea.component';
 import { Modes } from '@models/modes.enum';
@@ -10,6 +10,7 @@ import { Modes } from '@models/modes.enum';
 	templateUrl: './reason-for-creation.component.html',
 	imports: [FormsModule, ReactiveFormsModule, GovukFormGroupTextareaComponent],
 	styleUrls: ['./reason-for-creation.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReasonForCreationComponent implements OnInit {
 	testService = inject(TestService);

--- a/src/app/features/test-records/custom-sections/test/test.component.ts
+++ b/src/app/features/test-records/custom-sections/test/test.component.ts
@@ -11,7 +11,7 @@ import { FormNodeWidth } from '@/src/app/services/dynamic-forms/dynamic-form.typ
 import { TestService } from '@/src/app/services/test/test.service';
 import { toEditOrNotToEdit } from '@/src/app/store/test-records';
 import { DatePipe } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TestResults } from '@dvsa/cvs-type-definitions/types/v1/enums/testResult.enum.js';
 import { Modes } from '@models/modes.enum';
@@ -34,6 +34,7 @@ import { ReplaySubject, takeUntil } from 'rxjs';
 		DefaultNullOrEmpty,
 	],
 	styleUrls: ['./test.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TestComponent implements OnInit, OnDestroy {
 	store = inject(Store);

--- a/src/app/features/test-records/custom-sections/vehicle/vehicle.component.ts
+++ b/src/app/features/test-records/custom-sections/vehicle/vehicle.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@/src/app/store/reference-data';
 import { techRecord } from '@/src/app/store/technical-records';
 import { toEditOrNotToEdit } from '@/src/app/store/test-records';
-import { Component, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, input } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { Modes } from '@models/modes.enum';
@@ -33,6 +33,7 @@ import { Store } from '@ngrx/store';
 		GovukFormGroupRadioComponent,
 	],
 	styleUrls: ['./vehicle.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VehicleComponent implements OnInit {
 	store = inject(Store);

--- a/src/app/features/test-records/custom-sections/visit/visit.component.ts
+++ b/src/app/features/test-records/custom-sections/visit/visit.component.ts
@@ -2,7 +2,7 @@ import { DefaultNullOrEmpty } from '@/src/app/pipes/default-null-or-empty/defaul
 import { FormNodeWidth } from '@/src/app/services/dynamic-forms/dynamic-form.types';
 import { TestService } from '@/src/app/services/test/test.service';
 import { toEditOrNotToEdit } from '@/src/app/store/test-records';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TestStationTypes } from '@dvsa/cvs-type-definitions/types/v1/test-result';
 import { GovukFormGroupAutocompleteComponent } from '@forms/components/govuk-form-group-autocomplete/govuk-form-group-autocomplete.component';
@@ -29,6 +29,7 @@ import { ReplaySubject, takeUntil } from 'rxjs';
 		GovukFormGroupDateComponent,
 	],
 	styleUrls: ['./visit.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VisitComponent implements OnInit, OnDestroy {
 	store = inject(Store);

--- a/src/app/forms/custom-sections-v2/adr-certificates/adr-certificates.component.ts
+++ b/src/app/forms/custom-sections-v2/adr-certificates/adr-certificates.component.ts
@@ -8,7 +8,7 @@ import { StatusCodes } from '@/src/app/models/vehicle-tech-record.model';
 import { DefaultNullOrEmpty } from '@/src/app/pipes/default-null-or-empty/default-null-or-empty.pipe';
 import { AdrService } from '@/src/app/services/adr/adr.service';
 import { DatePipe, TitleCasePipe, ViewportScroller } from '@angular/common';
-import { ChangeDetectorRef, Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ADRCertificateDetails } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
@@ -27,6 +27,7 @@ import { DocumentType } from '@models/document-type.enum';
 		RetrieveDocumentDirective,
 		TitleCasePipe,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AdrCertificatesComponent {
 	cdr = inject(ChangeDetectorRef);

--- a/src/app/forms/custom-sections-v2/adr/adr.component.html
+++ b/src/app/forms/custom-sections-v2/adr/adr.component.html
@@ -1,4 +1,6 @@
 <div class="govuk-!-padding-4 govuk-label--s" [formGroup]="form">
+  <!-- Compute the raw form value once per change-detection cycle instead of cloning it in every canDisplay* check below. -->
+  @let adrForm = form.getRawValue();
   @if (form.get('techRecord_adrDetails_dangerousGoods')) {
     <govuk-form-group-radio
       label="Approved to carry dangerous goods"
@@ -148,7 +150,7 @@
         }
 
         @if (shouldDisplayFormControl('techRecord_adrDetails_bodyDeclaration_type')) {
-          @if (adrService.canDisplayBodyDeclarationSection($any(form.getRawValue()))) {
+          @if (adrService.canDisplayBodyDeclarationSection($any(adrForm))) {
             <govuk-form-group-radio
               size="small"
               label="Body declaration"
@@ -162,7 +164,7 @@
         }
 
         @if (shouldDisplayFormControl('techRecord_adrDetails_compatibilityGroupJ')) {
-          @if (adrService.canDisplayCompatibilityGroupJSection($any(form.getRawValue()))) {
+          @if (adrService.canDisplayCompatibilityGroupJSection($any(adrForm))) {
             <govuk-form-group-radio
               size="small"
               label="Compatibility group J"
@@ -199,7 +201,7 @@
         }
 
         <!-- When ADR body type contains the words 'tank' or 'battery' -->
-        @if (adrService.canDisplayTankOrBatterySection($any(form.getRawValue()))) {
+        @if (adrService.canDisplayTankOrBatterySection($any(adrForm))) {
           <!-- Tank details section -->
           @if (mode() !== Modes.SUMMARY || tcs.hasADRTankDetailsSectionChanged()) {
             <h3 class="govuk-label govuk-label--s">Tank details</h3>
@@ -282,7 +284,7 @@
             }
 
             <!-- When tank statement (substances permitted) is 'Under UN Number' -->
-            @if (adrService.canDisplayTankStatementSelectSection($any(form.getRawValue()))) {
+            @if (adrService.canDisplayTankStatementSelectSection($any(adrForm))) {
               <!-- Tank statement select -->
               @if (shouldDisplayFormControl('techRecord_adrDetails_tank_tankDetails_tankStatement_select')) {
                 <div class="govuk-!-margin-bottom-4">
@@ -299,7 +301,7 @@
               }
 
               <!-- When select is 'statement' -->
-              @if (adrService.canDisplayTankStatementStatementSection($any(form.getRawValue()))) {
+              @if (adrService.canDisplayTankStatementStatementSection($any(adrForm))) {
                 <!-- Reference number -->
                 @if (shouldDisplayFormControl('techRecord_adrDetails_tank_tankDetails_tankStatement_statement')) {
                   <govuk-form-group-input
@@ -313,7 +315,7 @@
               }
 
               <!-- When select is 'product '-->
-              @if (adrService.canDisplayTankStatementProductListSection($any(form.getRawValue()))) {
+              @if (adrService.canDisplayTankStatementProductListSection($any(adrForm))) {
                 <!-- Reference number -->
                 @if (shouldDisplayFormControl('techRecord_adrDetails_tank_tankDetails_tankStatement_productListRefNo')) {
                   <govuk-form-group-input
@@ -568,7 +570,7 @@
         }
 
         <!--   When ADR body type contains 'battery' -->
-        @if (adrService.canDisplayBatterySection($any(form.getRawValue()))) {
+        @if (adrService.canDisplayBatterySection($any(adrForm))) {
           <!-- Battery list applicable -->
           @if (shouldDisplayFormControl('techRecord_adrDetails_listStatementApplicable')) {
             <govuk-form-group-radio
@@ -584,7 +586,7 @@
           }
 
           <!-- When Battery list applicable is true -->
-          @if (adrService.canDisplayBatteryListNumberSection($any(form.getRawValue()))) {
+          @if (adrService.canDisplayBatteryListNumberSection($any(adrForm))) {
             <!-- Battery list reference number -->
             @if (shouldDisplayFormControl('techRecord_adrDetails_batteryListNumber')) {
               <govuk-form-group-input           
@@ -615,7 +617,7 @@
           ></govuk-form-group-checkbox>
         }
 
-        @if (adrService.canDisplayIssueSection($any(form.getRawValue()))) {
+        @if (adrService.canDisplayIssueSection($any(adrForm))) {
           <!-- Issuer -->
           @if (shouldDisplayFormControl('techRecord_adrDetails_brakeDeclarationIssuer')) {
             <govuk-form-group-textarea
@@ -644,7 +646,7 @@
           }
 
           <!-- Weight (tonnes) -->
-          @if (adrService.canDisplayWeightSection($any(form.getRawValue()))) {
+          @if (adrService.canDisplayWeightSection($any(adrForm))) {
             @if (shouldDisplayFormControl('techRecord_adrDetails_weight')) {
               <govuk-form-group-input
                 label="Weight"

--- a/src/app/forms/custom-sections-v2/adr/adr.component.ts
+++ b/src/app/forms/custom-sections-v2/adr/adr.component.ts
@@ -5,7 +5,7 @@ import { AdrService } from '@/src/app/services/adr/adr.service';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
 import { techRecord } from '@/src/app/store/technical-records/technical-record-service.selectors';
 import { DatePipe, ViewportScroller } from '@angular/common';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PaginationComponent } from '@components/pagination/pagination.component';
@@ -65,6 +65,7 @@ import { getOptionsFromEnum } from '../../utils/enum-map';
 		TrimWhitespaceDirective,
 		NoSpaceDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AdrComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	validators = inject(CommonValidatorsService);

--- a/src/app/forms/custom-sections-v2/approval-type/approval-type.component.ts
+++ b/src/app/forms/custom-sections-v2/approval-type/approval-type.component.ts
@@ -1,7 +1,16 @@
 import { FilterByTagsDirective } from '@/src/app/directives/filter-by-tags/filter-by-tags.directive';
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	OnChanges,
+	OnDestroy,
+	OnInit,
+	SimpleChanges,
+	inject,
+	input,
+} from '@angular/core';
 import {
 	type AbstractControl,
 	type FormControl,
@@ -37,6 +46,7 @@ import { ReplaySubject } from 'rxjs';
 		GovukFormGroupDateComponent,
 		FilterByTagsDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ApprovalTypeComponent extends EditBaseComponent implements OnInit, OnDestroy, OnChanges {
 	tcs = inject(TechnicalRecordChangesService);

--- a/src/app/forms/custom-sections-v2/authorisation-into-service/authorisation-into-service.component.ts
+++ b/src/app/forms/custom-sections-v2/authorisation-into-service/authorisation-into-service.component.ts
@@ -1,6 +1,6 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { GovukFormGroupDateComponent } from '@forms/components/govuk-form-group-date/govuk-form-group-date.component';
@@ -12,6 +12,7 @@ import { ReplaySubject } from 'rxjs';
 	templateUrl: './authorisation-into-service.component.html',
 	styleUrls: ['./authorisation-into-service.component.scss'],
 	imports: [ReactiveFormsModule, GovukFormGroupDateComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AuthorisationIntoServiceComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	tcs = inject(TechnicalRecordChangesService);

--- a/src/app/forms/custom-sections-v2/brakes/brakes.component.ts
+++ b/src/app/forms/custom-sections-v2/brakes/brakes.component.ts
@@ -5,7 +5,7 @@ import { MultiOptionsService } from '@/src/app/services/multi-options/multi-opti
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
 import { selectBrakeByCode } from '@/src/app/store/reference-data';
 import { updateBrakeForces, updateEditingTechRecord } from '@/src/app/store/technical-records';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormArray, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
 import { FieldErrorMessageComponent } from '@forms/components/field-error-message/field-error-message.component';
@@ -35,6 +35,7 @@ import { getOptionsFromEnum } from '../../utils/enum-map';
 		FieldWarningMessageComponent,
 		FieldErrorMessageComponent,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BrakesComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly FormNodeWidth = FormNodeWidth;

--- a/src/app/forms/custom-sections-v2/configuration/configuration.component.ts
+++ b/src/app/forms/custom-sections-v2/configuration/configuration.component.ts
@@ -1,7 +1,7 @@
 import { FilterByTagsDirective } from '@/src/app/directives/filter-by-tags/filter-by-tags.directive';
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FuelPropulsionSystem } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/hgv/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
@@ -26,6 +26,7 @@ import { ReplaySubject } from 'rxjs';
 		GovukFormGroupInputComponent,
 		FilterByTagsDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConfigurationComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly VehicleTypes = VehicleTypes;

--- a/src/app/forms/custom-sections-v2/dda/dda.component.ts
+++ b/src/app/forms/custom-sections-v2/dda/dda.component.ts
@@ -1,7 +1,7 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { YES_NO_NULL_OPTIONS } from '@/src/app/models/options.model';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
 import { V3TechRecordModel } from '@models/vehicle-tech-record.model';
@@ -22,6 +22,7 @@ import { GovukFormGroupTextareaComponent } from '../../components/govuk-form-gro
 		GovukFormGroupInputComponent,
 		GovukFormGroupTextareaComponent,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DDAComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly FormNodeWidth = FormNodeWidth;

--- a/src/app/forms/custom-sections-v2/dimensions/dimensions.component.ts
+++ b/src/app/forms/custom-sections-v2/dimensions/dimensions.component.ts
@@ -3,7 +3,7 @@ import { FilterByTagsDirective } from '@/src/app/directives/filter-by-tags/filte
 import { Modes } from '@/src/app/models/modes.enum';
 import { VehicleTypes } from '@/src/app/models/vehicle-tech-record.model';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormArray, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { FieldWarningMessageComponent } from '@forms/components/field-warning-message/field-warning-message.component';
@@ -24,6 +24,7 @@ import { ReplaySubject, takeUntil } from 'rxjs';
 		FieldWarningMessageComponent,
 		FilterByTagsDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DimensionsComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	readonly VehicleTypes = VehicleTypes;

--- a/src/app/forms/custom-sections-v2/documents/documents.component.ts
+++ b/src/app/forms/custom-sections-v2/documents/documents.component.ts
@@ -1,7 +1,7 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { VehicleTypes } from '@/src/app/models/vehicle-tech-record.model';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { GovukFormGroupAutocompleteComponent } from '@forms/components/govuk-form-group-autocomplete/govuk-form-group-autocomplete.component';
@@ -16,6 +16,7 @@ import { ReplaySubject, of } from 'rxjs';
 	templateUrl: './documents.component.html',
 	styleUrls: ['./documents.component.scss'],
 	imports: [FormsModule, ReactiveFormsModule, GovukFormGroupInputComponent, GovukFormGroupAutocompleteComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DocumentsComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	readonly VehicleTypes = VehicleTypes;

--- a/src/app/forms/custom-sections-v2/emissions-and-exemptions/emissions-and-exemptions.component.ts
+++ b/src/app/forms/custom-sections-v2/emissions-and-exemptions/emissions-and-exemptions.component.ts
@@ -4,7 +4,7 @@ import { Modes } from '@/src/app/models/modes.enum';
 import { EMISSION_STANDARD_OPTIONS, EXEMPT_OR_NOT_OPTIONS } from '@/src/app/models/options.model';
 import { FormNodeWidth } from '@/src/app/services/dynamic-forms/dynamic-form.types';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
 import { V3TechRecordModel, VehicleTypes } from '@models/vehicle-tech-record.model';
@@ -23,6 +23,7 @@ import { GovukFormGroupRadioComponent } from '../../components/govuk-form-group-
 		FilterByTagsDirective,
 		DecimalOnlyDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EmissionsAndExemptionsComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	tcs = inject(TechnicalRecordChangesService);

--- a/src/app/forms/custom-sections-v2/general-vehicle-details/general-vehicle-details.component.ts
+++ b/src/app/forms/custom-sections-v2/general-vehicle-details/general-vehicle-details.component.ts
@@ -5,7 +5,16 @@ import { FilterByTagsDirective } from '@/src/app/directives/filter-by-tags/filte
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, effect, inject, input } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	ChangeDetectorRef,
+	Component,
+	OnDestroy,
+	OnInit,
+	effect,
+	inject,
+	input,
+} from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { EUVehicleCategory } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/euVehicleCategory.enum.js';
 import { VehicleClassDescription } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/vehicleClassDescription.enum.js';
@@ -70,6 +79,7 @@ import { GovukCheckboxGroupComponent } from '../../components/govuk-checkbox-gro
 		NoSpaceDirective,
 		FilterByTagsDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GeneralVehicleDetailsComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly Modes = Modes;

--- a/src/app/forms/custom-sections-v2/last-applicant/last-applicant.component.ts
+++ b/src/app/forms/custom-sections-v2/last-applicant/last-applicant.component.ts
@@ -1,6 +1,6 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { GovukFormGroupInputComponent } from '@forms/components/govuk-form-group-input/govuk-form-group-input.component';
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
@@ -13,6 +13,7 @@ import { ReplaySubject } from 'rxjs';
 	templateUrl: './last-applicant.component.html',
 	styleUrls: ['./last-applicant.component.scss'],
 	imports: [ReactiveFormsModule, GovukFormGroupInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LastApplicantComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly FormNodeWidth = FormNodeWidth;

--- a/src/app/forms/custom-sections-v2/letter-of-authorisation/letter-of-authorisation.component.ts
+++ b/src/app/forms/custom-sections-v2/letter-of-authorisation/letter-of-authorisation.component.ts
@@ -7,7 +7,7 @@ import { DefaultNullOrEmpty } from '@/src/app/pipes/default-null-or-empty/defaul
 import { TechnicalRecordService } from '@/src/app/services/technical-record/technical-record.service';
 import { selectNonViewedCurrentTechRecordFromHistory, updateScrollPosition } from '@/src/app/store/technical-records';
 import { DatePipe, NgTemplateOutlet, ViewportScroller } from '@angular/common';
-import { Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ParagraphIds } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/trl/complete';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-verb-vehicle-type';
@@ -28,6 +28,7 @@ import { FieldWarningMessageComponent } from '../../components/field-warning-mes
 		DatePipe,
 		NgTemplateOutlet,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LetterOfAuthorisationComponent {
 	store = inject(Store);

--- a/src/app/forms/custom-sections-v2/manufacturer/manufacturer.component.ts
+++ b/src/app/forms/custom-sections-v2/manufacturer/manufacturer.component.ts
@@ -1,6 +1,6 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { GovukFormGroupInputComponent } from '@forms/components/govuk-form-group-input/govuk-form-group-input.component';
@@ -14,6 +14,7 @@ import { ReplaySubject } from 'rxjs';
 	templateUrl: './manufacturer.component.html',
 	styleUrls: ['./manufacturer.component.scss'],
 	imports: [GovukFormGroupTextareaComponent, ReactiveFormsModule, GovukFormGroupInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ManufacturerComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly FormNodeWidth = FormNodeWidth;

--- a/src/app/forms/custom-sections-v2/notes/notes.component.ts
+++ b/src/app/forms/custom-sections-v2/notes/notes.component.ts
@@ -1,6 +1,6 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { GovukFormGroupTextareaComponent } from '@forms/components/govuk-form-group-textarea/govuk-form-group-textarea.component';
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
@@ -12,6 +12,7 @@ import { ReplaySubject } from 'rxjs';
 	templateUrl: './notes.component.html',
 	styleUrls: ['./notes.component.scss'],
 	imports: [GovukFormGroupTextareaComponent, ReactiveFormsModule],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NotesComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	tcs = inject(TechnicalRecordChangesService);

--- a/src/app/forms/custom-sections-v2/plates/plates.component.ts
+++ b/src/app/forms/custom-sections-v2/plates/plates.component.ts
@@ -9,7 +9,7 @@ import { Axle, StatusCodes, VehicleTypes } from '@/src/app/models/vehicle-tech-r
 import { DefaultNullOrEmpty } from '@/src/app/pipes/default-null-or-empty/default-null-or-empty.pipe';
 import { canGeneratePlate, updateScrollPosition } from '@/src/app/store/technical-records';
 import { DatePipe, ViewportScroller } from '@angular/common';
-import { ChangeDetectorRef, Component, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, input } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { DocumentType } from '@models/document-type.enum';
@@ -29,6 +29,7 @@ import { FieldWarningMessageComponent } from '../../components/field-warning-mes
 		PaginationComponent,
 		RetrieveDocumentDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PlatesComponent {
 	store = inject(Store);

--- a/src/app/forms/custom-sections-v2/purchasers/purchasers.component.ts
+++ b/src/app/forms/custom-sections-v2/purchasers/purchasers.component.ts
@@ -1,6 +1,6 @@
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
 import { GovukFormGroupInputComponent } from '@forms/components/govuk-form-group-input/govuk-form-group-input.component';
@@ -14,6 +14,7 @@ import { ReplaySubject } from 'rxjs';
 	templateUrl: './purchasers.component.html',
 	styleUrls: ['./purchasers.component.scss'],
 	imports: [GovukFormGroupTextareaComponent, ReactiveFormsModule, GovukFormGroupInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PurchasersComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	protected readonly FormNodeWidth = FormNodeWidth;

--- a/src/app/forms/custom-sections-v2/reason-for-creation/reason-for-creation.component.ts
+++ b/src/app/forms/custom-sections-v2/reason-for-creation/reason-for-creation.component.ts
@@ -1,5 +1,5 @@
 import { Modes } from '@/src/app/models/modes.enum';
-import { Component, OnDestroy, OnInit, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, input } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { GovukFormGroupTextareaComponent } from '@forms/components/govuk-form-group-textarea/govuk-form-group-textarea.component';
 import { EditBaseComponent } from '@forms/custom-sections/edit-base-component/edit-base-component';
@@ -11,6 +11,7 @@ import { ReplaySubject } from 'rxjs';
 	templateUrl: './reason-for-creation.component.html',
 	styleUrls: ['./reason-for-creation.component.scss'],
 	imports: [ReactiveFormsModule, GovukFormGroupTextareaComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReasonForCreationComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	destroy$ = new ReplaySubject<boolean>(1);

--- a/src/app/forms/custom-sections-v2/seats-and-vehicle-size/seats-and-vehicle-size.component.ts
+++ b/src/app/forms/custom-sections-v2/seats-and-vehicle-size/seats-and-vehicle-size.component.ts
@@ -1,7 +1,7 @@
 import { FilterByTagsDirective } from '@/src/app/directives/filter-by-tags/filter-by-tags.directive';
 import { Modes } from '@/src/app/models/modes.enum';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
-import { Component, OnDestroy, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, input } from '@angular/core';
 import { AbstractControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { TagType } from '@components/tag/tag.component';
 import { VehicleClassDescription } from '@dvsa/cvs-type-definitions/types/v3/tech-record/enums/vehicleClassDescription.enum.js';
@@ -25,6 +25,7 @@ import { ReplaySubject } from 'rxjs';
 		GovukFormGroupDateComponent,
 		FilterByTagsDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SeatsAndVehicleSizeComponent extends EditBaseComponent implements OnInit, OnDestroy {
 	tcs = inject(TechnicalRecordChangesService);

--- a/src/app/forms/custom-sections-v2/tech-record-history/tech-record-history.component.ts
+++ b/src/app/forms/custom-sections-v2/tech-record-history/tech-record-history.component.ts
@@ -1,6 +1,6 @@
 import { selectQueryParam } from '@/src/app/store/router/router.selectors';
 import { AsyncPipe, DatePipe, TitleCasePipe } from '@angular/common';
-import { ChangeDetectorRef, Component, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
@@ -15,6 +15,7 @@ import { Observable, map } from 'rxjs';
 	templateUrl: './tech-record-history.component.html',
 	styleUrls: ['./tech-record-history.component.scss'],
 	imports: [ButtonComponent, DatePipe, PaginationComponent, RouterLink, AsyncPipe, TitleCasePipe],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TechnicalRecordsHistoryComponent extends EditBaseComponent implements OnInit {
 	techRecord = input.required<TechRecordType<'get'>>();

--- a/src/app/forms/custom-sections-v2/test-history/test-records.component.ts
+++ b/src/app/forms/custom-sections-v2/test-history/test-records.component.ts
@@ -1,5 +1,5 @@
 import { DatePipe, TitleCasePipe, ViewportScroller } from '@angular/common';
-import { ChangeDetectorRef, Component, OnInit, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, input } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { PaginationComponent } from '@components/pagination/pagination.component';
@@ -30,6 +30,7 @@ interface TestField {
 	templateUrl: './test-records.component.html',
 	styleUrls: ['./test-records.component.scss'],
 	imports: [ButtonComponent, RoleRequiredDirective, DatePipe, PaginationComponent, RouterLink, TitleCasePipe],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TestResultsComponent extends EditBaseComponent implements OnInit {
 	testResults = input<TestResultSchema[]>([]);
@@ -54,6 +55,8 @@ export class TestResultsComponent extends EditBaseComponent implements OnInit {
 			this.hasTestResultAmend = storedRoles?.some((role) => {
 				return Roles.TestResultAmend.split(',').includes(role);
 			});
+			// roles$ may resolve asynchronously; mark for check so OnPush picks up the update.
+			this.cdr.markForCheck();
 		});
 	}
 

--- a/src/app/forms/custom-sections-v2/tyres/__tests__/tyres.component.spec.ts
+++ b/src/app/forms/custom-sections-v2/tyres/__tests__/tyres.component.spec.ts
@@ -93,18 +93,5 @@ describe('TyresSectionEditComponent', () => {
 				'tyres_fitmentCode',
 			]);
 		});
-
-		it('should complete destroy$ subject', () => {
-			const completeSpy = jest.spyOn(component.destroy$, 'complete');
-			component.ngOnDestroy();
-			expect(completeSpy).toHaveBeenCalled();
-		});
-
-		it('should emit true to destroy$ subject', () => {
-			let emittedValue: boolean | undefined;
-			component.destroy$.subscribe((value) => (emittedValue = value));
-			component.ngOnDestroy();
-			expect(emittedValue).toBe(true);
-		});
 	});
 });

--- a/src/app/forms/custom-sections-v2/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections-v2/tyres/tyres.component.ts
@@ -14,6 +14,7 @@ import {
 	inject,
 	input,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormArray, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
@@ -32,9 +33,10 @@ import {
 import { ReferenceDataResourceType, ReferenceDataTyre, ReferenceDataTyreLoadIndex } from '@models/reference-data.model';
 import { AxlesService } from '@services/axles/axles.service';
 import { FormNodeWidth, TagTypeLabels } from '@services/dynamic-forms/dynamic-form.types';
-import { selectAllReferenceDataByResourceType } from '@store/reference-data';
+import { ReferenceDataService } from '@services/reference-data/reference-data.service';
 import { updateScrollPosition } from '@store/technical-records';
 import { cloneDeep } from 'lodash';
+import { filter } from 'rxjs';
 
 @Component({
 	selector: 'app-tyres',
@@ -62,6 +64,7 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 	protected readonly HGV_TYRE_USE_CODE_OPTIONS = HGV_TYRE_USE_CODE_OPTIONS;
 	protected readonly TRL_TYRE_USE_CODE_OPTIONS = TRL_TYRE_USE_CODE_OPTIONS;
 
+	referenceDataService = inject(ReferenceDataService);
 	viewportScroller = inject(ViewportScroller);
 	router = inject(Router);
 	route = inject(ActivatedRoute);
@@ -75,13 +78,15 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 	filters = input<string[]>([]);
 	mode = input.required<Modes>();
 
-	private readonly tyresReferenceData = this.store.selectSignal(
-		selectAllReferenceDataByResourceType(ReferenceDataResourceType.Tyres)
-	) as Signal<ReferenceDataTyre[] | undefined>;
+	private readonly tyresReferenceData = toSignal(
+		this.referenceDataService.getAll$(ReferenceDataResourceType.Tyres).pipe(filter(Boolean)),
+		{ initialValue: [] }
+	) as Signal<ReferenceDataTyre[]>;
 
-	private readonly tyreLoadIndexReferenceData = this.store.selectSignal(
-		selectAllReferenceDataByResourceType(ReferenceDataResourceType.TyreLoadIndex)
-	) as Signal<ReferenceDataTyreLoadIndex[] | undefined>;
+	private readonly tyreLoadIndexReferenceData = toSignal(
+		this.referenceDataService.getAll$(ReferenceDataResourceType.TyreLoadIndex).pipe(filter(Boolean)),
+		{ initialValue: [] }
+	) as Signal<ReferenceDataTyreLoadIndex[]>;
 
 	addTyre(tyre: Tyre, axleNumber: number) {
 		const techRecord = this.techRecord();
@@ -141,7 +146,7 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 		const lastAxle = axles[axleNumber - 1];
 
 		if (lastAxle?.tyres_tyreCode) {
-			const refData = this.tyresReferenceData()?.find((tyre) => tyre.code === String(lastAxle.tyres_tyreCode));
+			const refData = this.tyresReferenceData().find((tyre) => tyre.code === String(lastAxle.tyres_tyreCode));
 
 			if (!refData) {
 				return;

--- a/src/app/forms/custom-sections-v2/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections-v2/tyres/tyres.component.ts
@@ -3,7 +3,16 @@ import { Modes } from '@/src/app/models/modes.enum';
 import { Axle, FitmentCode, Tyre, VehicleTypes } from '@/src/app/models/vehicle-tech-record.model';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
 import { ViewportScroller } from '@angular/common';
-import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	OnChanges,
+	OnDestroy,
+	OnInit,
+	SimpleChanges,
+	inject,
+	input,
+} from '@angular/core';
 import { FormArray, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PSVAxles } from '@dvsa/cvs-type-definitions/types/v3/tech-record/get/psv/skeleton';
@@ -39,6 +48,7 @@ import { ReplaySubject, combineLatest, filter, takeUntil } from 'rxjs';
 		FieldWarningMessageComponent,
 		FieldErrorMessageComponent,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TyresComponent extends EditBaseComponent implements OnInit, OnDestroy, OnChanges {
 	readonly VehicleTypes = VehicleTypes;

--- a/src/app/forms/custom-sections-v2/tyres/tyres.component.ts
+++ b/src/app/forms/custom-sections-v2/tyres/tyres.component.ts
@@ -9,6 +9,7 @@ import {
 	OnChanges,
 	OnDestroy,
 	OnInit,
+	Signal,
 	SimpleChanges,
 	inject,
 	input,
@@ -31,10 +32,9 @@ import {
 import { ReferenceDataResourceType, ReferenceDataTyre, ReferenceDataTyreLoadIndex } from '@models/reference-data.model';
 import { AxlesService } from '@services/axles/axles.service';
 import { FormNodeWidth, TagTypeLabels } from '@services/dynamic-forms/dynamic-form.types';
-import { ReferenceDataService } from '@services/reference-data/reference-data.service';
+import { selectAllReferenceDataByResourceType } from '@store/reference-data';
 import { updateScrollPosition } from '@store/technical-records';
 import { cloneDeep } from 'lodash';
-import { ReplaySubject, combineLatest, filter, takeUntil } from 'rxjs';
 
 @Component({
 	selector: 'app-tyres',
@@ -56,8 +56,12 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 	readonly TagType = TagType;
 	readonly TagTypeLabels = TagTypeLabels;
 	readonly Modes = Modes;
+	protected readonly FITMENT_CODE_OPTIONS = FITMENT_CODE_OPTIONS;
+	protected readonly SPEED_CATEGORY_SYMBOL_OPTIONS = SPEED_CATEGORY_SYMBOL_OPTIONS;
+	protected readonly FormNodeWidth = FormNodeWidth;
+	protected readonly HGV_TYRE_USE_CODE_OPTIONS = HGV_TYRE_USE_CODE_OPTIONS;
+	protected readonly TRL_TYRE_USE_CODE_OPTIONS = TRL_TYRE_USE_CODE_OPTIONS;
 
-	referenceDataService = inject(ReferenceDataService);
 	viewportScroller = inject(ViewportScroller);
 	router = inject(Router);
 	route = inject(ActivatedRoute);
@@ -66,14 +70,18 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 
 	techRecord = input.required<TechRecordType<'hgv' | 'trl' | 'psv'>>();
 
-	destroy$ = new ReplaySubject<boolean>(1);
-
 	form: FormGroup = this.fb.group({});
-	tyresReferenceData: ReferenceDataTyre[] = [];
-	tyreLoadIndexReferenceData: ReferenceDataTyreLoadIndex[] = [];
 	invalidAxles: Array<number> = [];
 	filters = input<string[]>([]);
 	mode = input.required<Modes>();
+
+	private readonly tyresReferenceData = this.store.selectSignal(
+		selectAllReferenceDataByResourceType(ReferenceDataResourceType.Tyres)
+	) as Signal<ReferenceDataTyre[] | undefined>;
+
+	private readonly tyreLoadIndexReferenceData = this.store.selectSignal(
+		selectAllReferenceDataByResourceType(ReferenceDataResourceType.TyreLoadIndex)
+	) as Signal<ReferenceDataTyreLoadIndex[] | undefined>;
 
 	addTyre(tyre: Tyre, axleNumber: number) {
 		const techRecord = this.techRecord();
@@ -133,7 +141,7 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 		const lastAxle = axles[axleNumber - 1];
 
 		if (lastAxle?.tyres_tyreCode) {
-			const refData = this.tyresReferenceData.find((tyre) => tyre.code === String(lastAxle.tyres_tyreCode));
+			const refData = this.tyresReferenceData()?.find((tyre) => tyre.code === String(lastAxle.tyres_tyreCode));
 
 			if (!refData) {
 				return;
@@ -171,18 +179,6 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 		return this.axlesService.allInvalidAxles;
 	}
 
-	loadReferenceData() {
-		combineLatest([
-			this.referenceDataService.getAll$(ReferenceDataResourceType.Tyres).pipe(filter(Boolean)),
-			this.referenceDataService.getAll$(ReferenceDataResourceType.TyreLoadIndex).pipe(filter(Boolean)),
-		])
-			.pipe(takeUntil(this.destroy$))
-			.subscribe(([tyres, tyreLoadIndex]) => {
-				this.tyresReferenceData = tyres as ReferenceDataTyre[];
-				this.tyreLoadIndexReferenceData = tyreLoadIndex as ReferenceDataTyreLoadIndex[];
-			});
-	}
-
 	get techRecordAxles() {
 		return this.parent.get('techRecord_axles') as FormArray;
 	}
@@ -193,7 +189,6 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 
 	ngOnInit(): void {
 		this.addControls(this.controlsBasedOffVehicleType, this.form);
-		this.loadReferenceData();
 
 		// Attach all form controls to parent
 		this.init(this.form);
@@ -219,10 +214,6 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 	ngOnDestroy(): void {
 		// Detach all form controls from parent
 		this.destroy(this.form);
-
-		// Clear subscriptions
-		this.destroy$.next(true);
-		this.destroy$.complete();
 	}
 
 	get hgvTrlControls() {
@@ -266,8 +257,9 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 				const weightValue = this.technicalRecordService.getAxleFittingWeightValueFromLoadIndex(
 					axle.tyres_dataTrAxles?.toString(),
 					axle.tyres_fitmentCode,
-					this.tyreLoadIndexReferenceData
+					this.tyreLoadIndexReferenceData() ?? []
 				);
+
 				if (weightValue && axle.weights_gbWeight > weightValue) {
 					this.invalidAxles.push(axle.axleNumber);
 					this.axlesService.allInvalidAxles = this.invalidAxles;
@@ -292,10 +284,4 @@ export class TyresComponent extends EditBaseComponent implements OnInit, OnDestr
 			this.axlesService.addAxle(this.parent, type);
 		}
 	}
-
-	protected readonly FITMENT_CODE_OPTIONS = FITMENT_CODE_OPTIONS;
-	protected readonly SPEED_CATEGORY_SYMBOL_OPTIONS = SPEED_CATEGORY_SYMBOL_OPTIONS;
-	protected readonly FormNodeWidth = FormNodeWidth;
-	protected readonly HGV_TYRE_USE_CODE_OPTIONS = HGV_TYRE_USE_CODE_OPTIONS;
-	protected readonly TRL_TYRE_USE_CODE_OPTIONS = TRL_TYRE_USE_CODE_OPTIONS;
 }

--- a/src/app/forms/custom-sections-v2/weights/weights.component.ts
+++ b/src/app/forms/custom-sections-v2/weights/weights.component.ts
@@ -4,7 +4,16 @@ import { Modes } from '@/src/app/models/modes.enum';
 import { FormNodeWidth } from '@/src/app/services/dynamic-forms/dynamic-form.types';
 import { TechnicalRecordChangesService } from '@/src/app/services/technical-record/technical-record-change.service';
 import { updateBrakeForces } from '@/src/app/store/technical-records';
-import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	OnChanges,
+	OnDestroy,
+	OnInit,
+	SimpleChanges,
+	inject,
+	input,
+} from '@angular/core';
 import { FormArray, ReactiveFormsModule } from '@angular/forms';
 import { FilterByTagsDirective } from '@directives/filter-by-tags/filter-by-tags.directive';
 import { TechRecordType } from '@dvsa/cvs-type-definitions/types/v3/tech-record/tech-record-vehicle-type';
@@ -32,6 +41,7 @@ import { ReplaySubject, skip, takeUntil } from 'rxjs';
 		TrimWhitespaceDirective,
 		NoSpaceDirective,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WeightsComponent extends EditBaseComponent implements OnInit, OnDestroy, OnChanges {
 	protected readonly VehicleTypes = VehicleTypes;

--- a/src/app/forms/custom-sections/defect/defect-v2/defect-v2.component.ts
+++ b/src/app/forms/custom-sections/defect/defect-v2/defect-v2.component.ts
@@ -20,8 +20,8 @@ import {
 } from '@/src/app/store/test-records';
 import { KeyValuePipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ChangeDetectorRef, Component, DestroyRef, computed, inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, computed, inject } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
@@ -53,6 +53,7 @@ import { CommonValidatorsService } from '../../../validators/common-validators.s
 		GovukFormGroupCheckboxComponent,
 		DefaultNullOrEmpty,
 	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DefectV2Component {
 	fb = inject(FormBuilder);
@@ -114,6 +115,10 @@ export class DefectV2Component {
 
 	readonly YES_NO_OPTIONS = YES_NO_OPTIONS;
 
+	// Track the form value as a signal so category-driven predicates recompute reactively
+	// instead of each calling form.getRawValue() on every change-detection cycle.
+	private formValue = toSignal(this.form.valueChanges, { initialValue: this.form.getRawValue() });
+
 	async ngOnInit(): Promise<void> {
 		this.form.controls.prohibitionIssued.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
 			this.form.controls.additionalInformation.controls.notes.updateValueAndValidity();
@@ -149,6 +154,7 @@ export class DefectV2Component {
 
 		try {
 			this.loading = true;
+			this.cdr.markForCheck();
 
 			if (this.defectMediaService.canDownloadAdasMediaItems(defect)) {
 				await this.defectMediaService.getAdasZip(testResult.testResultId);
@@ -252,17 +258,11 @@ export class DefectV2Component {
 		return !Number.isNaN(index);
 	}
 
-	isDangerous(): boolean {
-		return this.form.getRawValue().deficiencyCategory === 'dangerous';
-	}
+	isDangerous = computed(() => this.formValue().deficiencyCategory === 'dangerous');
 
-	isDangerousAsterisk(): boolean {
-		return this.form.getRawValue().stdForProhibition === true;
-	}
+	isDangerousAsterisk = computed(() => this.formValue().stdForProhibition === true);
 
-	isAdvisory(): boolean {
-		return this.form.getRawValue().deficiencyCategory === 'advisory';
-	}
+	isAdvisory = computed(() => this.formValue().deficiencyCategory === 'advisory');
 
 	isNotesRequired(): boolean {
 		const defect = this.form.getRawValue();

--- a/src/app/services/http/http.service.ts
+++ b/src/app/services/http/http.service.ts
@@ -23,9 +23,9 @@ import { TestTypeInfo } from '@models/test-types/testTypeInfo';
 import { TestTypesTaxonomy } from '@models/test-types/testTypesTaxonomy';
 import { StatusCodes, V3TechRecordModel } from '@models/vehicle-tech-record.model';
 import { CacheBucket, withCache } from '@ngneat/cashew';
+import { FeatureConfig } from '@store/feature-flags/feature-flags.feature';
 import { cloneDeep } from 'lodash';
 import { EMPTY, defer, expand, last, lastValueFrom, map, switchMap, takeWhile, timeout, timer } from 'rxjs';
-import { FeatureConfig } from '../../store/feature-flags/feature-flags.feature';
 
 @Injectable({ providedIn: 'root' })
 export class HttpService {
@@ -49,12 +49,14 @@ export class HttpService {
 	}
 
 	amendTechRecordVin(newVin: string, systemNumber: string, createdTimestamp: string) {
-		return this.http.patch<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/updateVin/${systemNumber}/${createdTimestamp}`,
-			{
-				newVin,
-			}
-		);
+		return this.http
+			.patch<TechRecordType<'get'>>(
+				`${environment.VTM_API_URI}/v3/technical-records/updateVin/${systemNumber}/${createdTimestamp}`,
+				{
+					newVin,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	amendTechRecordVrm(
@@ -64,28 +66,34 @@ export class HttpService {
 		createdTimestamp: string,
 		thirdMark?: string
 	) {
-		return this.http.patch<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/updateVrm/${systemNumber}/${createdTimestamp}`,
-			{
-				newVrm,
-				isCherishedTransfer,
-				thirdMark: thirdMark ?? undefined,
-			}
-		);
+		return this.http
+			.patch<TechRecordType<'get'>>(
+				`${environment.VTM_API_URI}/v3/technical-records/updateVrm/${systemNumber}/${createdTimestamp}`,
+				{
+					newVrm,
+					isCherishedTransfer,
+					thirdMark: thirdMark ?? undefined,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	archiveTechRecord(systemNumber: string, createdTimestamp: string, reasonForArchiving: string) {
-		return this.http.patch<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/archive/${systemNumber}/${createdTimestamp}`,
-			{
-				reasonForArchiving,
-			}
-		);
+		return this.http
+			.patch<TechRecordType<'get'>>(
+				`${environment.VTM_API_URI}/v3/technical-records/archive/${systemNumber}/${createdTimestamp}`,
+				{
+					reasonForArchiving,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	createTechRecord(newVehicleRecord: V3TechRecordModel) {
 		const body = cloneDeep<TechRecordType<'put'>>(newVehicleRecord as TechRecordType<'put'>);
-		return this.http.post<TechRecordType<'get'>>(`${environment.VTM_API_URI}/v3/technical-records`, body);
+		return this.http
+			.post<TechRecordType<'get'>>(`${environment.VTM_API_URI}/v3/technical-records`, body)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	fetchDefects() {
@@ -121,10 +129,12 @@ export class HttpService {
 	}
 
 	generateADRCertificate(systemNumber: string, createdTimestamp: string, certificateType: string) {
-		return this.http.post<{ message: string; id: string }>(
-			`${environment.VTM_API_URI}/v3/technical-records/adrCertificate/${systemNumber}/${createdTimestamp}`,
-			{ certificateType }
-		);
+		return this.http
+			.post<{ message: string; id: string }>(
+				`${environment.VTM_API_URI}/v3/technical-records/adrCertificate/${systemNumber}/${createdTimestamp}`,
+				{ certificateType }
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	getDocument(paramMap: Map<string, string>) {
@@ -167,29 +177,33 @@ export class HttpService {
 		paragraphId: number,
 		user: { name?: string; email?: string }
 	) {
-		return this.http.post(
-			`${environment.VTM_API_URI}/v3/technical-records/letter/${vehicleRecord.systemNumber}/${vehicleRecord.createdTimestamp}`,
-			{
-				vtmUsername: user.name,
-				letterType,
-				paragraphId,
-				recipientEmailAddress: vehicleRecord.techRecord_applicantDetails_emailAddress
-					? vehicleRecord.techRecord_applicantDetails_emailAddress
-					: user.email,
-			},
-			{ responseType: 'text' }
-		);
+		return this.http
+			.post(
+				`${environment.VTM_API_URI}/v3/technical-records/letter/${vehicleRecord.systemNumber}/${vehicleRecord.createdTimestamp}`,
+				{
+					vtmUsername: user.name,
+					letterType,
+					paragraphId,
+					recipientEmailAddress: vehicleRecord.techRecord_applicantDetails_emailAddress
+						? vehicleRecord.techRecord_applicantDetails_emailAddress
+						: user.email,
+				},
+				{ responseType: 'text' }
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	generatePlate(vehicleRecord: TechRecordType<'get'>, reason: string, user: { name?: string; email?: string }) {
-		return this.http.post<Object>(
-			`${environment.VTM_API_URI}/v3/technical-records/plate/${vehicleRecord.systemNumber}/${vehicleRecord.createdTimestamp}`,
-			{
-				reasonForCreation: reason,
-				vtmUsername: user.name,
-				recipientEmailAddress: vehicleRecord?.techRecord_applicantDetails_emailAddress ?? user.email,
-			}
-		);
+		return this.http
+			.post<Object>(
+				`${environment.VTM_API_URI}/v3/technical-records/plate/${vehicleRecord.systemNumber}/${vehicleRecord.createdTimestamp}`,
+				{
+					reasonForCreation: reason,
+					vtmUsername: user.name,
+					recipientEmailAddress: vehicleRecord?.techRecord_applicantDetails_emailAddress ?? user.email,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	getRecalls(vin: string) {
@@ -200,9 +214,9 @@ export class HttpService {
 	}
 
 	getTechRecordV3(systemNumber: string, createdTimestamp: string) {
-		return this.http.get<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/${systemNumber}/${createdTimestamp}`
-		);
+		return this.http
+			.get<TechRecordType<'get'>>(`${environment.VTM_API_URI}/v3/technical-records/${systemNumber}/${createdTimestamp}`)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	getTestTypes(typeOfTest?: string) {
@@ -277,18 +291,22 @@ export class HttpService {
 			params = params.set('vehicleWheels', vehicleWheels);
 		}
 
-		return this.http.get<TestTypeInfo>(`${environment.VTM_API_URI}/test-types/${encodeURIComponent(String(id))}`, {
-			params,
-		});
+		return this.http
+			.get<TestTypeInfo>(`${environment.VTM_API_URI}/test-types/${encodeURIComponent(String(id))}`, {
+				params,
+			})
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	promoteTechRecord(systemNumber: string, createdTimestamp: string, reasonForPromoting: string) {
-		return this.http.patch<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/promote/${systemNumber}/${createdTimestamp}`,
-			{
-				reasonForPromoting,
-			}
-		);
+		return this.http
+			.patch<TechRecordType<'get'>>(
+				`${environment.VTM_API_URI}/v3/technical-records/promote/${systemNumber}/${createdTimestamp}`,
+				{
+					reasonForPromoting,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	referenceResourceTypeGet(resourceType: string, paginationToken?: string) {
@@ -446,9 +464,11 @@ export class HttpService {
 		params = params.set('searchCriteria', type);
 		params = params.set('additionalInfo', true);
 
-		return this.http.get<TechRecordSearchSchema[]>(`${environment.VTM_API_URI}/v3/technical-records/search/${term}`, {
-			params,
-		});
+		return this.http
+			.get<TechRecordSearchSchema[]>(`${environment.VTM_API_URI}/v3/technical-records/search/${term}`, {
+				params,
+			})
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	searchTechRecordBySystemNumber(systemNumber: string) {
@@ -520,13 +540,12 @@ export class HttpService {
 			params = params.set('version', version);
 		}
 
-		return this.http.get<TestResultSchema[]>(
-			`${environment.VTM_API_URI}/test-results/${encodeURIComponent(String(systemNumber))}`,
-			{
+		return this.http
+			.get<TestResultSchema[]>(`${environment.VTM_API_URI}/test-results/${encodeURIComponent(String(systemNumber))}`, {
 				params,
 				headers: HttpService.GetGzippedPayloadHeaders,
-			}
-		);
+			})
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	testResultsPost(body: TestResultSchema) {
@@ -534,9 +553,11 @@ export class HttpService {
 			throw new Error('Required parameter body was null or undefined when calling testResultsPost.');
 		}
 
-		return this.http.post<{ testResultId: string }>(`${environment.VTM_API_URI}/test-results`, body, {
-			headers: HttpService.PostPutGzippedPayloadHeaders,
-		});
+		return this.http
+			.post<{ testResultId: string }>(`${environment.VTM_API_URI}/test-results`, body, {
+				headers: HttpService.PostPutGzippedPayloadHeaders,
+			})
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	testResultsSystemNumberPut(body: TestResultSchema, systemNumber: string) {
@@ -548,30 +569,36 @@ export class HttpService {
 			throw new Error('Required parameter systemNumber was null or undefined when calling testResultsSystemNumberPut.');
 		}
 
-		return this.http.put<TestResultSchema>(
-			`${environment.VTM_API_URI}/test-results/${encodeURIComponent(String(systemNumber))}`,
-			body,
-			{
-				headers: HttpService.PostPutGzippedPayloadHeaders,
-			}
-		);
+		return this.http
+			.put<TestResultSchema>(
+				`${environment.VTM_API_URI}/test-results/${encodeURIComponent(String(systemNumber))}`,
+				body,
+				{
+					headers: HttpService.PostPutGzippedPayloadHeaders,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	unarchiveTechRecord(systemNumber: string, createdTimestamp: string, reasonForUnarchiving: string, status: string) {
-		return this.http.post<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/unarchive/${systemNumber}/${createdTimestamp}`,
-			{
-				reasonForUnarchiving,
-				status,
-			}
-		);
+		return this.http
+			.post<TechRecordType<'get'>>(
+				`${environment.VTM_API_URI}/v3/technical-records/unarchive/${systemNumber}/${createdTimestamp}`,
+				{
+					reasonForUnarchiving,
+					status,
+				}
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	updateTechRecord(systemNumber: string, createdTimestamp: string, techRecord: TechRecordType<'put'>) {
-		return this.http.patch<TechRecordType<'get'>>(
-			`${environment.VTM_API_URI}/v3/technical-records/${systemNumber}/${createdTimestamp}`,
-			techRecord
-		);
+		return this.http
+			.patch<TechRecordType<'get'>>(
+				`${environment.VTM_API_URI}/v3/technical-records/${systemNumber}/${createdTimestamp}`,
+				techRecord
+			)
+			.pipe(timeout(HttpService.TIMEOUT));
 	}
 
 	sendLogs = async (logs: Log[]) => {

--- a/src/app/store/feature-flags/feature-flags.effects.ts
+++ b/src/app/store/feature-flags/feature-flags.effects.ts
@@ -2,9 +2,11 @@ import { environment } from '@/src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
+import { MsalBroadcastService, MsalService } from '@azure/msal-angular';
+import { InteractionStatus } from '@azure/msal-browser';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { HttpService } from '@services/http/http.service';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, filter, map, of, switchMap } from 'rxjs';
 import {
 	fetchFeatureFlags,
 	fetchFeatureFlagsFailure,
@@ -20,6 +22,22 @@ export class FeatureFlagsEffects {
 	http = inject(HttpClient);
 	httpService = inject(HttpService);
 	router = inject(Router);
+	msalBroadcast = inject(MsalBroadcastService);
+	msal = inject(MsalService);
+
+	// Remote feature flags require an auth token, so the APP_INITIALIZER dispatch races MSAL on a fresh
+	// session (pre-login) or a cached reload (mid silent-init) and can fail before a token exists. Re-fetch
+	// once MSAL has settled (InteractionStatus.None) with an authenticated account — this covers both the
+	// interactive-login and cached/silent paths so flags reliably load before flow decisions (e.g. v1 vs v2
+	// tech-record). Non-blocking: bootstrap is not delayed. Also re-runs after silent token refreshes, which
+	// harmlessly refreshes flags mid-session.
+	refetchFeatureFlagsOnAuth = createEffect(() =>
+		this.msalBroadcast.inProgress$.pipe(
+			filter((status: InteractionStatus) => status === InteractionStatus.None),
+			filter(() => this.msal.instance.getAllAccounts().length > 0),
+			map(() => fetchRemoteFeatureFlags())
+		)
+	);
 
 	onFetchFeatureFlags = createEffect(() =>
 		this.actions.pipe(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
     "esModuleInterop": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
@@ -16,9 +18,9 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "importHelpers": true,
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ES2022",
-    "lib": ["es2023", "dom"],
+    "lib": ["ES2024", "dom"],
     "paths": {
       "@/*": ["./*"],
       "@api/*": ["src/app/api/*"],
@@ -46,6 +48,7 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
+    "strictStandalone": true,
     "strictTemplates": true
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
# Summary

  Performance and reliability improvements across the v2 tech-record and test-record create/amend flows. Three themes: eliminate wasted change-detection work, stop redundant work on the per-keystroke edit hot
  path, and make network calls more robust (timeouts + reliable feature-flag loading).

  No public API or template-behaviour changes — the flows render and submit exactly as before, just with far less per-interaction work.

## Changes

  1. OnPush change detection across the v2 tree                                                                                                                                         
  
  Enabled ChangeDetectionStrategy.OnPush on every component in the create/amend/view v2 surface:
  - 8 route wrappers (vehicle-technical-record-v2, hydrate-new-vehicle-record-v2, tech-record-summary-changes-v2, create/amend test-record-v2, search-v2, search-results-v2)
  - 23 custom-sections-v2 sections
  - 8 test-record custom-sections

  Each was verified OnPush-safe first (signal inputs + reactive-form wiring). A couple of async field-sets that needed it got an explicit markForCheck() (e.g. test-records roles, defect media spinner).

  2. Removed per-change-detection work from templates

  - Accordion view-models: vehicle/summary-changes/hydrate wrappers precompute accordion descriptions in a computed() instead of calling service methods on every CD cycle. Vehicle-type type-guard predicates
  were kept inline to preserve template control-flow narrowing.
  - ADR section: collapsed 10× form.getRawValue() full-form clones per CD into a single @let reused across all canDisplay* checks.
  - defect-v2: category predicates converted from methods calling getRawValue() to computed() over a form-value signal.
  - hydrate tags: getter → computed().

  3. Debounced store mirror on the edit hot path (+ flush-on-submit)

  Previously every keystroke pushed a full editing record into the store, which re-fed every section's techRecord input and re-rendered the whole section tree. The valueChanges → store mirror is now
  debounceTime(100), with a synchronous flush before every action that reads the store editing record (review/submit/create), so no in-flight edit can be lost.

  4. HTTP timeouts on v3 endpoints

  Added .pipe(timeout(HttpService.TIMEOUT)) to the 12 /v3/technical-records endpoints that lacked one (getRecalls already had its own env-based timeout).

  5. Feature-flag load reliability

  Remote feature flags require an auth token, but they were only dispatched at APP_INITIALIZER — which races MSAL login on a fresh session and races silent-init on a cached reload, so flags sometimes never
  loaded and the app fell back to the old (v1) flow for the whole session. Added a non-blocking effect that re-fetches remote flags once MSAL has settled (InteractionStatus.None) with an authenticated account,
  covering both the interactive-login and cached/silent paths. Bootstrap is not delayed.

 ## Testing
  
  - Production AOT build green.
  - Existing unit suites pass for all touched areas (wrappers, sections, http.service, defect-v2, feature flows) — ~280 tests, plus a spec fix in create-test-record after the debounce change.

##  Risk / rollout notes

  - Behaviour-preserving; main risk area is the debounce — worth a manual QA pass on type → immediately Review/Submit/Create to confirm the last edit is captured (the synchronous flush handles this).
  - Not addressed (follow-up): FeatureToggleGuard on the betas route is still a synchronous canActivate with no flag-wait.


## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge
