### PR TITLE
fix(cb2-22348): only show prohibition issued for dangerous defects

### DIFF
--- a/src/app/forms/custom-sections/defect/defect-v2/defect-v2.component.html
+++ b/src/app/forms/custom-sections/defect/defect-v2/defect-v2.component.html
@@ -162,12 +162,14 @@
             {{ defect.prs | defaultNullOrEmpty }}
           </dd>
         </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Prohibition Issued?</dt>
-          <dd class="govuk-summary-list__value" id="defect-additional-information-prohibition-issued">
-            {{ defect.prohibitionIssued | defaultNullOrEmpty }}
-          </dd>
-        </div>
+        @if (isDangerous()) {
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Prohibition Issued?</dt>
+            <dd class="govuk-summary-list__value" id="defect-additional-information-prohibition-issued">
+              {{ defect.prohibitionIssued | defaultNullOrEmpty }}
+            </dd>
+          </div>
+        }
       </dl>
     </div>
   </div>


### PR DESCRIPTION
## VTM - Advisory, Minor and Major defects contain Prohibition Issued? on defect details

[CB2-22348](https://dvsa.atlassian.net/browse/CB2-22348)

## Checklist

- [ ] Branch is rebased against the latest develop/common
- [ ] Code and UI has been tested manually after the additional changes
- [ ] PR title includes the JIRA ticket number
- [ ] Squashed commits contain the JIRA ticket number
- [ ] Delete branch after merge


[CB2-22348]: https://dvsa.atlassian.net/browse/CB2-22348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ